### PR TITLE
Pass in whether an ast::Path is in an expression context.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -117,7 +117,7 @@ impl Rewrite for ast::Expr {
                 rewrite_match(context, cond, arms, width, offset, self.span)
             }
             ast::Expr_::ExprPath(ref qself, ref path) => {
-                rewrite_path(context, qself.as_ref(), path, width, offset)
+                rewrite_path(context, true, qself.as_ref(), path, width, offset)
             }
             ast::Expr_::ExprAssign(ref lhs, ref rhs) => {
                 rewrite_assignment(context, lhs, rhs, None, width, offset)
@@ -1242,7 +1242,7 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
 
     // 2 = " {".len()
     let path_budget = try_opt!(width.checked_sub(2));
-    let path_str = try_opt!(path.rewrite(context, path_budget, offset));
+    let path_str = try_opt!(rewrite_path(context, true, None, path, path_budget, offset));
 
     // Foo { a: Foo } - indent is +3, width is -5.
     let h_budget = width.checked_sub(path_str.len() + 5).unwrap_or(0);

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -10,6 +10,7 @@
 
 use Indent;
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, definitive_tactic};
+use types::rewrite_path;
 use utils::span_after;
 use rewrite::{Rewrite, RewriteContext};
 
@@ -37,7 +38,7 @@ impl Rewrite for ast::ViewPath {
                 let ident_str = ident.to_string();
                 // 4 = " as ".len()
                 let budget = try_opt!(width.checked_sub(ident_str.len() + 4));
-                let path_str = try_opt!(path.rewrite(context, budget, offset));
+                let path_str = try_opt!(rewrite_path(context, false, None, path, budget, offset));
 
                 Some(if path.segments.last().unwrap().identifier == ident {
                     path_str
@@ -105,7 +106,7 @@ pub fn rewrite_use_list(width: usize,
                         -> Option<String> {
     // 1 = {}
     let budget = try_opt!(width.checked_sub(1));
-    let path_str = try_opt!(path.rewrite(context, budget, offset));
+    let path_str = try_opt!(rewrite_path(context, false, None, path, budget, offset));
 
     match path_list.len() {
         0 => unreachable!(),

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -45,7 +45,7 @@ impl Rewrite for Pat {
                 }
             }
             Pat_::PatQPath(ref q_self, ref path) => {
-                rewrite_path(context, Some(q_self), path, width, offset)
+                rewrite_path(context, true, Some(q_self), path, width, offset)
             }
             Pat_::PatRange(ref lhs, ref rhs) => {
                 rewrite_pair(&**lhs, &**rhs, "", "...", "", context, width, offset)
@@ -58,7 +58,12 @@ impl Rewrite for Pat {
                 rewrite_tuple(context, items, self.span, width, offset)
             }
             Pat_::PatEnum(ref path, Some(ref pat_vec)) => {
-                let path_str = try_opt!(::types::rewrite_path(context, None, path, width, offset));
+                let path_str = try_opt!(::types::rewrite_path(context,
+                                                              true,
+                                                              None,
+                                                              path,
+                                                              width,
+                                                              offset));
 
                 if pat_vec.is_empty() {
                     Some(path_str)

--- a/tests/source/paths.rs
+++ b/tests/source/paths.rs
@@ -16,6 +16,8 @@ fn main() {
                     >::some_func();
 
     < *mut JSObject >:: relocate(entry);
+
+    let x: Foo/*::*/<A   >;
 }
 
 fn op(foo: Bar, key : &[u8], upd : Fn(Option<&memcache::Item> , Baz  ) -> Result) -> MapResult {}

--- a/tests/target/paths.rs
+++ b/tests/target/paths.rs
@@ -15,6 +15,8 @@ fn main() {
     Quux::<ParamOne /* Comment 1 */, ParamTwo /* Comment 2 */>::some_func();
 
     <*mut JSObject>::relocate(entry);
+
+    let x: Foo<A>;
 }
 
 fn op(foo: Bar, key: &[u8], upd: Fn(Option<&memcache::Item>, Baz) -> Result) -> MapResult {


### PR DESCRIPTION
This gets rid of a slightly nasty hack involving scanning the source
expression for a ":".