### PR TITLE
Correct command that lists config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ notes above on running rustfmt.
 
 Rustfmt is designed to be very configurable. You can create a TOML file called
 rustfmt.toml, place it in the project directory and it will apply the options
-in that file. See `cargo run -- --config-help` for the options which are available,
+in that file. See `rustfmt --config-help` for the options which are available,
 or if you prefer to see source code, [src/config.rs](src/config.rs).
 
 By default, Rustfmt uses a style which (mostly) conforms to the


### PR DESCRIPTION
`cargo run -- --config-help` Simply runs a project without printing the config options.
`rustfmt --config-help` actually prints the config files.