### PR TITLE
Fix issues with empty macros with curly braces

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,7 +27,7 @@ use syntax::codemap::{mk_sp, BytePos};
 use Indent;
 use rewrite::RewriteContext;
 use expr::{rewrite_call, rewrite_array};
-use comment::FindUncommented;
+use comment::{FindUncommented, contains_comment};
 use utils::{CodeMapSpanUtils, wrap_str};
 
 const FORCED_BRACKET_MACROS: &'static [&'static str] = &["vec!"];
@@ -63,11 +63,11 @@ pub fn rewrite_macro(mac: &ast::Mac,
         original_style
     };
 
-    if mac.node.tts.is_empty() {
-        return if let MacroStyle::Parens = style {
-            Some(format!("{}()", macro_name))
-        } else {
-            Some(format!("{}[]", macro_name))
+    if mac.node.tts.is_empty() && !contains_comment(&context.snippet(mac.span)) {
+        return match style {
+            MacroStyle::Parens => Some(format!("{}()", macro_name)),
+            MacroStyle::Brackets => Some(format!("{}[]", macro_name)),
+            MacroStyle::Braces => Some(format!("{}{{}}", macro_name)),
         };
     }
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -33,4 +33,23 @@ fn main() {
     macrowithbraces! {dont,    format, me}
 
     x!(fn);
+
+    some_macro!(
+        
+    );
+
+    some_macro![
+    ];
+
+    some_macro!{
+        // comment
+    };
+
+    some_macro!{
+        // comment
+    };
+}
+
+impl X {
+    empty_invoc!{}
 }

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -39,4 +39,20 @@ fn main() {
     macrowithbraces! {dont,    format, me}
 
     x!(fn);
+
+    some_macro!();
+
+    some_macro![];
+
+    some_macro!{
+        // comment
+    };
+
+    some_macro!{
+        // comment
+    };
+}
+
+impl X {
+    empty_invoc!{}
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rustfmt/issues/839 and https://github.com/rust-lang-nursery/rustfmt/issues/536.

Empty macro invocations with comments and parens or brackets, e.g. `test!(/*comment*/)`, won't compile any longer for some reason.
