### PR TITLE
Add --version switch

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -23,7 +23,6 @@ use rustfmt::config::Config;
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::process::Command;
 use std::path::{Path, PathBuf};
 
 use getopts::{Matches, Options};
@@ -177,15 +176,11 @@ fn print_usage(opts: &Options, reason: &str) {
 }
 
 fn print_version() {
-    let cmd = Command::new("git")
-                  .arg("rev-parse")
-                  .arg("--short")
-                  .arg("HEAD")
-                  .output();
-    match cmd {
-        Ok(output) => print!("{}", String::from_utf8(output.stdout).unwrap()),
-        Err(e) => panic!("Unable te get version: {}", e),
-    }
+    println!("{}.{}.{}{}",
+             option_env!("CARGO_PKG_VERSION_MAJOR").unwrap_or("X"),
+             option_env!("CARGO_PKG_VERSION_MINOR").unwrap_or("X"),
+             option_env!("CARGO_PKG_VERSION_PATCH").unwrap_or("X"),
+             option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""));
 }
 
 fn determine_operation(matches: &Matches) -> Operation {

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -85,7 +85,7 @@ fn update_config(config: &mut Config, matches: &Matches) {
 fn execute() -> i32 {
     let mut opts = Options::new();
     opts.optflag("h", "help", "show this message");
-    opts.optflag("", "version", "show version information");
+    opts.optflag("V", "version", "show version information");
     opts.optflag("v", "verbose", "show progress");
     opts.optopt("",
                 "write-mode",


### PR DESCRIPTION
Add --version switch, which prints a short hash of the current commit. Fix #612