### PR TITLE
bin: Properly handle a directories named rustfmt.toml

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -57,8 +57,11 @@ fn lookup_project_file(input_file: &Path) -> io::Result<PathBuf> {
 
     loop {
         let config_file = current.join("rustfmt.toml");
-        if fs::metadata(&config_file).is_ok() {
-            return Ok(config_file);
+        if let Ok(md) = fs::metadata(&config_file) {
+            // Properly handle unlikely situation of a directory named `rustfmt.toml`.
+            if md.is_file() {
+                return Ok(config_file);
+            }
         }
 
         // If the current directory has no parent, we're done searching.


### PR DESCRIPTION
`lookup_project_file` could erroneously find a *directory* named
`rustmfmt.toml` if there was one in its lookup path, and so ignore any
configuration file it should have found further up. The error handling
resulted in this silently using the default configuration.