### PR TITLE
Remove `--write-mode=replace` from cargo-fmt

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -69,11 +69,8 @@ fn format_crate(opts: &Options) {
 }
 
 fn get_fmt_args() -> Vec<String> {
-    let mut args = vec!["--write-mode=replace".to_string()];
     // All arguments after -- are passed to rustfmt
-    args.extend(env::args().skip_while(|a| a != "--").skip(1));
-
-    args
+    env::args().skip_while(|a| a != "--").skip(1).collect()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Since replace is the default rustfmt write mode, there's no need to
call rustfmt with `--write-mode=replace`. As a bonus, it is now also
possible to override the write-mode.