### PR TITLE
Fix an off-by-one error due to the comma in a struct lit field

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -663,7 +663,7 @@ fn format_struct_struct(context: &RewriteContext,
     }
 
     let item_indent = offset.block_indent(context.config);
-    // 2 = ","
+    // 1 = ","
     let item_budget = try_opt!(context.config.max_width.checked_sub(item_indent.width() + 1));
 
     let items = itemize_list(context.codemap,

--- a/tests/source/struct_lits.rs
+++ b/tests/source/struct_lits.rs
@@ -114,3 +114,12 @@ fn issue491() {
     Foo { a: aaaaaaaaaa, b: bbbbbbbb, c: cccccccccc, d: dddddddddd, /* a comment */
       e: eeeeeeeee };
 }
+
+fn issue698() {
+    Record {
+        ffffffffffffffffffffffffffields: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    };
+    Record {
+        ffffffffffffffffffffffffffields: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    }
+}

--- a/tests/target/struct_lits.rs
+++ b/tests/target/struct_lits.rs
@@ -149,3 +149,13 @@ fn issue491() {
         e: eeeeeeeee,
     };
 }
+
+fn issue698() {
+    Record {
+        ffffffffffffffffffffffffffields: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    };
+    Record {
+        ffffffffffffffffffffffffffields:
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    }
+}


### PR DESCRIPTION
Also allows splitting the field expression on a new line after the field name.

Fixes #698 

r? @marcusklaas 