### PR TITLE
Add cargo-fmt binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ dependencies = [
  "term 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -145,15 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "walkdir"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "term 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -144,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 include = ["src/*.rs", "Cargo.toml"]
 
+[features]
+default = ["cargo-fmt"]
+cargo-fmt = ["walkdir"]
+
 [dependencies]
 toml = "0.1.20"
 rustc-serialize = "0.3.14"
@@ -21,3 +25,5 @@ syntex_syntax = "0.23.0"
 log = "0.3.2"
 env_logger = "0.3.1"
 getopts = "0.2"
+
+walkdir = {version = "0.1.5", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ include = ["src/*.rs", "Cargo.toml"]
 
 [features]
 default = ["cargo-fmt"]
-cargo-fmt = ["walkdir"]
+cargo-fmt = []
 
 [dependencies]
 toml = "0.1.20"
@@ -25,5 +25,3 @@ syntex_syntax = "0.23.0"
 log = "0.3.2"
 env_logger = "0.3.1"
 getopts = "0.2"
-
-walkdir = {version = "0.1.5", optional = true}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You can run Rustfmt by just typing `rustfmt filename` if you used `Cargo
 install`. This runs rustfmt on the given file, if the file includes out of line
 modules, then we reformat those too. So to run on a whole module or crate, you
 just need to run on the root file (usually mod.rs or lib.rs). Rustfmt can also
-read data from stdin.
+read data from stdin. Alternatively, you can use `cargo fmt` to format all Rust
+files in the `src` directory of your crate.
 
 You'll probably want to specify the write mode. Currently, there are modes for
 replace, overwrite, display, and coverage. The replace mode is the default
@@ -59,8 +60,9 @@ First make sure you've got Rust **1.4.0** or greater available, then:
 
 `cargo test` to run all tests.
 
-To run rustfmt after this, use `cargo run -- filename`. See the notes above on
-running rustfmt.
+To run rustfmt after this, use `cargo run --bin rustfmt -- filename`. See the
+notes above on running rustfmt. To run cargo-fmt, use
+`cargo run --bin cargo-fmt`
 
 
 ## What style does Rustfmt use?

--- a/README.md
+++ b/README.md
@@ -21,15 +21,21 @@ or if you're using [`multirust`](https://github.com/brson/multirust)
 multirust run nightly cargo install --git https://github.com/rust-lang-nursery/rustfmt
 ```
 
+Usually cargo-fmt, which enables usage of Cargo subcommand `cargo fmt`, is
+installed alongside rustfmt. To only install rustfmt run
+
+```
+cargo install --no-default-features --git https://github.com/rust-lang-nursery/rustfmt
+```
 
 ## Running
 
-You can run Rustfmt by just typing `rustfmt filename` if you used `Cargo
+You can run Rustfmt by just typing `rustfmt filename` if you used `cargo
 install`. This runs rustfmt on the given file, if the file includes out of line
 modules, then we reformat those too. So to run on a whole module or crate, you
 just need to run on the root file (usually mod.rs or lib.rs). Rustfmt can also
-read data from stdin. Alternatively, you can use `cargo fmt` to format all Rust
-files in the `src` directory of your crate.
+read data from stdin. Alternatively, you can use `cargo fmt` to format all
+binary and library targets of your crate.
 
 You'll probably want to specify the write mode. Currently, there are modes for
 replace, overwrite, display, and coverage. The replace mode is the default
@@ -43,6 +49,7 @@ screen, for example.
 
 You can run `rustfmt --help` for more information.
 
+`cargo fmt` uses `--write-mode=overwrite` by default.
 
 ## Running Rustfmt from your editor
 
@@ -61,8 +68,7 @@ First make sure you've got Rust **1.4.0** or greater available, then:
 `cargo test` to run all tests.
 
 To run rustfmt after this, use `cargo run --bin rustfmt -- filename`. See the
-notes above on running rustfmt. To run cargo-fmt, use
-`cargo run --bin cargo-fmt`
+notes above on running rustfmt.
 
 
 ## What style does Rustfmt use?

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -1,0 +1,116 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Inspired by Paul Woolcock's cargo-fmt (https://github.com/pwoolcoc/cargo-fmt/)
+
+#![cfg(not(test))]
+#![cfg(feature="cargo-fmt")]
+
+extern crate getopts;
+extern crate walkdir;
+extern crate rustc_serialize;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::env;
+use std::str;
+
+use getopts::Options;
+use walkdir::{WalkDir, DirEntry};
+use rustc_serialize::json::Json;
+
+fn main() {
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "show this message");
+
+    let matches = match opts.parse(env::args().skip(1)) {
+        Ok(m) => m,
+        Err(e) => {
+            print_usage(&opts, &e.to_string());
+            return;
+        }
+    };
+
+    if matches.opt_present("h") {
+        print_usage(&opts, "");
+    } else {
+        format_crate(&opts);
+    }
+}
+
+fn print_usage(opts: &Options, reason: &str) {
+    let msg = format!("{}\nusage: cargo fmt [options]", reason);
+    println!("{}\nThis utility formats all readable .rs files in the src directory of the \
+              current crate using rustfmt.",
+             opts.usage(&msg));
+}
+
+fn format_crate(opts: &Options) {
+    let mut root = match locate_root() {
+        Ok(r) => r,
+        Err(e) => {
+            print_usage(opts, &e.to_string());
+            return;
+        }
+    };
+
+    // Currently only files in [root]/src can be formatted
+    root.push("src");
+    // All unreadable or non .rs files are skipped
+    let files: Vec<_> = WalkDir::new(root)
+                            .into_iter()
+                            .filter(is_rs_file)
+                            .filter_map(|f| f.ok())
+                            .map(|e| e.path().to_owned())
+                            .collect();
+
+    format_files(&files).unwrap_or_else(|e| print_usage(opts, &e.to_string()));
+}
+
+fn locate_root() -> Result<PathBuf, std::io::Error> {
+    // This seems adequate, as cargo-fmt can only be used systems that have Cargo installed
+    let output = try!(Command::new("cargo").arg("locate-project").output());
+    if output.status.success() {
+        // We assume cargo locate-project is not broken and
+        // it will output a valid json document
+        let data = &String::from_utf8(output.stdout).unwrap();
+        let json = Json::from_str(data).unwrap();
+        let root = PathBuf::from(json.find("root").unwrap().as_string().unwrap());
+
+        // root.parent() should never fail if locate-project's output is correct
+        Ok(root.parent().unwrap().to_owned())
+    } else {
+        // This happens when cargo-fmt is not used inside a crate
+        Err(std::io::Error::new(std::io::ErrorKind::NotFound,
+                                str::from_utf8(&output.stderr).unwrap()))
+    }
+}
+
+fn is_rs_file(entry: &Result<walkdir::DirEntry, walkdir::Error>) -> bool {
+    match *entry {
+        Ok(ref file) => {
+            match file.path().extension() {
+                Some(ext) => ext == "rs",
+                None => false,
+            }
+        }
+        Err(_) => false,
+    }
+}
+
+fn format_files(files: &Vec<PathBuf>) -> Result<(), std::io::Error> {
+    let mut command = try!(Command::new("rustfmt")
+                               .arg("--write-mode=overwrite")
+                               .args(files)
+                               .spawn());
+    try!(command.wait());
+
+    Ok(())
+}


### PR DESCRIPTION
Fix #613 by adding a new utility, which formats all readable `.rs` files in the `src` directory of the crate using `rustfmt` binary. Both binaries can be installed using `cargo install rustfmt`, users that don't need `cargo-fmt` can opt-out by disabling default features. `cargo-fmt` can be used as a Cargo subcommand - `cargo fmt`.

There is a downside to having 2 binaries in a crate: `cargo run` can no longer be used without the `--bin` flag to specify which binary to run.