### PR TITLE
Don't reformat strings if we don't have to.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -334,7 +334,8 @@ create_config! {
     chain_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indentation of chain";
     reorder_imports: bool, false, "Reorder import statements alphabetically";
     single_line_if_else: bool, false, "Put else on same line as closing brace for if statements";
-    format_strings: bool, true, "Format string literals, or leave as is";
+    format_strings: bool, true, "Format string literals where necessary";
+    force_format_strings: bool, false, "Always format string literals";
     chains_overflow_last: bool, true, "Allow last call in method chain to break the line";
     take_source_hints: bool, true, "Retain some formatting characteristics from the source code";
     hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";

--- a/tests/source/string-lit-2.rs
+++ b/tests/source/string-lit-2.rs
@@ -1,0 +1,14 @@
+fn main() -> &'static str {
+    let too_many_lines = "H\
+                          e\
+                          l\
+                          l\
+                          o";
+    let leave_me = "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\
+                    s
+                    jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj";
+    // Crappy formatting :-(
+    let change_me = "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\
+                     s
+                     jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj";
+}

--- a/tests/source/string-lit.rs
+++ b/tests/source/string-lit.rs
@@ -1,3 +1,4 @@
+// rustfmt-force_format_strings: true
 // Long string literals
 
 fn main() -> &'static str {

--- a/tests/target/string-lit-2.rs
+++ b/tests/target/string-lit-2.rs
@@ -1,0 +1,15 @@
+fn main() -> &'static str {
+    let too_many_lines = "H\
+                          e\
+                          l\
+                          l\
+                          o";
+    let leave_me = "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\
+                    s
+                    jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj";
+    // Crappy formatting :-(
+    let change_me = "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+                     \
+                     jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj\
+                     j";
+}

--- a/tests/target/string-lit.rs
+++ b/tests/target/string-lit.rs
@@ -1,3 +1,4 @@
+// rustfmt-force_format_strings: true
 // Long string literals
 
 fn main() -> &'static str {


### PR DESCRIPTION
Specifically if no line exceeds the allowed width and we aren't moving the string to a new offset

r? @marcusklaas 