### PR TITLE
Add cargo-fmt 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "term 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -50,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "kernel32-sys"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -144,6 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 include = ["src/*.rs", "Cargo.toml"]
 
+[features]
+default = ["cargo-fmt"]
+cargo-fmt = ["walkdir"]
+
 [dependencies]
 toml = "0.1.20"
 rustc-serialize = "0.3.14"
@@ -21,3 +25,5 @@ syntex_syntax = "0.23.0"
 log = "0.3.2"
 env_logger = "0.3.1"
 getopts = "0.2"
+
+walkdir = {version = "0.1.5", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/nick29581/rustfmt"
 readme = "README.md"
 license = "Apache-2.0/MIT"
 
+[features]
+default = ["cargo-fmt"]
+cargo-fmt = ["walkdir"]
+
 [dependencies]
 toml = "0.1.20"
 rustc-serialize = "0.3.14"
@@ -20,5 +24,7 @@ syntex_syntax = { git = "https://github.com/serde-rs/syntex" }
 log = "0.3.2"
 env_logger = "0.3.1"
 getopts = "0.2"
+
+walkdir = {version = "0.1.5", optional = true}
 
 [dev-dependencies]

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -1,0 +1,107 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Inspired by Paul Woolcock's cargo-fmt (https://github.com/pwoolcoc/cargo-fmt/)
+
+#![cfg(not(test))]
+#![cfg(feature="cargo-fmt")]
+
+extern crate getopts;
+extern crate walkdir;
+extern crate rustc_serialize;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::env;
+use std::str;
+
+use getopts::Options;
+use walkdir::{WalkDir, DirEntry};
+use rustc_serialize::json::Json;
+
+fn main() {
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "show this message");
+
+    let matches = opts.parse(env::args().skip(1)).unwrap_or_else(|e| {
+        print_usage(&opts, &e.to_string());
+        return;
+    });
+
+    if matches.opt_present("h") {
+        print_usage(&opts, "");
+    } else {
+        format_crate(&opts);
+    }
+}
+
+fn print_usage(opts: &Options, reason: &str) {
+    let msg = format!("{}\nusage: cargo fmt [options]", reason);
+    println!("{}\nThis utility formats all readable .rs files in the src directory of the \
+              current crate using rustfmt.",
+             opts.usage(&msg));
+}
+
+fn format_crate(opts: &Options) {
+    let mut root = locate_root().unwrap_or_else(|e| {
+        print_usage(opts, &e.to_string());
+        return;
+    });
+
+    // Currently only files in [root]/src can be formatted
+    root.push("src");
+    // All unreadable or non .rs files are skipped
+    let files: Vec<_> = WalkDir::new(root)
+                            .into_iter()
+                            .filter(is_rs_file)
+                            .filter_map(|f| f.ok())
+                            .map(|e| e.path().to_owned())
+                            .collect();
+
+    format_files(&files).unwrap_or_else(|e| print_usage(opts, &e.to_string));
+}
+
+fn locate_root() -> Result<PathBuf, std::io::Error> {
+    // This seems adequate, as cargo-fmt can only be used systems that have Cargo installed
+    let output = try!(Command::new("cargo").arg("locate-project").output());
+    if output.status.success() {
+        // We assume cargo locate-project is not broken and
+        // it will output a valid json document
+        let data = &String::from_utf8(output.stdout).unwrap();
+        let json = Json::from_str(data).unwrap();
+        let root = PathBuf::from(json.find("root").unwrap().as_string().unwrap());
+
+        // root.parent() should never fail if locate-project's output is correct
+        Ok(root.parent().unwrap().to_owned())
+    } else {
+        // This happens when cargo-fmt is not used inside a crate
+        Err(std::io::Error::new(std::io::ErrorKind::NotFound,
+                                str::from_utf8(&output.stderr).unwrap()))
+    }
+}
+
+fn is_rs_file(entry: &Result<walkdir::DirEntry, walkdir::Error>) -> bool {
+    match *entry {
+        Ok(ref file) => match file.path().extension() {
+            Some(ext) => ext == "rs",
+            None => false,
+        },
+        Err(_) => false,
+    }
+}
+
+fn format_files(files: &Vec<PathBuf>) -> Result<(), std::io::Error> {
+    let mut command = try!(Command::new("rustfmt")
+                               .args(files)
+                               .spawn());
+    try!(command.wait());
+
+    Ok(())
+}


### PR DESCRIPTION
`cargo-fmt` is a utility that finds the root of a crate using `cargo locate-project` and formats all `.rs` files in the `src` directory recursively.

It can be installed alongside `rustfmt` using `cargo install rustfmt` and can be used as a Cargo subcommand (`cargo fmt` will format the current crate).
I've a added a feature gate, so cargo-fmt can be optionally excluded from the build.

[Fix #613]