### PR TITLE
Format item macros

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -253,13 +253,9 @@ impl<'a> FmtVisitor<'a> {
                 self.format_missing_with_indent(item.span.lo);
                 self.format_mod(module, item.vis, item.span, item.ident);
             }
-            ast::Item_::ItemMac(..) => {
+            ast::Item_::ItemMac(ref mac) => {
                 self.format_missing_with_indent(item.span.lo);
-                let snippet = self.snippet(item.span);
-                self.buffer.push_str(&snippet);
-                self.last_pos = item.span.hi;
-                // FIXME: we cannot format these yet, because of a bad span.
-                // See rust lang issue #28424.
+                self.visit_mac(mac);
             }
             ast::Item_::ItemForeignMod(ref foreign_mod) => {
                 self.format_missing_with_indent(item.span.lo);

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -1,5 +1,9 @@
 itemmacro!(this, is.now() .formatted(yay));
 
+itemmacro!(really, long.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb() .is.formatted());
+
+itemmacro!{this, is.bracket().formatted()}
+
 fn main() {
     foo! ( );
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -1,4 +1,4 @@
-itemmacro!(this, is.not() .formatted(yet));
+itemmacro!(this, is.now() .formatted(yay));
 
 fn main() {
     foo! ( );

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -1,4 +1,4 @@
-itemmacro!(this, is.not() .formatted(yet));
+itemmacro!(this, is.now().formatted(yay));
 
 fn main() {
     foo!();

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -1,5 +1,12 @@
 itemmacro!(this, is.now().formatted(yay));
 
+itemmacro!(really,
+           long.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb()
+               .is
+               .formatted());
+
+itemmacro!{this, is.bracket().formatted()}
+
 fn main() {
     foo!();
 


### PR DESCRIPTION
With macro spans fixed in Rust 1.6, we can now format ItemMac properly. Part of #438.