### PR TITLE
Added option for tighter punctuation in types. fixes #489

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,13 @@ configuration_option_enum! { Density:
     CompressedIfEmpty,
 }
 
+configuration_option_enum! { TypeDensity:
+    // No spaces around "=" and "+"
+    Compressed,
+    // Spaces around " = " and " + "
+    WhiteSpace,
+}
+
 impl Density {
     pub fn to_list_tactic(self) -> ListTactic {
         match self {
@@ -278,6 +285,8 @@ create_config! {
     fn_args_density: Density, Density::Tall, "Argument density in functions";
     fn_args_layout: StructLitStyle, StructLitStyle::Visual, "Layout of function arguments";
     fn_arg_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indent on function arguments";
+    type_punctuation_density: TypeDensity, TypeDensity::WhiteSpace,
+        "Determines if '+' or '=' are wrapped in spaces in the punctuation of types";
     // Should we at least try to put the where clause on the same line as the rest of the
     // function decl?
     where_density: Density, Density::CompressedIfEmpty, "Density of a where clause";

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ configuration_option_enum! { TypeDensity:
     // No spaces around "=" and "+"
     Compressed,
     // Spaces around " = " and " + "
-    WhiteSpace,
+    Wide,
 }
 
 impl Density {
@@ -285,7 +285,7 @@ create_config! {
     fn_args_density: Density, Density::Tall, "Argument density in functions";
     fn_args_layout: StructLitStyle, StructLitStyle::Visual, "Layout of function arguments";
     fn_arg_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indent on function arguments";
-    type_punctuation_density: TypeDensity, TypeDensity::WhiteSpace,
+    type_punctuation_density: TypeDensity, TypeDensity::Wide,
         "Determines if '+' or '=' are wrapped in spaces in the punctuation of types";
     // Should we at least try to put the where clause on the same line as the rest of the
     // function decl?

--- a/src/types.rs
+++ b/src/types.rs
@@ -425,10 +425,10 @@ impl Rewrite for ast::TyParam {
             result.push_str(&bounds);
         }
         if let Some(ref def) = self.default {
-            let eq_str = if context.config.type_punctuation_density == TypeDensity::Compressed {
-                "="
-            } else {
-                " = "
+
+            let eq_str = match context.config.type_punctuation_density {
+                TypeDensity::Compressed => "=",
+                TypeDensity::Wide => " = ",
             };
             result.push_str(eq_str);
             let budget = try_opt!(width.checked_sub(result.len()));
@@ -473,11 +473,9 @@ impl Rewrite for ast::Ty {
             ast::TyObjectSum(ref ty, ref bounds) => {
                 let ty_str = try_opt!(ty.rewrite(context, width, offset));
                 let overhead = ty_str.len() + 3;
-                let plus_str = if context.config.type_punctuation_density ==
-                                  TypeDensity::Compressed {
-                    "+"
-                } else {
-                    " + "
+                let plus_str = match context.config.type_punctuation_density {
+                    TypeDensity::Compressed => "+",
+                    TypeDensity::Wide => " + ",
                 };
                 Some(format!("{}{}{}",
                              ty_str,

--- a/tests/source/type-punctuation.rs
+++ b/tests/source/type-punctuation.rs
@@ -1,0 +1,5 @@
+// rustfmt-type_punctuation_density: Compressed
+
+fn Foo<T = Foo, Output = Expr<'tcx> + Foo>() {
+    let i = 6;
+}

--- a/tests/target/type-punctuation.rs
+++ b/tests/target/type-punctuation.rs
@@ -1,0 +1,5 @@
+// rustfmt-type_punctuation_density: Compressed
+
+fn Foo<T=Foo, Output=Expr<'tcx>+Foo>() {
+    let i = 6;
+}


### PR DESCRIPTION
Added config option type_punctuation_density that can be set to `TypeDensity::Compressed` or `TypeDensity::WhiteSpace`.
Default option is `WhiteSpace`, if `Compressed` is enabled it will format as follows:
```
- fn Foo<T = Foo, Output = Expr<'tcx> + Foo>() {
+ fn Foo<T=Foo, Output=Expr<'tcx>+Foo>() {
...
```