### PR TITLE
Add a &mut FormatReport to RewriteContext

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -515,7 +515,7 @@ impl<'a> Iterator for CommentCodeSlices<'a> {
 /// (if it fits in the width/offset, else return None), else return `new`
 pub fn recover_comment_removed(new: String,
                                span: Span,
-                               context: &RewriteContext,
+                               context: &mut RewriteContext,
                                width: usize,
                                offset: Indent)
                                -> Option<String> {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -22,7 +22,11 @@ use syntax::codemap::Span;
 
 impl Rewrite for ast::ViewPath {
     // Returns an empty string when the ViewPath is empty (like foo::bar::{})
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String> {
+    fn rewrite(&self,
+               context: &mut RewriteContext,
+               width: usize,
+               offset: Indent)
+               -> Option<String> {
         match self.node {
             ast::ViewPath_::ViewPathList(_, ref path_list) if path_list.is_empty() => {
                 Some(String::new())
@@ -98,7 +102,7 @@ pub fn rewrite_use_list(width: usize,
                         path: &ast::Path,
                         path_list: &[ast::PathListItem],
                         span: Span,
-                        context: &RewriteContext)
+                        context: &mut RewriteContext)
                         -> Option<String> {
     // 1 = {}
     let budget = try_opt!(width.checked_sub(1));

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -340,9 +340,9 @@ pub struct ListItems<'a, I, F1, F2, F3>
 
 impl<'a, T, I, F1, F2, F3> Iterator for ListItems<'a, I, F1, F2, F3>
     where I: Iterator<Item = T>,
-          F1: Fn(&T) -> BytePos,
-          F2: Fn(&T) -> BytePos,
-          F3: Fn(&T) -> Option<String>
+          F1: FnMut(&T) -> BytePos,
+          F2: FnMut(&T) -> BytePos,
+          F3: FnMut(&T) -> Option<String>
 {
     type Item = ListItem;
 
@@ -462,9 +462,9 @@ pub fn itemize_list<'a, T, I, F1, F2, F3>(codemap: &'a CodeMap,
                                           next_span_start: BytePos)
                                           -> ListItems<'a, I, F1, F2, F3>
     where I: Iterator<Item = T>,
-          F1: Fn(&T) -> BytePos,
-          F2: Fn(&T) -> BytePos,
-          F3: Fn(&T) -> Option<String>
+          F1: FnMut(&T) -> BytePos,
+          F2: FnMut(&T) -> BytePos,
+          F3: FnMut(&T) -> Option<String>
 {
     ListItems {
         codemap: codemap,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,7 +51,7 @@ impl MacroStyle {
 }
 
 pub fn rewrite_macro(mac: &ast::Mac,
-                     context: &RewriteContext,
+                     context: &mut RewriteContext,
                      width: usize,
                      offset: Indent)
                      -> Option<String> {
@@ -124,7 +124,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
     }
 }
 
-fn macro_style(mac: &ast::Mac, context: &RewriteContext) -> MacroStyle {
+fn macro_style(mac: &ast::Mac, context: &mut RewriteContext) -> MacroStyle {
     let snippet = context.snippet(mac.span);
     let paren_pos = snippet.find_uncommented("(").unwrap_or(usize::max_value());
     let bracket_pos = snippet.find_uncommented("[").unwrap_or(usize::max_value());

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -19,7 +19,11 @@ use syntax::ast::{BindingMode, Pat, Pat_};
 
 // FIXME(#18): implement pattern formatting.
 impl Rewrite for Pat {
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String> {
+    fn rewrite(&self,
+               context: &mut RewriteContext,
+               width: usize,
+               offset: Indent)
+               -> Option<String> {
         match self.node {
             Pat_::PatBox(ref pat) => rewrite_unary_prefix(context, "box ", &**pat, width, offset),
             Pat_::PatIdent(binding_mode, ident, None) => {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -13,7 +13,7 @@
 use syntax::codemap::{CodeMap, Span};
 use syntax::parse::ParseSess;
 
-use Indent;
+use {FormatReport, Indent};
 use config::Config;
 
 pub trait Rewrite {
@@ -24,7 +24,11 @@ pub trait Rewrite {
     /// `width` is the maximum number of characters on the last line
     /// (excluding offset). The width of other lines is not limited by
     /// `width`.
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String>;
+    fn rewrite(&self,
+               context: &mut RewriteContext,
+               width: usize,
+               offset: Indent)
+               -> Option<String>;
 }
 
 pub struct RewriteContext<'a> {
@@ -33,15 +37,17 @@ pub struct RewriteContext<'a> {
     pub config: &'a Config,
     // Indentation due to nesting of blocks.
     pub block_indent: Indent,
+    pub format_report: &'a mut FormatReport,
 }
 
 impl<'a> RewriteContext<'a> {
-    pub fn nested_context(&self) -> RewriteContext<'a> {
+    pub fn nested_context<'b>(&'b mut self) -> RewriteContext<'b> {
         RewriteContext {
             parse_session: self.parse_session,
             codemap: self.codemap,
             config: self.config,
             block_indent: self.block_indent.block_indent(self.config),
+            format_report: self.format_report,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -288,7 +288,11 @@ pub fn wrap_str<S: AsRef<str>>(s: S, max_width: usize, width: usize, offset: Ind
 }
 
 impl Rewrite for String {
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String> {
+    fn rewrite(&self,
+               context: &mut RewriteContext,
+               width: usize,
+               offset: Indent)
+               -> Option<String> {
         wrap_str(self, context.config.max_width, width, offset).map(ToOwned::to_owned)
     }
 }
@@ -298,8 +302,8 @@ impl Rewrite for String {
 // The callback takes an integer and returns either an Ok, or an Err indicating
 // whether the `guess' was too high (Ordering::Less), or too low.
 // This function is guaranteed to try to the hi value first.
-pub fn binary_search<C, T>(mut lo: usize, mut hi: usize, callback: C) -> Option<T>
-    where C: Fn(usize) -> Result<T, Ordering>
+pub fn binary_search<C, T>(mut lo: usize, mut hi: usize, mut callback: C) -> Option<T>
+    where C: FnMut(usize) -> Result<T, Ordering>
 {
     let mut middle = hi;
 


### PR DESCRIPTION
This forces all `&RewriteContext` to become `&mut RewriteContext`, which make a lot of small changes.
The goal is to be able to signal warnings as discussed in #756.
I send already this to not suffer a merge hell if I take some time to implement all warnings.