### PR TITLE
utils: Add CodeMapExt extension trait for span_* methods

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -11,7 +11,7 @@
 use Indent;
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, definitive_tactic};
 use types::rewrite_path;
-use utils::span_after;
+use utils::CodeMapSpanUtils;
 use rewrite::{Rewrite, RewriteContext};
 
 use syntax::ast;
@@ -130,7 +130,7 @@ pub fn rewrite_use_list(width: usize,
                                 |vpi| vpi.span.lo,
                                 |vpi| vpi.span.hi,
                                 rewrite_path_item,
-                                span_after(span, "{", context.codemap),
+                                context.codemap.span_after(span, "{"),
                                 span.hi);
         items.extend(iter);
         items

--- a/src/items.rs
+++ b/src/items.rs
@@ -11,9 +11,8 @@
 // Formatting top-level items - functions, structs, enums, traits, impls.
 
 use Indent;
-use utils::{format_mutability, format_visibility, contains_skip, span_after, end_typaram,
-            wrap_str, last_line_width, semicolon_for_expr, format_unsafety, trim_newlines,
-            span_after_last};
+use utils::{CodeMapSpanUtils, format_mutability, format_visibility, contains_skip, end_typaram,
+            wrap_str, last_line_width, semicolon_for_expr, format_unsafety, trim_newlines};
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic,
             DefinitiveListTactic, definitive_tactic, format_item_list};
 use expr::{is_empty_block, is_simple_block_stmt, rewrite_assign_rhs};
@@ -452,7 +451,7 @@ pub fn format_impl(context: &RewriteContext, item: &ast::Item, offset: Indent) -
         result.push_str(format_unsafety(unsafety));
         result.push_str("impl");
 
