### PR TITLE
Fix missed edgecases in formatting of type aliases

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -774,6 +774,20 @@ pub fn rewrite_type_alias(context: &RewriteContext,
                                                  generics_span));
 
     result.push_str(&generics_str);
+
+    let where_budget = try_opt!(context.config
+                                       .max_width
+                                       .checked_sub(last_line_width(&result)));
+    let where_clause_str = try_opt!(rewrite_where_clause(context,
+                                                         &generics.where_clause,
+                                                         context.config,
+                                                         context.config.item_brace_style,
+                                                         indent,
+                                                         where_budget,
+                                                         context.config.where_density,
+                                                         "=",
+                                                         Some(span.hi)));
+    result.push_str(&where_clause_str);
     result.push_str(" = ");
 
     let line_width = last_line_width(&result);

--- a/tests/source/type_alias.rs
+++ b/tests/source/type_alias.rs
@@ -18,3 +18,10 @@ pub type CommentTest< /* Lifetime */ 'a
         // Type
         T
                     > = ();
+
+
+pub type WithWhereClause<LONGPARAMETERNAME, T> where T: Clone, LONGPARAMETERNAME: Clone + Eq + OtherTrait = Option<T>;
+
+pub type Exactly100CharstoEqualWhereTest<T, U, PARAMET> where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;
+
+pub type Exactly101CharstoEqualWhereTest<T, U, PARAMETE> where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;

--- a/tests/source/type_alias.rs
+++ b/tests/source/type_alias.rs
@@ -9,6 +9,10 @@ pub type Exactly100CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAM
 
 pub type Exactly101CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B> = Vec<Test>;
 
+pub type Exactly100CharsToEqualTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B, C> = Vec<i32>;
+
+pub type GenericsFitButNotEqualTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A1, B, C> = Vec<i32>;
+
 pub type CommentTest< /* Lifetime */ 'a
             ,
         // Type

--- a/tests/target/type_alias.rs
+++ b/tests/target/type_alias.rs
@@ -22,6 +22,19 @@ pub type Exactly100CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAM
 pub type Exactly101CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B> =
     Vec<Test>;
 
+pub type Exactly100CharsToEqualTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B, C> =
+    Vec<i32>;
+
+pub type GenericsFitButNotEqualTest<'a,
+                                    'b,
+                                    'c,
+                                    'd,
+                                    LONGPARAMETERNAME,
+                                    LONGPARAMETERNAME,
+                                    A1,
+                                    B,
+                                    C> = Vec<i32>;
+
 pub type CommentTest<// Lifetime
                      'a, // Type
                      T> = ();

--- a/tests/target/type_alias.rs
+++ b/tests/target/type_alias.rs
@@ -38,3 +38,14 @@ pub type GenericsFitButNotEqualTest<'a,
 pub type CommentTest<// Lifetime
                      'a, // Type
                      T> = ();
+
+
+pub type WithWhereClause<LONGPARAMETERNAME, T>
+    where T: Clone,
+          LONGPARAMETERNAME: Clone + Eq + OtherTrait = Option<T>;
+
+pub type Exactly100CharstoEqualWhereTest<T, U, PARAMET> where T: Clone + Ord + Eq + SomeOtherTrait =
+    Option<T>;
+
+pub type Exactly101CharstoEqualWhereTest<T, U, PARAMETE>
+    where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;


### PR DESCRIPTION
Followup of #640 which fixes where clauses (which I forgot about) and an edge case where '=' was close or at the max width.