### PR TITLE
Add emacs integration to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ multirust run nightly cargo install --git https://github.com/rust-lang-nursery/r
 ```
 
 
-## Running Rustfmt from Vim
+## Editor integrations
 
-See [instructions](http://johannh.me/blog/rustfmt-vim.html).
+* [Vim](http://johannh.me/blog/rustfmt-vim.html)
+* [Emacs](https://gist.github.com/cskksc/733dc0c4d4170380b6ec)
 
 
 ## How to build and test


### PR DESCRIPTION
A small function to integrate rustfmt with emacs. I'm very new to rust and not quite sure if cargo 6.0.0 can be installed independent of the rust nightly install script (except from building it from source of course). If there is, we can change step 1 accordingly.

Here's the gist I've made.
https://gist.github.com/cskksc/733dc0c4d4170380b6ec