-        let lo = span_after(item.span, "impl", context.codemap);
+        let lo = context.codemap.span_after(item.span, "impl");
         let hi = match *trait_ref {
             Some(ref tr) => tr.path.span.lo,
             None => self_ty.span.lo,
@@ -633,7 +632,7 @@ fn format_struct_struct(context: &RewriteContext,
     let header_str = format_header(item_name, ident, vis);
     result.push_str(&header_str);
 
-    let body_lo = span_after(span, "{", context.codemap);
+    let body_lo = context.codemap.span_after(span, "{");
 
     let generics_str = match generics {
         Some(g) => {
@@ -680,7 +679,7 @@ fn format_struct_struct(context: &RewriteContext,
                              },
                              |field| field.node.ty.span.hi,
                              |field| field.rewrite(context, item_budget, item_indent),
-                             span_after(span, "{", context.codemap),
+                             context.codemap.span_after(span, "{"),
                              span.hi);
     // 1 = ,
     let budget = context.config.max_width - offset.width() + context.config.tab_spaces - 1;
@@ -762,7 +761,7 @@ fn format_tuple_struct(context: &RewriteContext,
                              },
                              |field| field.node.ty.span.hi,
                              |field| field.rewrite(context, item_budget, item_indent),
-                             span_after(span, "(", context.codemap),
+                             context.codemap.span_after(span, "("),
                              span.hi);
     let body = try_opt!(format_item_list(items, item_budget, item_indent, context.config));
     result.push_str(&body);
@@ -798,7 +797,7 @@ pub fn rewrite_type_alias(context: &RewriteContext,
     result.push_str(&ident.to_string());
 
     let generics_indent = indent + result.len();
-    let generics_span = mk_sp(span_after(span, "type", context.codemap), ty.span.lo);
+    let generics_span = mk_sp(context.codemap.span_after(span, "type"), ty.span.lo);
     let generics_width = context.config.max_width - " =".len();
     let generics_str = try_opt!(rewrite_generics(context,
                                                  generics,
@@ -1152,7 +1151,7 @@ fn rewrite_fn_base(context: &RewriteContext,
     let args_start = generics.ty_params
                              .last()
                              .map_or(span.lo, |tp| end_typaram(tp));
-    let args_span = mk_sp(span_after(mk_sp(args_start, span.hi), "(", context.codemap),
+    let args_span = mk_sp(context.codemap.span_after(mk_sp(args_start, span.hi), "("),
                           span_for_return(&fd.output).lo);
     let arg_str = try_opt!(rewrite_args(context,
                                         &fd.inputs,
@@ -1304,7 +1303,7 @@ fn rewrite_args(context: &RewriteContext,
     if args.len() >= min_args || variadic {
         let comment_span_start = if min_args == 2 {
             let reduced_span = mk_sp(span.lo, args[1].ty.span.lo);
-            span_after_last(reduced_span, ",", context.codemap)
+            context.codemap.span_after_last(reduced_span, ",")
         } else {
             span.lo
         };
@@ -1316,7 +1315,7 @@ fn rewrite_args(context: &RewriteContext,
 
         let variadic_arg = if variadic {
             let variadic_span = mk_sp(args.last().unwrap().ty.span.hi, span.hi);
-            let variadic_start = span_after(variadic_span, "...", context.codemap) - BytePos(3);
+            let variadic_start = context.codemap.span_after(variadic_span, "...") - BytePos(3);
             Some(ArgumentKind::Variadic(variadic_start))
         } else {
             None
@@ -1476,7 +1475,7 @@ fn rewrite_generics(context: &RewriteContext,
                              |&(sp, _)| sp.hi,
                              // FIXME: don't clone
                              |&(_, ref str)| str.clone(),
-                             span_after(span, "<", context.codemap),
+                             context.codemap.span_after(span, "<"),
                              span.hi);
     let list_str = try_opt!(format_item_list(items, h_budget, offset, context.config));
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,7 +28,7 @@ use Indent;
 use rewrite::RewriteContext;
 use expr::{rewrite_call, rewrite_array};
 use comment::FindUncommented;
-use utils::{wrap_str, span_after};
+use utils::{CodeMapSpanUtils, wrap_str};
 
 const FORCED_BRACKET_MACROS: &'static [&'static str] = &["vec!"];
 
@@ -104,9 +104,8 @@ pub fn rewrite_macro(mac: &ast::Mac,
             // Format macro invocation as array literal.
             let extra_offset = macro_name.len();
             let rewrite = try_opt!(rewrite_array(expr_vec.iter().map(|x| &**x),
-                                                 mk_sp(span_after(mac.span,
-                                                                  original_style.opener(),
-                                                                  context.codemap),
+                                                 mk_sp(context.codemap.span_after(mac.span,
+                                                                  original_style.opener()),
                                                        mac.span.hi - BytePos(1)),
                                                  context,
                                                  try_opt!(width.checked_sub(extra_offset)),

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -10,7 +10,7 @@
 
 use Indent;
 use rewrite::{Rewrite, RewriteContext};
-use utils::{wrap_str, format_mutability, span_after};
+use utils::{CodeMapSpanUtils, wrap_str, format_mutability};
 use lists::{format_item_list, itemize_list};
 use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple};
 use types::rewrite_path;
@@ -84,7 +84,7 @@ impl Rewrite for Pat {
                                                      |item| item.span.lo,
                                                      |item| item.span.hi,
                                                      |item| item.rewrite(context, width, offset),
-                                                     span_after(self.span, "(", context.codemap),
+                                                     context.codemap.span_after(self.span, "("),
                                                      self.span.hi);
                             Some(format!("{}({})",
                                          path_str,
@@ -141,7 +141,7 @@ impl Rewrite for Pat {
                                          |f| f.span.lo,
                                          |f| f.span.hi,
                                          |f| f.node.rewrite(context, budget, offset),
-                                         span_after(self.span, "{", context.codemap),
+                                         context.codemap.span_after(self.span, "{"),
                                          self.span.hi);
                 let mut field_string = try_opt!(format_item_list(items,
                                                                  budget,

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ use syntax::abi;
 use {Indent, Spanned};
 use lists::{format_item_list, itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
-use utils::{extra_offset, span_after, format_mutability, wrap_str};
+use utils::{CodeMapSpanUtils, extra_offset, format_mutability, wrap_str};
 use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple};
 use config::TypeDensity;
 
@@ -183,7 +183,7 @@ fn rewrite_segment(expr_context: bool,
                                  .collect::<Vec<_>>();
 
             let next_span_lo = param_list.last().unwrap().get_span().hi + BytePos(1);
-            let list_lo = span_after(codemap::mk_sp(*span_lo, span_hi), "<", context.codemap);
+            let list_lo = context.codemap.span_after(codemap::mk_sp(*span_lo, span_hi), "<");
             let separator = if expr_context {
                 "::"
             } else {
@@ -246,7 +246,7 @@ fn format_function_type<'a, I>(inputs: I,
     let budget = try_opt!(width.checked_sub(2));
     // 1 for (
     let offset = offset + 1;
-    let list_lo = span_after(span, "(", context.codemap);
+    let list_lo = context.codemap.span_after(span, "(");
     let items = itemize_list(context.codemap,
                              inputs,
                              ")",

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -16,7 +16,7 @@ use syntax::visit;
 use strings::string_buffer::StringBuffer;
 
 use Indent;
-use utils;
+use utils::{self, CodeMapSpanUtils};
 use config::Config;
 use rewrite::{Rewrite, RewriteContext};
 use comment::rewrite_comment;
@@ -450,7 +450,7 @@ impl<'a> FmtVisitor<'a> {
         if is_internal {
             self.buffer.push_str(" {");
             // Hackery to account for the closing }.
-            let mod_lo = ::utils::span_after(s, "{", self.codemap);
+            let mod_lo = self.codemap.span_after(s, "{");
             let body_snippet = self.snippet(codemap::mk_sp(mod_lo, m.inner.hi - BytePos(1)));
             let body_snippet = body_snippet.trim();
             if body_snippet.is_empty() {


### PR DESCRIPTION
This commit adds a CodeMapExt extension trait on CodeMap, and moves some
functions to methods there:
  - span_after
  - span_after_last
  - span_before

This better reflects them being lookup methods on the codemap.