### PR TITLE
Format const array as block if remaining width is less than half

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -70,7 +70,8 @@ impl Rewrite for ast::Local {
                                                  result,
                                                  ex,
                                                  budget,
-                                                 context.block_indent));
+                                                 context.block_indent,
+                                                 false));
         }
 
         result.push(';');
@@ -874,7 +875,13 @@ pub fn rewrite_static(prefix: &str,
 
     // 1 = ;
     let remaining_width = context.config.max_width - context.block_indent.width() - 1;
-    rewrite_assign_rhs(context, lhs, expr, remaining_width, context.block_indent).map(|s| s + ";")
+    let result = rewrite_assign_rhs(context,
+                                    lhs,
+                                    expr,
+                                    remaining_width,
+                                    context.block_indent,
+                                    true);
+    result.map(|s| s + ";")
 }
 
 impl Rewrite for ast::FunctionRetTy {

--- a/tests/source/static-block.rs
+++ b/tests/source/static-block.rs
@@ -1,0 +1,10 @@
+const TRAIT_METHODS: [(&'static str, usize, SelfKind, OutType, &'static str); 30] = [("add",
+                                                                                      2,
+                                                                                      ValueSelf,
+                                                                                      AnyType,
+                                                                                      "std::ops::Add"),
+                                                                                     ("sub",
+                                                                                      2,
+                                                                                      ValueSelf,
+                                                                                      AnyType,
+                                                                                      "std::ops::Sub")];

--- a/tests/target/static-block.rs
+++ b/tests/target/static-block.rs
@@ -1,0 +1,4 @@
+const TRAIT_METHODS: [(&'static str, usize, SelfKind, OutType, &'static str); 30] = [
+    ("add", 2, ValueSelf, AnyType, "std::ops::Add"),
+    ("sub", 2, ValueSelf, AnyType, "std::ops::Sub"),
+];


### PR DESCRIPTION
Motivated by poor formatting in Manishearth/rust-clippy#540.