### PR TITLE
Don't print an unnecessary newline after printing format report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,7 @@ pub fn format(file: &Path, config: &Config, mode: WriteMode) -> FileMap {
 pub fn run(file: &Path, write_mode: WriteMode, config: &Config) {
     let mut result = format(file, config, write_mode);
 
-    println!("{}", fmt_lines(&mut result, config));
+    print!("{}", fmt_lines(&mut result, config));
 
     let write_result = filemap::write_all_files(&result, write_mode, config);
 


### PR DESCRIPTION
The Display implementation for FormatReport already prints
a newline after every error.

However, if the format report does not contain errors, we
don't want to print an empty newline.

This behavior clutters up the console output with
empty lines when rustfmt is invoked multiple times
(from .e.g a script or cargo-fmt).

So instead of using println! to print the report, we just
use print!.