### PR TITLE
Properly format macro's with an extra ident

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -154,7 +154,7 @@ impl Rewrite for ast::Expr {
             ast::ExprKind::Mac(ref mac) => {
                 // Failure to rewrite a marco should not imply failure to
                 // rewrite the expression.
-                rewrite_macro(mac, context, width, offset).or_else(|| {
+                rewrite_macro(mac, None, context, width, offset).or_else(|| {
                     wrap_str(context.snippet(self.span),
                              context.config.max_width,
                              width,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,12 +51,16 @@ impl MacroStyle {
 }
 
 pub fn rewrite_macro(mac: &ast::Mac,
+                     extra_ident: Option<ast::Ident>,
                      context: &RewriteContext,
                      width: usize,
                      offset: Indent)
                      -> Option<String> {
     let original_style = macro_style(mac, context);
-    let macro_name = format!("{}!", mac.node.path);
+    let macro_name = match extra_ident {
+        None | Some(ast::Ident { name: ast::Name(0), .. }) => format!("{}!", mac.node.path),
+        Some(ident) => format!("{}! {}", mac.node.path, ident),
+    };
     let style = if FORCED_BRACKET_MACROS.contains(&&macro_name[..]) {
         MacroStyle::Brackets
     } else {

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -4,6 +4,8 @@ itemmacro!(really, long.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 itemmacro!{this, is.bracket().formatted()}
 
+peg_file!   modname  ("mygrammarfile.rustpeg");
+
 fn main() {
     foo! ( );
 

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -7,6 +7,8 @@ itemmacro!(really,
 
 itemmacro!{this, is.bracket().formatted()}
 
+peg_file! modname("mygrammarfile.rustpeg");
+
 fn main() {
     foo!();
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rustfmt/issues/806.