### PR TITLE
Keep comments in empty impl body

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,12 +144,12 @@ pub fn semicolon_for_stmt(stmt: &ast::Stmt) -> bool {
 
 #[inline]
 pub fn trim_newlines(input: &str) -> &str {
-    let start = input.find(|c| c != '\n' && c != '\r').unwrap_or(0);
-    let end = input.rfind(|c| c != '\n' && c != '\r').unwrap_or(0) + 1;
-    if start == 0 && end == 1 {
-        input
-    } else {
-        &input[start..end]
+    match input.find(|c| c != '\n' && c != '\r') {
+        Some(start) => {
+            let end = input.rfind(|c| c != '\n' && c != '\r').unwrap_or(0) + 1;
+            &input[start..end]
+        }
+        None => "",
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -146,7 +146,11 @@ pub fn semicolon_for_stmt(stmt: &ast::Stmt) -> bool {
 pub fn trim_newlines(input: &str) -> &str {
     let start = input.find(|c| c != '\n' && c != '\r').unwrap_or(0);
     let end = input.rfind(|c| c != '\n' && c != '\r').unwrap_or(0) + 1;
-    &input[start..end]
+    if start == 0 && end == 1 {
+        input
+    } else {
+        &input[start..end]
+    }
 }
 
 #[inline]

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -51,3 +51,10 @@ mod b {
         }
     }
 }
+
+impl Foo { add_fun!(); }
+
+impl Blah {
+    fn boop() {}
+    add_fun!();
+}

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -26,6 +26,16 @@ impl Foo {
     fn foo() {}
 }
 
+impl Boo {
+
+    // BOO
+    fn boo() {}
+    // FOO
+
+    
+    
+}
+
 mod a {
     impl Foo {
         // Hello!

--- a/tests/target/impl.rs
+++ b/tests/target/impl.rs
@@ -1,3 +1,7 @@
 // Test impls
 
 impl<T> JSTraceable for SmallVec<[T; 1]> {}
+
+impl<K, V, NodeRef: Deref<Target = Node<K, V>>> Handle<NodeRef, handle::Edge, handle::Internal> {
+    // Keep this.
+}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -63,3 +63,12 @@ mod b {
         }
     }
 }
+
+impl Foo {
+    add_fun!();
+}
+
+impl Blah {
+    fn boop() {}
+    add_fun!();
+}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -42,6 +42,12 @@ impl Foo {
     fn foo() {}
 }
 
+impl Boo {
+    // BOO
+    fn boo() {}
+    // FOO
+}
+
 mod a {
     impl Foo {
         // Hello!

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -13,6 +13,7 @@ pub impl Foo for Bar {
     fn foo() {
         "hi"
     }
+    // Comment 3
 }
 
 pub unsafe impl<'a, 'b, X, Y: Foo<Bar>> !Foo<'a, X> for Bar<'b, Y> where X: Foo<'a, Z>


### PR DESCRIPTION
Fixes #651, yo.

This also keeps comments that exist after impl items, e.g.
```rust
impl Foo() {
    fn foo() {}
    // Comment 3
}
```

However, I notice there's an existing test in impls.rs that removes such comments, so I can do the same if desired.