### PR TITLE
Fix issue with windows line endings (#717).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,7 @@ pub fn fmt_lines(file_map: &mut FileMap, config: &Config) -> FormatReport {
 
         for (c, b) in text.chars() {
             if c == '\r' {
+                line_len += c.len_utf8();
                 continue;
             }
 
@@ -367,7 +368,7 @@ pub fn fmt_lines(file_map: &mut FileMap, config: &Config) -> FormatReport {
                 last_wspace = None;
             } else {
                 newline_count = 0;
-                line_len += 1;
+                line_len += c.len_utf8();
                 if c.is_whitespace() {
                     if last_wspace.is_none() {
                         last_wspace = Some(b);


### PR DESCRIPTION
The '\r' character wasn't counted in the line length.
I think it's not possible to add regression tests for this due to git behavior with line endings.