### PR TITLE
Remove trailing whitespace for fn types /w non-unit return

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -268,7 +268,7 @@ fn format_function_type<'a, I>(inputs: I,
         FunctionRetTy::Default(..) => String::new(),
     };
 
-    let infix = if output.len() + list_str.len() > width {
+    let infix = if output.len() > 0 && output.len() + list_str.len() > width {
         format!("\n{}", (offset - 1).to_string(context.config))
     } else {
         String::new()

--- a/tests/source/type_alias.rs
+++ b/tests/source/type_alias.rs
@@ -25,3 +25,5 @@ pub type WithWhereClause<LONGPARAMETERNAME, T> where T: Clone, LONGPARAMETERNAME
 pub type Exactly100CharstoEqualWhereTest<T, U, PARAMET> where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;
 
 pub type Exactly101CharstoEqualWhereTest<T, U, PARAMETE> where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;
+
+type RegisterPlugin = unsafe fn(pt: *const c_char, plugin: *mut c_void, data: *mut CallbackData);

--- a/tests/target/type_alias.rs
+++ b/tests/target/type_alias.rs
@@ -49,3 +49,7 @@ pub type Exactly100CharstoEqualWhereTest<T, U, PARAMET> where T: Clone + Ord + E
 
 pub type Exactly101CharstoEqualWhereTest<T, U, PARAMETE>
     where T: Clone + Ord + Eq + SomeOtherTrait = Option<T>;
+
+type RegisterPlugin = unsafe fn(pt: *const c_char,
+                                plugin: *mut c_void,
+                                data: *mut CallbackData);


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rustfmt/issues/830.