### PR TITLE
Make fn argument formatting more resilient for complex self types

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -12,7 +12,8 @@
 
 use Indent;
 use utils::{format_mutability, format_visibility, contains_skip, span_after, end_typaram,
-            wrap_str, last_line_width, semicolon_for_expr, format_unsafety, trim_newlines};
+            wrap_str, last_line_width, semicolon_for_expr, format_unsafety, trim_newlines,
+            span_after_last};
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic,
             DefinitiveListTactic, definitive_tactic, format_item_list};
 use expr::{is_empty_block, is_simple_block_stmt, rewrite_assign_rhs};
@@ -1260,7 +1261,8 @@ fn rewrite_args(context: &RewriteContext,
     // it is explicit.
     if args.len() >= min_args || variadic {
         let comment_span_start = if min_args == 2 {
-            span_after(span, ",", context.codemap)
+            let reduced_span = mk_sp(span.lo, args[1].ty.span.lo);
+            span_after_last(reduced_span, ",", context.codemap)
         } else {
             span.lo
         };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,6 +39,18 @@ pub fn span_after(original: Span, needle: &str, codemap: &CodeMap) -> BytePos {
 }
 
 #[inline]
+pub fn span_after_last(original: Span, needle: &str, codemap: &CodeMap) -> BytePos {
+    let snippet = codemap.span_to_snippet(original).unwrap();
+    let mut offset = 0;
+
+    while let Some(additional_offset) = snippet[offset..].find_uncommented(needle) {
+        offset += additional_offset + needle.len();
+    }
+
+    original.lo + BytePos(offset as u32)
+}
+
+#[inline]
 pub fn format_visibility(vis: Visibility) -> &'static str {
     match vis {
         Visibility::Public => "pub ",

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -60,3 +60,7 @@ impl Blah {
 }
 
 impl X { fn do_parse(  mut  self : X ) {} }
+
+impl Y5000 {
+    fn bar(self: X< 'a ,  'b >, y: Y) {}
+}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -76,3 +76,7 @@ impl Blah {
 impl X {
     fn do_parse(mut self: X) {}
 }
+
+impl Y5000 {
+    fn bar(self: X<'a, 'b>, y: Y) {}
+}


### PR DESCRIPTION
Closes https://github.com/rust-lang-nursery/rustfmt/issues/724.