### PR TITLE
Use argv[0] for usage output

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -164,7 +164,7 @@ fn main() {
 fn print_usage(opts: &Options, reason: &str) {
     let reason = format!("{}\nusage: {} [options] <file>...",
                          reason,
-                         env::current_exe().unwrap().display());
+                         env::args_os().next().unwrap().to_string_lossy());
     println!("{}", opts.usage(&reason));
 }
 


### PR DESCRIPTION
Usage messages traditionally use this as it contains the path that the
user provided to run the executable (e.g. `rustfmt` instead of
`/usr/local/bin/rustfmt`).