### PR TITLE
Fix incorrect indent with fn_args_layout: Block

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1339,6 +1339,7 @@ fn rewrite_fn_base(context: &RewriteContext,
     result.push_str(&arg_str);
     if context.config.fn_args_layout == StructLitStyle::Block {
         result.push('\n');
+        result.push_str(&indent.to_string(context.config));
     }
     result.push(')');
 

--- a/tests/source/fn-custom-6.rs
+++ b/tests/source/fn-custom-6.rs
@@ -34,3 +34,9 @@ fn foo(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb) -> String where T: UUUUUUUUUUU {
 fn bar(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb, c: Cccccccccccccccccc, d: Dddddddddddddddd, e: Eeeeeeeeeeeeeee) -> String where T: UUUUUUUUUUU {
     bar();
 }
+
+trait Test {
+    fn foo(a: u8) {}
+
+    fn bar(a: u8) -> String {}
+}

--- a/tests/source/fn-custom-7.rs
+++ b/tests/source/fn-custom-7.rs
@@ -17,3 +17,9 @@ fn foo(a: u8 /* Comment 1 */, b: u8 /* Comment 2 */) -> u8 {
 fn foo(/* Comment 1 */ a: u8, /* Comment 2 */ b: u8) -> u8 {
     bar()
 }
+
+trait Test {
+    fn foo(a: u8) {}
+
+    fn bar(a: u8) -> String {}
+}

--- a/tests/source/fn_args_layout-block.rs
+++ b/tests/source/fn_args_layout-block.rs
@@ -1,0 +1,24 @@
+// rustfmt-fn_args_layout: Block
+
+
+fn foo(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb) {
+    foo();
+}
+
+fn bar(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb, c: Cccccccccccccccccc, d: Dddddddddddddddd, e: Eeeeeeeeeeeeeee) {
+    bar();
+}
+
+fn foo(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb) -> String {
+    foo();
+}
+
+fn bar(a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb, c: Cccccccccccccccccc, d: Dddddddddddddddd, e: Eeeeeeeeeeeeeee) -> String {
+    bar();
+}
+
+trait Test {
+    fn foo(a: u8) {}
+
+    fn bar(a: u8) -> String {}
+}

--- a/tests/target/fn-custom-6.rs
+++ b/tests/target/fn-custom-6.rs
@@ -68,3 +68,15 @@ fn bar(
 where T: UUUUUUUUUUU {
     bar();
 }
+
+trait Test {
+    fn foo(
+        a: u8
+    ) {
+    }
+
+    fn bar(
+        a: u8
+    ) -> String {
+    }
+}

--- a/tests/target/fn-custom-7.rs
+++ b/tests/target/fn-custom-7.rs
@@ -30,3 +30,17 @@ fn foo(
 {
     bar()
 }
+
+trait Test {
+    fn foo(
+        a: u8
+    )
+    {
+    }
+
+    fn bar(
+        a: u8
+    ) -> String
+    {
+    }
+}

--- a/tests/target/fn_args_layout-block.rs
+++ b/tests/target/fn_args_layout-block.rs
@@ -1,0 +1,46 @@
+// rustfmt-fn_args_layout: Block
+
+
+fn foo(
+    a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb
+) {
+    foo();
+}
+
+fn bar(
+    a: Aaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbb,
+    c: Cccccccccccccccccc,
+    d: Dddddddddddddddd,
+    e: Eeeeeeeeeeeeeee
+) {
+    bar();
+}
+
+fn foo(
+    a: Aaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbb
+) -> String {
+    foo();
+}
+
+fn bar(
+    a: Aaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbb,
+    c: Cccccccccccccccccc,
+    d: Dddddddddddddddd,
+    e: Eeeeeeeeeeeeeee
+) -> String {
+    bar();
+}
+
+trait Test {
+    fn foo(
+        a: u8
+    ) {
+    }
+
+    fn bar(
+        a: u8
+    ) -> String {
+    }
+}


### PR DESCRIPTION
The closing parenthesis for the arg list was written on a new line without first applying the appropriate indent.

Fixes #707.
