### PR TITLE
Fix for #784 edge case in comment handling

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -147,11 +147,11 @@ impl<'a> FmtVisitor<'a> {
                     if let Some('/') = subslice.chars().skip(1).next() {
                         // Add a newline after line comments
                         self.buffer.push_str("\n");
-                    } else if line_start < snippet.len() {
+                    } else if line_start <= snippet.len() {
                         // For other comments add a newline if there isn't one at the end already
-                        let c = snippet[line_start..].chars().next().unwrap();
-                        if c != '\n' && c != '\r' {
-                            self.buffer.push_str("\n");
+                        match snippet[line_start..].chars().next() {
+                            Some('\n') | Some('\r') => (),
+                            _ => self.buffer.push_str("\n"),
                         }
                     }
 

--- a/tests/source/comment.rs
+++ b/tests/source/comment.rs
@@ -45,3 +45,5 @@ fn chains() {
 
 /*
  * random comment */
+
+fn main() {/* Test */}

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -46,3 +46,7 @@ fn chains() {
 }
 
 // random comment
+
+fn main() {
+    // Test
+}


### PR DESCRIPTION
The case where `line_start == snippet.len()` wasn't handled so we had a missing newline.
Since we can't get the next char after `line_start` in this case I handle the `None` implicitly with the match. 