### PR TITLE
gitignore .rs.bk files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+**/*.rs.bk
 /target/


### PR DESCRIPTION
These clutter up `git status` output when working on rustfmt.