### PR TITLE
Don't include failed item rewrites in missed spans

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -191,6 +191,7 @@ impl<'a> FmtVisitor<'a> {
             }
             _ => {
                 if self.visit_attrs(&item.attrs) {
+                    self.push_rewrite(item.span, None);
                     return;
                 }
             }
@@ -377,11 +378,9 @@ impl<'a> FmtVisitor<'a> {
 
     fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {
         self.format_missing_with_indent(span.lo);
-
-        if let Some(res) = rewrite {
-            self.buffer.push_str(&res);
-            self.last_pos = span.hi;
-        }
+        let result = rewrite.unwrap_or_else(|| self.snippet(span));
+        self.buffer.push_str(&result);
+        self.last_pos = span.hi;
     }
 
     pub fn from_codemap(parse_session: &'a ParseSess,

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -32,7 +32,7 @@ struct Qux<'a,
 (
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // Comment
     BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
-    #[AnAttr]    
+    #[AnAttr]
     // Comment
     /// Testdoc
     G,

--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -85,3 +85,9 @@ fn inner() {
     #![inline]
     x
 }
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn foo(a: i32) -> i32 {
+    // comment
+    if a > 0 { 1 } else { 2 }
+}


### PR DESCRIPTION
Fix https://github.com/rust-lang-nursery/rustfmt/issues/661.