### PR TITLE
Add normalise_comments option.

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -27,9 +27,23 @@ pub fn rewrite_comment(orig: &str,
     // Edge case: block comments. Let's not trim their lines (for now).
     let (opener, closer, line_start) = if block_style {
         ("/* ", " */", " * ")
-    } else if orig.starts_with("///") {
+    } else if !config.normalise_comments {
+        if orig.starts_with("/**") {
+            ("/** ", " **/", " ** ")
+        } else if orig.starts_with("/*!") {
+            ("/*! ", " */", " * ")
+        } else if orig.starts_with("/*") {
+            ("/* ", " */", " * ")
+        } else if orig.starts_with("///") {
+            ("/// ", "", "/// ")
+        } else if orig.starts_with("//!") {
+            ("//! ", "", "//! ")
+        } else {
+            ("// ", "", "// ")
+        }
+    } else if orig.starts_with("///") || orig.starts_with("/**") {
         ("/// ", "", "/// ")
-    } else if orig.starts_with("//!") {
+    } else if orig.starts_with("//!") || orig.starts_with("/*!") {
         ("//! ", "", "//! ")
     } else {
         ("// ", "", "// ")
@@ -72,10 +86,12 @@ pub fn rewrite_comment(orig: &str,
                  });
 
     let mut result = opener.to_owned();
-    let mut first = true;
-
     for line in lines {
-        if !first {
+        if result == opener {
+            if line.len() == 0 {
+                continue;
+            }
+        } else {
             result.push('\n');
             result.push_str(&indent_str);
             result.push_str(line_start);
@@ -91,22 +107,27 @@ pub fn rewrite_comment(orig: &str,
             }
             result.push_str(line);
         }
-
-        first = false;
     }
 
     result.push_str(closer);
+    if result == opener {
+        // Trailing space.
+        result.pop();
+    }
 
     Some(result)
 }
 
 fn left_trim_comment_line(line: &str) -> &str {
-    if line.starts_with("//! ") || line.starts_with("/// ") {
+    if line.starts_with("//! ") || line.starts_with("/// ") || line.starts_with("/*! ") ||
+       line.starts_with("/** ") {
         &line[4..]
     } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
-       line.starts_with("///") {
+       line.starts_with("///") || line.starts_with("** ") || line.starts_with("/*!") ||
+       line.starts_with("/**") {
         &line[3..]
-    } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//") {
+    } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//") ||
+       line.starts_with("**") {
         &line[2..]
     } else if line.starts_with("*") {
         &line[1..]

--- a/src/config.rs
+++ b/src/config.rs
@@ -307,6 +307,7 @@ create_config! {
     take_source_hints: bool, true, "Retain some formatting characteristics from the source code";
     hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";
     wrap_comments: bool, false, "Break comments to fit on the line";
+    normalise_comments: bool, true, "Convert /* */ comments to // comments where possible";
     wrap_match_arms: bool, true, "Wrap multiline match arms in blocks";
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -530,6 +530,7 @@ impl<'a> Rewrite for [ast::Attribute] {
         for (i, a) in self.iter().enumerate() {
             let a_str = context.snippet(a.span);
 
+            // Write comments and blank lines between attributes.
             if i > 0 {
                 let comment = context.snippet(codemap::mk_sp(self[i - 1].span.hi, a.span.lo));
                 // This particular horror show is to preserve line breaks in between doc
@@ -553,6 +554,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                 result.push_str(&indent);
             }
 
+            // Write the attribute itself.
             result.push_str(&a_str);
 
             if i < self.len() - 1 {

--- a/tests/source/comment4.rs
+++ b/tests/source/comment4.rs
@@ -1,10 +1,7 @@
-// rustfmt-wrap_comments: true
+// rustfmt-normalise_comments: false
 
 //! Doc comment
 fn test() {
-            /*!
-             * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam */
-
 // comment
         // comment2
 
@@ -36,12 +33,3 @@ fn test() {
   /// test123
 fn doc_comment() {
 }
-
-fn chains() {
-                foo.bar(|| { 
-                let x = 10;
-                /* comment */ x })
-}
-
-/*
- * random comment */

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -2,6 +2,9 @@
 
 //! Doc comment
 fn test() {
+    //! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam
+    //! lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+
     // comment
     // comment2
 
@@ -41,3 +44,5 @@ fn chains() {
         x
     })
 }
+
+// random comment

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -1,0 +1,34 @@
+// rustfmt-normalise_comments: false
+
+//! Doc comment
+fn test() {
+    // comment
+    // comment2
+
+    code(); /* leave this comment alone!
+             * ok? */
+
+    /* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a
+     * diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+     * viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+     * Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam
+     * tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut
+     * libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit
+     * amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis
+     * felis, pulvinar a semper sed, adipiscing id dolor. */
+
+    // Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment that should be split
+
+    // println!("{:?}", rewrite_comment(subslice,
+    //                                       false,
+    //                                       comment_width,
+    //                                       self.block_indent,
+    //                                       self.config)
+    //                           .unwrap());
+
+    funk(); //dontchangeme
+            // or me
+}
+
+/// test123
+fn doc_comment() {}


### PR DESCRIPTION
So block comments are not converted to line comments

Fixes #610 

cc #518