### PR TITLE
Adding a "Native" option to newline_style.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ macro_rules! configuration_option_enum{
 configuration_option_enum! { NewlineStyle:
     Windows, // \r\n
     Unix, // \n
+    Native, // \r\n in Windows, \n on other platforms
 }
 
 configuration_option_enum! { BraceStyle:

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -59,7 +59,17 @@ pub fn write_file(text: &StringBuffer,
                                 -> Result<(), io::Error>
         where T: Write
     {
-        match config.newline_style {
+        let style = if config.newline_style == NewlineStyle::Native {
+            if cfg!(windows) {
+                NewlineStyle::Windows
+            } else {
+                NewlineStyle::Unix
+            }
+        } else {
+            config.newline_style
+        };
+
+        match style {
             NewlineStyle::Unix => write!(writer, "{}", text),
             NewlineStyle::Windows => {
                 for (c, _) in text.chars() {
@@ -71,6 +81,7 @@ pub fn write_file(text: &StringBuffer,
                 }
                 Ok(())
             }
+            NewlineStyle::Native => unreachable!(),
         }
     }
 


### PR DESCRIPTION
By using it one will get `\r\n` line endings on Windows, and `\n` line endings on other platforms. This is the ideal case when using [git's autocrlf option](https://git-scm.com/book/tr/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace).