### PR TITLE
config: Rename Replace WriteMode variant to Backup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -124,8 +124,8 @@ configuration_option_enum! { ReportTactic:
 }
 
 configuration_option_enum! { WriteMode:
-    // Backsup the original file and overwrites the orignal.
-    Replace,
+    // Takes a backup of the original file with .rs.bk extension before overwriting.
+    Backup,
     // Overwrites original file without backup.
     Overwrite,
     // Write the output to stdout.
@@ -349,6 +349,7 @@ create_config! {
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
     match_wildcard_trailing_comma: bool, true, "Put a trailing comma after a wildcard arm";
-    write_mode: WriteMode, WriteMode::Replace,
-        "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";
+    write_mode: WriteMode, WriteMode::Backup,
+        "What Write Mode to use when none is supplied: Backup, Overwrite, Display, Diff, \
+        Coverage, Plain, Checkstyle";
 }

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -110,7 +110,7 @@ pub fn write_file<T>(text: &StringBuffer,
     }
 
     match config.write_mode {
-        WriteMode::Replace => {
+        WriteMode::Backup => {
             if let Ok((ori, fmt)) = source_and_formatted_text(text, filename, config) {
                 if fmt != ori {
                     // Do a little dance to make writing safer - write to a temp file


### PR DESCRIPTION
The new variant name more closely matches its purpose. The `rustfmt`
binary is modified to accept `--write-mode replace` as a synonym for the
new name.