### PR TITLE
Add commas after skipped arms when needed

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -898,8 +898,7 @@ impl Rewrite for ast::Arm {
             attr_visitor.last_pos = attrs[0].span.lo;
             if attr_visitor.visit_attrs(attrs) {
                 // Attributes included a skip instruction.
-                let snippet = context.snippet(mk_sp(attrs[0].span.lo, body.span.hi));
-                return Some(snippet);
+                return None;
             }
             attr_visitor.format_missing(pats[0].span.lo);
             attr_visitor.buffer.to_string()

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -100,6 +100,14 @@ fn matches() {
     }
 }
 
+fn match_skip() {
+    let _ = match Some(1) {
+        #[rustfmt_skip]
+        Some( n ) => n,
+        None      => 1,
+    };
+}
+
 fn issue339() {
     match a {
         b => {}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -115,6 +115,14 @@ fn matches() {
     }
 }
 
+fn match_skip() {
+    let _ = match Some(1) {
+        #[rustfmt_skip]
+        Some( n ) => n,
+        None => 1,
+    };
+}
+
 fn issue339() {
     match a {
         b => {}


### PR DESCRIPTION
Fix #737.