### PR TITLE
Allow at most one file to be specified

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -178,6 +178,10 @@ fn determine_operation<I>(opts: &Options, args: I) -> Operation
         return Operation::Stdin(buffer, WriteMode::Plain);
     }
 
+    if matches.free.len() > 1 {
+        return Operation::InvalidInput("rustfmt accepts at most one file argument".into());
+    }
+
     let write_mode = match matches.opt_str("write-mode") {
         Some(mode) => {
             match mode.parse() {


### PR DESCRIPTION
It might be reasonable to expect

    $ rustfmt src/bin/rustfmt.rs src/lib.rs

to work, but it silently formats only the first argument.