### PR TITLE
Single-line Functions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -269,6 +269,7 @@ create_config! {
     newline_style: NewlineStyle, NewlineStyle::Unix, "Unix or Windows line endings";
     fn_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for functions";
     item_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for structs and enums";
+    fn_empty_single_line: bool, true, "Put empty-body functions on a single line";
     fn_single_line: bool, false, "Put single-expression functions on a single line";
     fn_return_indent: ReturnIndent, ReturnIndent::WithArgs,
         "Location of return type in function declaration";

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,6 +269,7 @@ create_config! {
     newline_style: NewlineStyle, NewlineStyle::Unix, "Unix or Windows line endings";
     fn_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for functions";
     item_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for structs and enums";
+    fn_single_line: bool, false, "Put single-expression functions on a single line";
     fn_return_indent: ReturnIndent, ReturnIndent::WithArgs,
         "Location of return type in function declaration";
     fn_args_paren_newline: bool, true, "If function argument parenthesis goes on a newline";

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -705,36 +705,25 @@ fn single_line_if_else(context: &RewriteContext,
     None
 }
 
-// Checks that a block contains no statements, an expression and no comments.
-fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
-    if !block.stmts.is_empty() || block.expr.is_none() {
-        return false;
-    }
-
+fn block_contains_comment(block: &ast::Block, codemap: &CodeMap) -> bool {
     let snippet = codemap.span_to_snippet(block.span).unwrap();
+    contains_comment(&snippet)
+}
 
-    !contains_comment(&snippet)
+// Checks that a block contains no statements, an expression and no comments.
+pub fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
+    block.stmts.is_empty() && block.expr.is_some() && !block_contains_comment(block, codemap)
 }
 
 /// Checks whether a block contains at most one statement or expression, and no comments.
 pub fn is_simple_block_stmt(block: &ast::Block, codemap: &CodeMap) -> bool {
-    if (!block.stmts.is_empty() && block.expr.is_some()) ||
-       (block.stmts.len() != 1 && block.expr.is_none()) {
-        return false;
-    }
-
-    let snippet = codemap.span_to_snippet(block.span).unwrap();
-    !contains_comment(&snippet)
+    (block.stmts.is_empty() || (block.stmts.len() == 1 && block.expr.is_none())) &&
+    !block_contains_comment(block, codemap)
 }
 
 /// Checks whether a block contains no statements, expressions, or comments.
 pub fn is_empty_block(block: &ast::Block, codemap: &CodeMap) -> bool {
-    if !block.stmts.is_empty() || block.expr.is_some() {
-        return false;
-    }
-
-    let snippet = codemap.span_to_snippet(block.span).unwrap();
-    !contains_comment(&snippet)
+    block.stmts.is_empty() && block.expr.is_none() && !block_contains_comment(block, codemap)
 }
 
 // inter-match-arm-comment-rules:

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -688,6 +688,27 @@ fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
     !contains_comment(&snippet)
 }
 
+/// Checks whether a block contains at most one statement or expression, and no comments.
+pub fn is_simple_block_stmt(block: &ast::Block, codemap: &CodeMap) -> bool {
+    if (!block.stmts.is_empty() && block.expr.is_some()) ||
+       (block.stmts.len() != 1 && block.expr.is_none()) {
+        return false;
+    }
+
+    let snippet = codemap.span_to_snippet(block.span).unwrap();
+    !contains_comment(&snippet)
+}
+
+/// Checks whether a block contains no statements, expressions, or comments.
+pub fn is_empty_block(block: &ast::Block, codemap: &CodeMap) -> bool {
+    if !block.stmts.is_empty() || block.expr.is_some() {
+        return false;
+    }
+
+    let snippet = codemap.span_to_snippet(block.span).unwrap();
+    !contains_comment(&snippet)
+}
+
 // inter-match-arm-comment-rules:
 //  - all comments following a match arm before the start of the next arm
 //    are about the second arm

