### PR TITLE
Report test coverage with travis-cargo & coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,25 @@ cache:
  directories:
   - $HOME/.cargo
 
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
+    - libelf-dev
+    - libdw-dev
+
+before_script:
+- |
+  pip install 'travis-cargo<0.2' --user &&
+  export PATH=$HOME/.local/bin:$PATH
+
 script:
- - cargo build
- - cargo test
+- |
+  travis-cargo build &&
+  travis-cargo test
+
+after_success:
+- travis-cargo coveralls --no-sudo
 
 before_deploy:
   # TODO: cross build


### PR DESCRIPTION
As this project grows, it might be beneficial to require pull requests
to keep a certain level of test coverage. Plus it's a fun statistic.

Somebody with access to this repo would have to enable it in https://coveralls.io/.