### PR TITLE
Allow for setting of write-mode via config file. FIxes #215

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -17,8 +17,8 @@ extern crate toml;
 extern crate env_logger;
 extern crate getopts;
 
-use rustfmt::{WriteMode, run, run_from_stdin};
-use rustfmt::config::Config;
+use rustfmt::{run, run_from_stdin};
+use rustfmt::config::{Config, WriteMode};
 
 use std::env;
 use std::fs::{self, File};
@@ -216,7 +216,7 @@ fn determine_operation(matches: &Matches) -> Operation {
                 Err(..) => return Operation::InvalidInput("Unrecognized write mode".into()),
             }
         }
-        None => WriteMode::Replace,
+        None => WriteMode::Default,
     };
 
     let files: Vec<_> = matches.free.iter().map(PathBuf::from).collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,24 @@ configuration_option_enum! { ReportTactic:
     Never,
 }
 
+configuration_option_enum! { WriteMode:
+    // Used internally to represent when no option is given
+    // Treated as Replace.
+    Default,
+    // Backsup the original file and overwrites the orignal.
+    Replace,
+    // Overwrites original file without backup.
+    Overwrite,
+    // Write the output to stdout.
+    Display,
+    // Write the diff to stdout.
+    Diff,
+    // Display how much of the input file was processed
+    Coverage,
+    // Unfancy stdout
+    Plain,
+}
+
 // This trait and the following impl blocks are there so that we an use
 // UCFS inside the get_docs() function on types for configs.
 pub trait ConfigType {
@@ -323,4 +341,6 @@ create_config! {
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
     match_wildcard_trailing_comma: bool, true, "Put a trailing comma after a wildcard arm";
+    write_mode: WriteMode, WriteMode::Default,
+        "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";
 }

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use WriteMode;
+use config::WriteMode;
 use visitor::FmtVisitor;
 use syntax::codemap::{self, BytePos, Span, Pos};
 use comment::{CodeCharKind, CommentCodeSlices, rewrite_comment};

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -15,9 +15,9 @@ use syntax::visit;
 
 use strings::string_buffer::StringBuffer;
 
-use {Indent, WriteMode};
+use Indent;
 use utils;
-use config::Config;
+use config::{Config, WriteMode};
 use rewrite::{Rewrite, RewriteContext};
 use comment::rewrite_comment;
 use macros::rewrite_macro;


### PR DESCRIPTION
Also from @marcusklaas:
> Refactor code output functions          
> Specifically, `write_all_files` no longer returns a HashMap. It would sometimes
> contain items, and sometimes be empty. When "fixed" newlines are required, this
> must now be done with a separate call. The tests use this strategy and should now pass!

I did not know how to mantain his PR commit and do the clean rebase at the same time...

Refer to #764, and #735 for more information.