--- a/src/items.rs
+++ b/src/items.rs
@@ -448,20 +448,19 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn rewrite_single_line_fn(&self,
-                                  fn_rewrite: &Option<String>,
+                                  fn_str: &str,
                                   block: &ast::Block)
                                   -> Option<String> {
 
-        let fn_str = match *fn_rewrite {
-            Some(ref s) if !s.contains('\n') => s,
-            _ => return None,
-        };
+        if fn_str.contains('\n') {
+            return None;
+        }
 
         let codemap = self.get_context().codemap;
 
-        if is_empty_block(block, codemap) &&
-           self.block_indent.width() + fn_str.len() + 3 <= self.config.max_width {
-            return Some(format!("{}{{ }}", fn_str));
+        if self.config.fn_empty_single_line && is_empty_block(block, codemap) &&
+           self.block_indent.width() + fn_str.len() + 2 <= self.config.max_width {
+            return Some(format!("{}{{}}", fn_str));
         }
 
         if self.config.fn_single_line && is_simple_block_stmt(block, codemap) {
@@ -488,7 +487,7 @@ impl<'a> FmtVisitor<'a> {
             };
 
             if let Some(res) = rewrite {
-                let width = self.block_indent.width() + fn_str.len() + res.len() + 3;
+                let width = self.block_indent.width() + fn_str.len() + res.len() + 4;
                 if !res.contains('\n') && width <= self.config.max_width {
                     return Some(format!("{}{{ {} }}", fn_str, res));
                 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -15,14 +15,14 @@ use utils::{format_mutability, format_visibility, contains_skip, span_after, end
             wrap_str, last_line_width, semicolon_for_expr, semicolon_for_stmt};
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic,
             DefinitiveListTactic, definitive_tactic, format_item_list};
-use expr::rewrite_assign_rhs;
-use comment::{FindUncommented, contains_comment};
+use expr::{is_empty_block, is_simple_block_stmt, rewrite_assign_rhs};
+use comment::FindUncommented;
 use visitor::FmtVisitor;
 use rewrite::{Rewrite, RewriteContext};
 use config::{Config, BlockIndentStyle, Density, ReturnIndent, BraceStyle, StructLitStyle};
 
 use syntax::{ast, abi};
-use syntax::codemap::{Span, BytePos, CodeMap, mk_sp};
+use syntax::codemap::{Span, BytePos, mk_sp};
 use syntax::print::pprust;
 use syntax::parse::token;
 
@@ -1391,24 +1391,4 @@ fn span_for_where_pred(pred: &ast::WherePredicate) -> Span {
         ast::WherePredicate::RegionPredicate(ref p) => p.span,
         ast::WherePredicate::EqPredicate(ref p) => p.span,
     }
-}
-
-// Checks whether a block contains at most one statement or expression, and no comments.
-fn is_simple_block_stmt(block: &ast::Block, codemap: &CodeMap) -> bool {
-    if (!block.stmts.is_empty() && block.expr.is_some()) ||
-       (block.stmts.len() != 1 && block.expr.is_none()) {
-        return false;
-    }
-
-    let snippet = codemap.span_to_snippet(block.span).unwrap();
-    !contains_comment(&snippet)
-}
-
-fn is_empty_block(block: &ast::Block, codemap: &CodeMap) -> bool {
-    if !block.stmts.is_empty() || block.expr.is_some() {
-        return false;
-    }
-
-    let snippet = codemap.span_to_snippet(block.span).unwrap();
-    !contains_comment(&snippet)
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -177,7 +177,8 @@ impl<'a> FmtVisitor<'a> {
                       constness: ast::Constness,
                       abi: abi::Abi,
                       vis: ast::Visibility,
-                      span: Span)
+                      span: Span,
+                      block: &ast::Block)
                       -> Option<String> {
         let mut newline_brace = self.newline_for_brace(&generics.where_clause);
 
@@ -212,7 +213,7 @@ impl<'a> FmtVisitor<'a> {
             result.push(' ');
         }
 
-        Some(result)
+        self.single_line_fn(&result, block).or_else(|| Some(result))
     }
 
     pub fn rewrite_required_fn(&mut self,
@@ -447,10 +448,7 @@ impl<'a> FmtVisitor<'a> {
         Some((result, force_new_line_for_brace))
     }
 
-    pub fn rewrite_single_line_fn(&self,
-                                  fn_str: &str,
-                                  block: &ast::Block)
-                                  -> Option<String> {
+    fn single_line_fn(&self, fn_str: &str, block: &ast::Block) -> Option<String> {
 
         if fn_str.contains('\n') {
             return None;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -103,6 +103,33 @@ pub fn end_typaram(typaram: &ast::TyParam) -> BytePos {
 }
 
 #[inline]
+pub fn semicolon_for_expr(expr: &ast::Expr) -> bool {
+    match expr.node {
+        ast::Expr_::ExprRet(..) |
+        ast::Expr_::ExprAgain(..) |
+        ast::Expr_::ExprBreak(..) => true,
+        _ => false,
+    }
+}
+
+#[inline]
+pub fn semicolon_for_stmt(stmt: &ast::Stmt) -> bool {
+    match stmt.node {
+        ast::Stmt_::StmtSemi(ref expr, _) => {
+            match expr.node {
+                ast::Expr_::ExprWhile(..) |
+                ast::Expr_::ExprWhileLet(..) |
+                ast::Expr_::ExprLoop(..) |
+                ast::Expr_::ExprForLoop(..) => false,
+                _ => true,
+            }
+        }
+        ast::Stmt_::StmtExpr(..) => false,
+        _ => true,
+    }
+}
+
+#[inline]
 #[cfg(target_pointer_width="64")]
 // Based on the trick layed out at
 // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -38,28 +38,15 @@ impl<'a> FmtVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &ast::Stmt) {
         match stmt.node {
             ast::Stmt_::StmtDecl(ref decl, _) => {
-                match decl.node {
-                    ast::Decl_::DeclLocal(ref local) => {
-                        let rewrite = {
-                            let context = self.get_context();
-                            local.rewrite(&context, self.config.max_width, self.block_indent)
-                        };
-                        self.push_rewrite(stmt.span, rewrite);
-                    }
-                    ast::Decl_::DeclItem(ref item) => self.visit_item(item),
+                if let ast::Decl_::DeclItem(ref item) = decl.node {
+                    self.visit_item(item);
+                } else {
+                    let rewrite = self.rewrite_stmt(stmt);
+                    self.push_rewrite(stmt.span, rewrite);
                 }
             }
-            ast::Stmt_::StmtExpr(ref ex, _) | ast::Stmt_::StmtSemi(ref ex, _) => {
-                let suffix = if semicolon_for_stmt(stmt) {
-                    ";"
-                } else {
-                    ""
-                };
-                let rewrite = ex.rewrite(&self.get_context(),
-                                         self.config.max_width - self.block_indent.width() -
-                                         suffix.len(),
-                                         self.block_indent)
-                                .map(|s| s + suffix);
+            ast::Stmt_::StmtExpr(..) | ast::Stmt_::StmtSemi(..) => {
+                let rewrite = self.rewrite_stmt(stmt);
                 self.push_rewrite(stmt.span, rewrite);
             }
             ast::Stmt_::StmtMac(ref mac, _macro_style) => {
@@ -101,7 +88,7 @@ impl<'a> FmtVisitor<'a> {
             self.buffer.push_str(&rewrite);
             self.last_pos = e.span.hi;
 
-            if semicolon_for_expr(e) {
+            if utils::semicolon_for_expr(e) {
                 self.buffer.push_str(";");
             }
         }
@@ -160,6 +147,13 @@ impl<'a> FmtVisitor<'a> {
             }
             visit::FnKind::Closure => None,
         };
+
+        if let Some(ref single_line_fn) = self.rewrite_single_line_fn(&rewrite, &b) {
+            self.format_missing_with_indent(s.lo);
+            self.buffer.push_str(single_line_fn);
+            self.last_pos = b.span.hi;
+            return;
+        }
 
         if let Some(fn_str) = rewrite {
             self.format_missing_with_indent(s.lo);
@@ -498,31 +492,6 @@ impl<'a> FmtVisitor<'a> {
             config: self.config,
             block_indent: self.block_indent,
         }
-    }
-}
-
-fn semicolon_for_stmt(stmt: &ast::Stmt) -> bool {
-    match stmt.node {
-        ast::Stmt_::StmtSemi(ref expr, _) => {
-            match expr.node {
-                ast::Expr_::ExprWhile(..) |
-                ast::Expr_::ExprWhileLet(..) |
-                ast::Expr_::ExprLoop(..) |
-                ast::Expr_::ExprForLoop(..) => false,
-                _ => true,
-            }
-        }
-        ast::Stmt_::StmtExpr(..) => false,
-        _ => true,
-    }
-}
-
-fn semicolon_for_expr(expr: &ast::Expr) -> bool {
-    match expr.node {
-        ast::Expr_::ExprRet(..) |
-        ast::Expr_::ExprAgain(..) |
-        ast::Expr_::ExprBreak(..) => true,
-        _ => false,
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -41,12 +41,18 @@ impl<'a> FmtVisitor<'a> {
                 if let ast::Decl_::DeclItem(ref item) = decl.node {
                     self.visit_item(item);
                 } else {
-                    let rewrite = self.rewrite_stmt(stmt);
+                    let rewrite = stmt.rewrite(&self.get_context(),
+                                               self.config.max_width - self.block_indent.width(),
+                                               self.block_indent);
+
                     self.push_rewrite(stmt.span, rewrite);
                 }
             }
             ast::Stmt_::StmtExpr(..) | ast::Stmt_::StmtSemi(..) => {
-                let rewrite = self.rewrite_stmt(stmt);
+                let rewrite = stmt.rewrite(&self.get_context(),
+                                           self.config.max_width - self.block_indent.width(),
+                                           self.block_indent);
+
                 self.push_rewrite(stmt.span, rewrite);
             }
             ast::Stmt_::StmtMac(ref mac, _macro_style) => {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -154,16 +154,15 @@ impl<'a> FmtVisitor<'a> {
             visit::FnKind::Closure => None,
         };
 
-        if let Some(ref single_line_fn) = self.rewrite_single_line_fn(&rewrite, &b) {
-            self.format_missing_with_indent(s.lo);
-            self.buffer.push_str(single_line_fn);
-            self.last_pos = b.span.hi;
-            return;
-        }
-
         if let Some(fn_str) = rewrite {
             self.format_missing_with_indent(s.lo);
-            self.buffer.push_str(&fn_str);
+            if let Some(ref single_line_fn) = self.rewrite_single_line_fn(&fn_str, &b) {
+                self.buffer.push_str(single_line_fn);
+                self.last_pos = b.span.hi;
+                return;
+            } else {
+                self.buffer.push_str(&fn_str);
+            }
         } else {
             self.format_missing(b.span.lo);
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -137,7 +137,8 @@ impl<'a> FmtVisitor<'a> {
                                 constness,
                                 abi,
                                 vis,
-                                codemap::mk_sp(s.lo, b.span.lo))
+                                codemap::mk_sp(s.lo, b.span.lo),
+                                &b)
             }
             visit::FnKind::Method(ident, ref sig, vis) => {
                 self.rewrite_fn(indent,
@@ -149,19 +150,20 @@ impl<'a> FmtVisitor<'a> {
                                 sig.constness,
                                 sig.abi,
                                 vis.unwrap_or(ast::Visibility::Inherited),
-                                codemap::mk_sp(s.lo, b.span.lo))
+                                codemap::mk_sp(s.lo, b.span.lo),
+                                &b)
             }
             visit::FnKind::Closure => None,
         };
 
         if let Some(fn_str) = rewrite {
             self.format_missing_with_indent(s.lo);
-            if let Some(ref single_line_fn) = self.rewrite_single_line_fn(&fn_str, &b) {
-                self.buffer.push_str(single_line_fn);
-                self.last_pos = b.span.hi;
-                return;
-            } else {
-                self.buffer.push_str(&fn_str);
+            self.buffer.push_str(&fn_str);
+            if let Some(c) = fn_str.chars().last() {
+                if c == '}' {
+                    self.last_pos = b.span.hi;
+                    return;
+                }
             }
         } else {
             self.format_missing(b.span.lo);

--- a/tests/source/fn-single-line.rs
+++ b/tests/source/fn-single-line.rs
@@ -64,6 +64,8 @@ fn lots_of_space                      ()                                        
                            1                 
 }
 
+fn mac() -> Vec<i32> { vec![] }
+
 trait CoolTypes {
     fn dummy(&self) {
     }

--- a/tests/source/fn-single-line.rs
+++ b/tests/source/fn-single-line.rs
@@ -1,0 +1,74 @@
+// rustfmt-fn_single_line: true
+// Test single-line functions.
+
+fn foo_expr() {
+    1
+}
+
+fn foo_stmt() {
+    foo();
+}
+
+fn foo_decl_local()  {
+    let z = 5;
+   }
+
+fn    foo_decl_item(x: &mut i32) {
+    x = 3;
+}
+
+   fn empty()     {
+
+}
+
+fn foo_return() -> String {
+    "yay"
+}
+
+fn foo_where() -> T where T: Sync {
+    let x = 2;
+}
+
+fn fooblock() {
+    {
+        "inner-block"
+    }
+}
+
+fn fooblock2(x: i32) {
+    let z = match x {
+        _ => 2,
+    };
+}
+
+fn comment() {
+    // this is a test comment
+    1
+}
+
+fn comment2() {
+    // multi-line comment
+    let z = 2;
+    1
+}
+
+fn only_comment() {
+    // Keep this here
+}
+
+fn aaaaaaaaaaaaaaaaa_looooooooooooooooooooooong_name() {
+    let z = "aaaaaaawwwwwwwwwwwwwwwwwwwwwwwwwwww";
+}
+
+fn lots_of_space                      ()                                                           {
+                           1                 
+}
+
+trait CoolTypes {
+    fn dummy(&self) {
+    }
+}
+
+trait CoolerTypes { fn dummy(&self) { 
+}
+}

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -13,8 +13,7 @@ impl Bar {
     /// Blah blah blooo.
     /// Blah blah blooo.
     #[an_attribute]
-    fn foo(&mut self) -> isize {
-    }
+    fn foo(&mut self) -> isize { }
 
     /// Blah blah bing.
     /// Blah blah bing.
@@ -28,8 +27,7 @@ impl Bar {
     }
 
     #[another_attribute]
-    fn f3(self) -> Dog {
-    }
+    fn f3(self) -> Dog { }
 
     /// Blah blah bing.
     #[attrib1]
@@ -38,6 +36,5 @@ impl Bar {
     // Another comment that needs rewrite because it's tooooooooooooooooooooooooooooooo
     // loooooooooooong.
     /// Blah blah bing.
-    fn f4(self) -> Cat {
-    }
+    fn f4(self) -> Cat { }
 }

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -13,7 +13,7 @@ impl Bar {
     /// Blah blah blooo.
     /// Blah blah blooo.
     #[an_attribute]
-    fn foo(&mut self) -> isize { }
+    fn foo(&mut self) -> isize {}
 
     /// Blah blah bing.
     /// Blah blah bing.
@@ -27,7 +27,7 @@ impl Bar {
     }
 
     #[another_attribute]
-    fn f3(self) -> Dog { }
+    fn f3(self) -> Dog {}
 
     /// Blah blah bing.
     #[attrib1]
@@ -36,5 +36,5 @@ impl Bar {
     // Another comment that needs rewrite because it's tooooooooooooooooooooooooooooooo
     // loooooooooooong.
     /// Blah blah bing.
-    fn f4(self) -> Cat { }
+    fn f4(self) -> Cat {}
 }

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -32,7 +32,7 @@ fn test() {
 }
 
 /// test123
-fn doc_comment() { }
+fn doc_comment() {}
 
 fn chains() {
     foo.bar(|| {

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -32,8 +32,7 @@ fn test() {
 }
 
 /// test123
-fn doc_comment() {
-}
+fn doc_comment() { }
 
 fn chains() {
     foo.bar(|| {

--- a/tests/target/comments-fn.rs
+++ b/tests/target/comments-fn.rs
@@ -16,6 +16,6 @@ fn foo<F, G>(a: aaaaaaaaaaaaa, // A comment
 
 }
 
-fn bar<F /* comment on F */, G /* comment on G */>() { }
+fn bar<F /* comment on F */, G /* comment on G */>() {}
 
-fn baz() -> Baz /* Comment after return type */ { }
+fn baz() -> Baz /* Comment after return type */ {}

--- a/tests/target/comments-fn.rs
+++ b/tests/target/comments-fn.rs
@@ -16,8 +16,6 @@ fn foo<F, G>(a: aaaaaaaaaaaaa, // A comment
 
 }
 
-fn bar<F /* comment on F */, G /* comment on G */>() {
-}
+fn bar<F /* comment on F */, G /* comment on G */>() { }
 
-fn baz() -> Baz /* Comment after return type */ {
-}
+fn baz() -> Baz /* Comment after return type */ { }

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -28,15 +28,13 @@ fn generic<T>(arg: T) -> &SomeType
     arg(a, b, c, d, e)
 }
 
-fn foo() -> ! {
-}
+fn foo() -> ! { }
 
 pub fn http_fetch_async(listener: Box<AsyncCORSResponseListener + Send>,
                         script_chan: Box<ScriptChan + Send>) {
 }
 
-fn some_func<T: Box<Trait + Bound>>(val: T) {
-}
+fn some_func<T: Box<Trait + Bound>>(val: T) { }
 
 fn zzzzzzzzzzzzzzzzzzzz<Type, NodeType>(selff: Type,
                                         mut handle: node::Handle<IdRef<'id, Node<K, V>>,

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -28,13 +28,13 @@ fn generic<T>(arg: T) -> &SomeType
     arg(a, b, c, d, e)
 }
 
-fn foo() -> ! { }
+fn foo() -> ! {}
 
 pub fn http_fetch_async(listener: Box<AsyncCORSResponseListener + Send>,
                         script_chan: Box<ScriptChan + Send>) {
 }
 
-fn some_func<T: Box<Trait + Bound>>(val: T) { }
+fn some_func<T: Box<Trait + Bound>>(val: T) {}
 
 fn zzzzzzzzzzzzzzzzzzzz<Type, NodeType>(selff: Type,
                                         mut handle: node::Handle<IdRef<'id, Node<K, V>>,

--- a/tests/target/fn-single-line.rs
+++ b/tests/target/fn-single-line.rs
@@ -1,0 +1,61 @@
+// rustfmt-fn_single_line: true
+// Test single-line functions.
+
+fn foo_expr() { 1 }
+
+fn foo_stmt() { foo(); }
+
+fn foo_decl_local() { let z = 5; }
+
+fn foo_decl_item(x: &mut i32) { x = 3; }
+
+fn empty() { }
+
+fn foo_return() -> String { "yay" }
+
+fn foo_where() -> T
+    where T: Sync
+{
+    let x = 2;
+}
+
+fn fooblock() {
+    {
+        "inner-block"
+    }
+}
+
+fn fooblock2(x: i32) {
+    let z = match x {
+        _ => 2,
+    };
+}
+
+fn comment() {
+    // this is a test comment
+    1
+}
+
+fn comment2() {
+    // multi-line comment
+    let z = 2;
+    1
+}
+
+fn only_comment() {
+    // Keep this here
+}
+
+fn aaaaaaaaaaaaaaaaa_looooooooooooooooooooooong_name() {
+    let z = "aaaaaaawwwwwwwwwwwwwwwwwwwwwwwwwwww";
+}
+
+fn lots_of_space() { 1 }
+
+trait CoolTypes {
+    fn dummy(&self) { }
+}
+
+trait CoolerTypes {
+    fn dummy(&self) { }
+}

--- a/tests/target/fn-single-line.rs
+++ b/tests/target/fn-single-line.rs
@@ -9,7 +9,7 @@ fn foo_decl_local() { let z = 5; }
 
 fn foo_decl_item(x: &mut i32) { x = 3; }
 
-fn empty() { }
+fn empty() {}
 
 fn foo_return() -> String { "yay" }
 
@@ -55,9 +55,9 @@ fn lots_of_space() { 1 }
 fn mac() -> Vec<i32> { vec![] }
 
 trait CoolTypes {
-    fn dummy(&self) { }
+    fn dummy(&self) {}
 }
 
 trait CoolerTypes {
-    fn dummy(&self) { }
+    fn dummy(&self) {}
 }

--- a/tests/target/fn-single-line.rs
+++ b/tests/target/fn-single-line.rs
@@ -52,6 +52,8 @@ fn aaaaaaaaaaaaaaaaa_looooooooooooooooooooooong_name() {
 
 fn lots_of_space() { 1 }
 
+fn mac() -> Vec<i32> { vec![] }
+
 trait CoolTypes {
     fn dummy(&self) { }
 }

--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -1,6 +1,6 @@
 // Tests different fns
 
-fn foo(a: AAAA, b: BBB, c: CCC) -> RetType { }
+fn foo(a: AAAA, b: BBB, c: CCC) -> RetType {}
 
 fn foo(a: AAAA, b: BBB /* some, weird, inline comment */, c: CCC) -> RetType
     where T: Blah
@@ -32,7 +32,7 @@ fn foo<U, T>(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
 
 }
 
-fn foo<U: Fn(A) -> B /* paren inside generics */>() { }
+fn foo<U: Fn(A) -> B /* paren inside generics */>() {}
 
 impl Foo {
     fn with_no_errors<T, F>(&mut self, f: F) -> T
@@ -40,9 +40,9 @@ impl Foo {
     {
     }
 
-    fn foo(mut self, mut bar: u32) { }
+    fn foo(mut self, mut bar: u32) {}
 
-    fn bar(self, mut bazz: u32) { }
+    fn bar(self, mut bazz: u32) {}
 }
 
 pub fn render<'a,
@@ -70,9 +70,9 @@ impl Foo {
     }
 }
 
-fn homura<T: Deref<Target = i32>>(_: T) { }
+fn homura<T: Deref<Target = i32>>(_: T) {}
 
-fn issue377() -> (Box<CompositorProxy + Send>, Box<CompositorReceiver>) { }
+fn issue377() -> (Box<CompositorProxy + Send>, Box<CompositorReceiver>) {}
 
 fn main() {
     let _ = function(move || 5);

--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -1,8 +1,6 @@
 // Tests different fns
 
-fn foo(a: AAAA, b: BBB, c: CCC) -> RetType {
-
-}
+fn foo(a: AAAA, b: BBB, c: CCC) -> RetType { }
 
 fn foo(a: AAAA, b: BBB /* some, weird, inline comment */, c: CCC) -> RetType
     where T: Blah
@@ -34,8 +32,7 @@ fn foo<U, T>(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
 
 }
 
-fn foo<U: Fn(A) -> B /* paren inside generics */>() {
-}
+fn foo<U: Fn(A) -> B /* paren inside generics */>() { }
 
 impl Foo {
     fn with_no_errors<T, F>(&mut self, f: F) -> T
@@ -43,11 +40,9 @@ impl Foo {
     {
     }
 
-    fn foo(mut self, mut bar: u32) {
-    }
+    fn foo(mut self, mut bar: u32) { }
 
-    fn bar(self, mut bazz: u32) {
-    }
+    fn bar(self, mut bazz: u32) { }
 }
 
 pub fn render<'a,
@@ -75,12 +70,9 @@ impl Foo {
     }
 }
 
-fn homura<T: Deref<Target = i32>>(_: T) {
+fn homura<T: Deref<Target = i32>>(_: T) { }
 
-}
-
-fn issue377() -> (Box<CompositorProxy + Send>, Box<CompositorReceiver>) {
-}
+fn issue377() -> (Box<CompositorProxy + Send>, Box<CompositorReceiver>) { }
 
 fn main() {
     let _ = function(move || 5);

--- a/tests/target/multiple.rs
+++ b/tests/target/multiple.rs
@@ -26,9 +26,7 @@ mod other;
 // sfdgfffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // ffffffffffffffffffffffffffffffffffffffffff
 
-fn foo(a: isize, b: u32 /* blah blah */, c: f64) {
-
-}
+fn foo(a: isize, b: u32 /* blah blah */, c: f64) { }
 
 fn foo() -> Box<Write + 'static>
     where 'a: 'b,
@@ -77,8 +75,7 @@ impl Bar {
     }
 
     #[an_attribute]
-    fn f3(self) -> Dog {
-    }
+    fn f3(self) -> Dog { }
 }
 
 /// The `nodes` and `edges` method each return instantiations of
@@ -118,8 +115,7 @@ pub struct Foo<'a, Y: Baz>
     f: SomeType, // Comment beside a field
 }
 
-fn foo(ann: &'a (PpAnn + 'a)) {
-}
+fn foo(ann: &'a (PpAnn + 'a)) { }
 
 fn main() {
     for i in 0i32..4 {

--- a/tests/target/multiple.rs
+++ b/tests/target/multiple.rs
@@ -26,7 +26,7 @@ mod other;
 // sfdgfffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // ffffffffffffffffffffffffffffffffffffffffff
 
-fn foo(a: isize, b: u32 /* blah blah */, c: f64) { }
+fn foo(a: isize, b: u32 /* blah blah */, c: f64) {}
 
 fn foo() -> Box<Write + 'static>
     where 'a: 'b,
@@ -75,7 +75,7 @@ impl Bar {
     }
 
     #[an_attribute]
-    fn f3(self) -> Dog { }
+    fn f3(self) -> Dog {}
 }
 
 /// The `nodes` and `edges` method each return instantiations of
@@ -115,7 +115,7 @@ pub struct Foo<'a, Y: Baz>
     f: SomeType, // Comment beside a field
 }
 
-fn foo(ann: &'a (PpAnn + 'a)) { }
+fn foo(ann: &'a (PpAnn + 'a)) {}
 
 fn main() {
     for i in 0i32..4 {

--- a/tests/target/nestedmod/mod2c.rs
+++ b/tests/target/nestedmod/mod2c.rs
@@ -1,3 +1,3 @@
 // A standard mod
 
-fn a() { }
+fn a() {}

--- a/tests/target/nestedmod/mod2c.rs
+++ b/tests/target/nestedmod/mod2c.rs
@@ -1,4 +1,3 @@
 // A standard mod
 
-fn a() {
-}
+fn a() { }

--- a/tests/target/nestedmod/mymod1/mod3a.rs
+++ b/tests/target/nestedmod/mymod1/mod3a.rs
@@ -1,2 +1,2 @@
 // Another mod
-fn a() { }
+fn a() {}

--- a/tests/target/nestedmod/mymod1/mod3a.rs
+++ b/tests/target/nestedmod/mymod1/mod3a.rs
@@ -1,3 +1,2 @@
 // Another mod
-fn a() {
-}
+fn a() { }

--- a/tests/target/nestedmod/submod2/a.rs
+++ b/tests/target/nestedmod/submod2/a.rs
@@ -3,4 +3,4 @@
 
 use c::a;
 
-fn foo() { }
+fn foo() {}

--- a/tests/target/nestedmod/submod2/a.rs
+++ b/tests/target/nestedmod/submod2/a.rs
@@ -3,5 +3,4 @@
 
 use c::a;
 
-fn foo() {
-}
+fn foo() { }

--- a/tests/target/no_new_line_beginning.rs
+++ b/tests/target/no_new_line_beginning.rs
@@ -1,1 +1,1 @@
-fn main() { }
+fn main() {}

--- a/tests/target/no_new_line_beginning.rs
+++ b/tests/target/no_new_line_beginning.rs
@@ -1,2 +1,1 @@
-fn main() {
-}
+fn main() { }

--- a/tests/target/paths.rs
+++ b/tests/target/paths.rs
@@ -19,4 +19,4 @@ fn main() {
     let x: Foo<A>;
 }
 
-fn op(foo: Bar, key: &[u8], upd: Fn(Option<&memcache::Item>, Baz) -> Result) -> MapResult { }
+fn op(foo: Bar, key: &[u8], upd: Fn(Option<&memcache::Item>, Baz) -> Result) -> MapResult {}

--- a/tests/target/paths.rs
+++ b/tests/target/paths.rs
@@ -19,5 +19,4 @@ fn main() {
     let x: Foo<A>;
 }
 
-fn op(foo: Bar, key: &[u8], upd: Fn(Option<&memcache::Item>, Baz) -> Result) -> MapResult {
-}
+fn op(foo: Bar, key: &[u8], upd: Fn(Option<&memcache::Item>, Baz) -> Result) -> MapResult { }


### PR DESCRIPTION
Fixes #262.

Formats empty-body functions on a single-line if possible, and adds the `fn_single_line` option to do the same for single-statement/expression functions.

Organizational changes:
* `semicolon_for_stmt`, `semicolon_for_expr` moved to utils module; I wasn't sure if these were better suited in the expr module.
* `visit_stmt` logic split off into `impl Rewrite for ast::Stmt`. The visit function still takes care of the logic for visiting/rewriting Items and Macs.