### PR TITLE
Chains tabbed indent

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -56,7 +56,15 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
     } else if is_block_expr(parent, &parent_rewrite) {
         (parent_block_indent, false)
     } else {
-        (offset + Indent::new(context.config.tab_spaces, 0), false)
+        match context.config.chain_indent {
+            BlockIndentStyle::Inherit => (context.block_indent, false),
+            BlockIndentStyle::Tabbed => {
+                (context.block_indent.block_indent(context.config), false)
+            }
+            BlockIndentStyle::Visual => {
+                (offset + Indent::new(context.config.tab_spaces, 0), false)
+            }
+        }
     };
 
     let max_width = try_opt!((width + offset.width()).checked_sub(indent.width()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,6 +294,7 @@ create_config! {
     report_fixme: ReportTactic, ReportTactic::Never,
         "Report all, none or unnumbered occurrences of FIXME in source file comments";
     chain_base_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indent on chain base";
+    chain_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indentation of chain";
     reorder_imports: bool, false, "Reorder import statements alphabetically";
     single_line_if_else: bool, false, "Put else on same line as closing brace for if statements";
     format_strings: bool, true, "Format string literals, or leave as is";

--- a/tests/source/chains-indent-inherit.rs
+++ b/tests/source/chains-indent-inherit.rs
@@ -1,0 +1,5 @@
+// rustfmt-chain_indent: Inherit
+
+fn test() {
+    let x = my_long_function().my_even_longer_function().my_nested_function().some_random_name().another_function().do_it();
+}

--- a/tests/source/chains-indent-tabbed.rs
+++ b/tests/source/chains-indent-tabbed.rs
@@ -1,0 +1,5 @@
+// rustfmt-chain_indent: Tabbed
+
+fn test() {
+    let x = my_long_function().my_even_longer_function().my_nested_function().some_random_name().another_function().do_it();
+}

--- a/tests/source/chains-indent-visual.rs
+++ b/tests/source/chains-indent-visual.rs
@@ -1,0 +1,5 @@
+// rustfmt-chain_indent: Visual
+
+fn test() {
+    let x = my_long_function().my_even_longer_function().my_nested_function().some_random_name().another_function().do_it();
+}

--- a/tests/target/chains-indent-inherit.rs
+++ b/tests/target/chains-indent-inherit.rs
@@ -1,0 +1,10 @@
+// rustfmt-chain_indent: Inherit
+
+fn test() {
+    let x = my_long_function()
+    .my_even_longer_function()
+    .my_nested_function()
+    .some_random_name()
+    .another_function()
+    .do_it();
+}

--- a/tests/target/chains-indent-tabbed.rs
+++ b/tests/target/chains-indent-tabbed.rs
@@ -1,0 +1,10 @@
+// rustfmt-chain_indent: Tabbed
+
+fn test() {
+    let x = my_long_function()
+        .my_even_longer_function()
+        .my_nested_function()
+        .some_random_name()
+        .another_function()
+        .do_it();
+}

--- a/tests/target/chains-indent-visual.rs
+++ b/tests/target/chains-indent-visual.rs
@@ -1,0 +1,10 @@
+// rustfmt-chain_indent: Visual
+
+fn test() {
+    let x = my_long_function()
+                .my_even_longer_function()
+                .my_nested_function()
+                .some_random_name()
+                .another_function()
+                .do_it();
+}


### PR DESCRIPTION
When breaking chains, the indentation was too large in "Tabbed" mode. Is this the correct way to fix this?