### PR TITLE
Enable rustfmt to format a list of files

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -29,7 +29,7 @@ use getopts::Options;
 
 /// Rustfmt operations.
 enum Operation {
-    /// Format files and its child modules.
+    /// Format files and their child modules.
     Format(Vec<PathBuf>, WriteMode),
     /// Print the help message.
     Help,
@@ -193,11 +193,7 @@ fn determine_operation<I>(opts: &Options, args: I) -> Operation
         None => WriteMode::Replace,
     };
 
-    let mut files = Vec::with_capacity(matches.free.len());
-
-    for arg in matches.free {
-        files.push(PathBuf::from(arg));
-    }
+    let files: Vec<_> = matches.free.iter().map(|a| PathBuf::from(a)).collect();
 
     Operation::Format(files, write_mode)
 }


### PR DESCRIPTION
Fix #580 by allowing rustfmt to accept a list of files. This also enables usage of shell wildcard expansion, although notably this does not work with cmd.exe on Windows. For example: `rustfmt *.rs` will format all rust files in the current working directory.

  - Change usage text to show rustfmt will accept a list of files
  - Change `Using rustfmt config file: {}` message to `Using rustfmt config file {} for {}`
  - Change `Operation::Format(PathBuf, WriteMode)` to `Operation::Format(Vec<PathBuf>, WriteMode)`
  - Loop through `Vec<PathBuf>`, load config and call 'run' for each path