### PR TITLE
Correct doc comment indentation for struct fields

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1195,15 +1195,14 @@ impl Rewrite for ast::StructField {
             ast::StructFieldKind::NamedField(_, vis) |
             ast::StructFieldKind::UnnamedField(vis) => format_visibility(vis),
         };
-        let indent = context.block_indent.block_indent(context.config);
         let mut attr_str = try_opt!(self.node
                                         .attrs
                                         .rewrite(context,
-                                                 context.config.max_width - indent.width(),
-                                                 indent));
+                                                 context.config.max_width - offset.width(),
+                                                 offset));
         if !attr_str.is_empty() {
             attr_str.push('\n');
-            attr_str.push_str(&indent.to_string(context.config));
+            attr_str.push_str(&offset.to_string(context.config));
         }
 
         let result = match name {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -14,7 +14,6 @@ use std::iter::Peekable;
 use syntax::codemap::{self, CodeMap, BytePos};
 
 use Indent;
-use utils::wrap_str;
 use comment::{FindUncommented, rewrite_comment, find_comment_end};
 use config::Config;
 
@@ -280,12 +279,7 @@ pub fn write_list<'b, I, T>(items: I, formatting: &ListFormatting<'b>) -> Option
             }
         }
 
-        // Make sure that string actually fits.
-        let item_str = try_opt!(wrap_str(&inner_item[..],
-                                         formatting.config.max_width,
-                                         formatting.width,
-                                         formatting.indent));
-        result.push_str(&item_str);
+        result.push_str(&inner_item[..]);
 
         // Post-comments
         if tactic != DefinitiveListTactic::Vertical && item.post_comment.is_some() {

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -141,3 +141,7 @@ mod m {
         a: T,
     }
 }
+
+struct Foo<T>(TTTTTTTTTTTTTTTTTTT,
+              /// Qux
+    UUUUUUUUUUUUUUUUUUU);

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -2,7 +2,8 @@
 
 // Long import.
 use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
-use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
+use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA,
+                                                                                                ItemB};
 use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA,
                                                                                              ItemB};
 

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -149,3 +149,7 @@ mod m {
         a: T,
     }
 }
+
+struct Foo<T>(TTTTTTTTTTTTTTTTTTT,
+              /// Qux
+              UUUUUUUUUUUUUUUUUUU);


### PR DESCRIPTION
Fix https://github.com/rust-lang-nursery/rustfmt/issues/572.