### PR TITLE
Fix for #650

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,7 @@ create_config! {
     newline_style: NewlineStyle, NewlineStyle::Unix, "Unix or Windows line endings";
     fn_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for functions";
     item_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for structs and enums";
+    impl_empty_single_line: bool, true, "Put empty-body implementations on a single line";
     fn_empty_single_line: bool, true, "Put empty-body functions on a single line";
     fn_single_line: bool, false, "Put single-expression functions on a single line";
     fn_return_indent: ReturnIndent, ReturnIndent::WithArgs,

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -22,6 +22,12 @@ impl<'a, 'b, X, Y: Foo<Bar>> Foo<'a, X> for Bar<'b, Y> where X: Fooooooooooooooo
     fn foo() { "hi" }    
 }
 
+impl<T> Foo for Bar<T> where T: Baz 
+{
+}
+
+impl<T> Foo for Bar<T> where T: Baz { /* Comment */ }
+
 impl Foo {
     fn foo() {}
 }
@@ -64,3 +70,10 @@ impl X { fn do_parse(  mut  self : X ) {} }
 impl Y5000 {
     fn bar(self: X< 'a ,  'b >, y: Y) {}
 }
+
+pub impl<T> Foo for Bar<T> where T: Foo
+{
+    fn foo() { "hi" }
+}
+
+pub impl<T, Z> Foo for Bar<T, Z> where T: Foo, Z: Baz {}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -16,7 +16,8 @@ pub impl Foo for Bar {
     // Comment 3
 }
 
-pub unsafe impl<'a, 'b, X, Y: Foo<Bar>> !Foo<'a, X> for Bar<'b, Y> where X: Foo<'a, Z>
+pub unsafe impl<'a, 'b, X, Y: Foo<Bar>> !Foo<'a, X> for Bar<'b, Y>
+    where X: Foo<'a, Z>
 {
     fn foo() {
         "hi"
@@ -31,11 +32,20 @@ impl<'a, 'b, X, Y: Foo<Bar>> Foo<'a, X> for Bar<'b, Y>
     }
 }
 
-impl<'a, 'b, X, Y: Foo<Bar>> Foo<'a, X> for Bar<'b, Y> where X: Foooooooooooooooooooooooooooo<'a, Z>
+impl<'a, 'b, X, Y: Foo<Bar>> Foo<'a, X> for Bar<'b, Y>
+    where X: Foooooooooooooooooooooooooooo<'a, Z>
 {
     fn foo() {
         "hi"
     }
+}
+
+impl<T> Foo for Bar<T> where T: Baz {}
+
+impl<T> Foo for Bar<T>
+    where T: Baz
+{
+    // Comment
 }
 
 impl Foo {
@@ -79,4 +89,18 @@ impl X {
 
 impl Y5000 {
     fn bar(self: X<'a, 'b>, y: Y) {}
+}
+
+pub impl<T> Foo for Bar<T>
+    where T: Foo
+{
+    fn foo() {
+        "hi"
+    }
+}
+
+pub impl<T, Z> Foo for Bar<T, Z>
+    where T: Foo,
+          Z: Baz
+{
 }


### PR DESCRIPTION
If the `where` clause is on the same line as the `impl`, `{` is put on a new line. Fixes issue #650 