### PR TITLE
Where clause is on same line as fn if fn is empty Fixes #760

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -182,8 +182,8 @@ impl<'a> FmtVisitor<'a> {
         let context = self.get_context();
 
         let block_snippet = self.snippet(codemap::mk_sp(block.span.lo, block.span.hi));
-        let is_block_empty = block_snippet[1..block_snippet.len() - 1].trim().is_empty() &&
-                             context.config.fn_empty_single_line;
+        let has_body = !block_snippet[1..block_snippet.len() - 1].trim().is_empty() ||
+                       !context.config.fn_empty_single_line;
 
         let (mut result, force_newline_brace) = try_opt!(rewrite_fn_base(&context,
                                                                          indent,
@@ -197,7 +197,7 @@ impl<'a> FmtVisitor<'a> {
                                                                          vis,
                                                                          span,
                                                                          newline_brace,
-                                                                         !is_block_empty));
+                                                                         has_body));
 
         if self.config.fn_brace_style != BraceStyle::AlwaysNextLine && !result.contains('\n') {
             newline_brace = false;

--- a/src/items.rs
+++ b/src/items.rs
@@ -21,6 +21,7 @@ use comment::{FindUncommented, contains_comment};
 use visitor::FmtVisitor;
 use rewrite::{Rewrite, RewriteContext};
 use config::{Config, BlockIndentStyle, Density, ReturnIndent, BraceStyle, StructLitStyle};
+use syntax::codemap;
 
 use syntax::{ast, abi};
 use syntax::codemap::{Span, BytePos, mk_sp};
@@ -180,6 +181,10 @@ impl<'a> FmtVisitor<'a> {
         let mut newline_brace = newline_for_brace(self.config, &generics.where_clause);
         let context = self.get_context();
 
+        let block_snippet = self.snippet(codemap::mk_sp(block.span.lo, block.span.hi));
+        let is_block_empty = block_snippet[1..block_snippet.len() - 1].trim().is_empty() &&
+                             context.config.fn_empty_single_line;
+
         let (mut result, force_newline_brace) = try_opt!(rewrite_fn_base(&context,
                                                                          indent,
                                                                          ident,
@@ -192,7 +197,7 @@ impl<'a> FmtVisitor<'a> {
                                                                          vis,
                                                                          span,
                                                                          newline_brace,
-                                                                         true));
+                                                                         !is_block_empty));
 
         if self.config.fn_brace_style != BraceStyle::AlwaysNextLine && !result.contains('\n') {
             newline_brace = false;
@@ -1196,7 +1201,7 @@ fn rewrite_fn_base(context: &RewriteContext,
                            (context.config.fn_args_layout == StructLitStyle::Block &&
                             ret_str.is_empty()) ||
                            (context.config.where_density == Density::CompressedIfEmpty &&
-                            !has_body) {
+                            !has_body && !result.contains('\n')) {
         Density::Compressed
     } else {
         Density::Tall
@@ -1213,6 +1218,12 @@ fn rewrite_fn_base(context: &RewriteContext,
                                                          where_density,
                                                          "{",
                                                          Some(span.hi)));
+
+    if last_line_width(&result) + where_clause_str.len() > context.config.max_width &&
+       !where_clause_str.contains('\n') {
+        result.push('\n');
+    }
+
     result.push_str(&where_clause_str);
 
     Some((result, force_new_line_for_brace))

--- a/tests/source/fn-single-line.rs
+++ b/tests/source/fn-single-line.rs
@@ -74,3 +74,6 @@ trait CoolTypes {
 trait CoolerTypes { fn dummy(&self) { 
 }
 }
+
+fn Foo<T>() where T: Bar {
+}

--- a/tests/target/fn-single-line.rs
+++ b/tests/target/fn-single-line.rs
@@ -61,3 +61,5 @@ trait CoolTypes {
 trait CoolerTypes {
     fn dummy(&self) {}
 }
+
+fn Foo<T>() where T: Bar {}

--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -2,17 +2,9 @@
 
 fn foo(a: AAAA, b: BBB, c: CCC) -> RetType {}
 
-fn foo(a: AAAA, b: BBB /* some, weird, inline comment */, c: CCC) -> RetType
-    where T: Blah
-{
+fn foo(a: AAAA, b: BBB /* some, weird, inline comment */, c: CCC) -> RetType where T: Blah {}
 
-}
-
-fn foo(a: AAA /* (comment) */)
-    where T: Blah
-{
-
-}
+fn foo(a: AAA /* (comment) */) where T: Blah {}
 
 fn foo(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
        b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
@@ -35,10 +27,7 @@ fn foo<U, T>(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
 fn foo<U: Fn(A) -> B /* paren inside generics */>() {}
 
 impl Foo {
-    fn with_no_errors<T, F>(&mut self, f: F) -> T
-        where F: FnOnce(&mut Resolver) -> T
-    {
-    }
+    fn with_no_errors<T, F>(&mut self, f: F) -> T where F: FnOnce(&mut Resolver) -> T {}
 
     fn foo(mut self, mut bar: u32) {}
 


### PR DESCRIPTION
If `fn_empty_single_line` is true, and a function's body is empty, its where clause is put on the same line as the `fn`.

ex:
```
+ fn Foo<T>() where T: Bar {}
- fn Foo<T>() 
-     where T: Bar 
- {
- }
```