### PR TITLE
Avoid adding an extra newline after block comments

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -143,11 +143,12 @@ impl<'a> FmtVisitor<'a> {
                     line_start = offset + subslice.len();
 
                     if let Some('/') = subslice.chars().skip(1).next() {
+                        // Add a newline after line comments
                         self.buffer.push_str("\n");
                     } else if line_start < snippet.len() {
-                        let x = (&snippet[line_start..]).chars().next().unwrap() != '\n';
-
-                        if x {
+                        // For other comments add a newline if there isn't one at the end already
+                        let c = snippet[line_start..].chars().next().unwrap();
+                        if c != '\n' && c != '\r' {
                             self.buffer.push_str("\n");
                         }
                     }

--- a/tests/source/comment_crlf_newline.rs
+++ b/tests/source/comment_crlf_newline.rs
@@ -1,0 +1,3 @@
+/* Block comments followed by CRLF newlines should not an extra newline at the end */
+
+/* Something else */

--- a/tests/target/comment_crlf_newline.rs
+++ b/tests/target/comment_crlf_newline.rs
@@ -1,0 +1,3 @@
+// Block comments followed by CRLF newlines should not an extra newline at the end
+
+// Something else


### PR DESCRIPTION
When block comments were rewritten to line comments they check if a new line needs to be added and adds one if needed. It only checked for '\n' however which would cause a newline to be added even if the comment was ended by "\r\n".