### PR TITLE
If where clause is not on a new line, { should not be on a new line. Fixes #650

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -499,7 +499,13 @@ pub fn format_impl(context: &RewriteContext, item: &ast::Item, offset: Indent) -
             BraceStyle::PreferSameLine => result.push(' '),
             BraceStyle::SameLineWhere => {
                 if !where_clause_str.is_empty() {
-                    result.push('\n')
+                    if where_clause_str.contains('\n') ||
+                       result.len() + where_clause_str.len() + offset.width() >
+                       context.config.max_width {
+                        result.push('\n')
+                    } else {
+                        result.push(' ')
+                    }
                 } else {
                     result.push(' ')
                 }

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -64,3 +64,9 @@ impl X { fn do_parse(  mut  self : X ) {} }
 impl Y5000 {
     fn bar(self: X< 'a ,  'b >, y: Y) {}
 }
+
+pub impl<T> Foo for Bar<T> where X: Foo
+{
+    fn foo() { "hi" }
+}
+

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -80,3 +80,9 @@ impl X {
 impl Y5000 {
     fn bar(self: X<'a, 'b>, y: Y) {}
 }
+
+pub impl<T> Foo for Bar<T> where X: Foo {
+    fn foo() {
+        "hi"
+    }
+}


### PR DESCRIPTION
If `where` is not on a new line, the `{` is not put on a new line, unless the line is too long.