### PR TITLE
Fix. rustfmt write to stderr instead stdout

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -223,8 +223,8 @@ fn execute() -> i32 {
                                                                       file.display()));
                     if let Some(path) = path_tmp.as_ref() {
                         println!("Using rustfmt config file {} for {}",
-                             path.display(),
-                             file.display());
+                                 path.display(),
+                                 file.display());
                     }
                     config = config_tmp;
                 }

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -212,7 +212,7 @@ fn execute() -> i32 {
                 path = path_tmp;
             };
             if let Some(path) = path.as_ref() {
-                msg!("Using rustfmt config file {}", path.display());
+                println!("Using rustfmt config file {}", path.display());
             }
             for file in files {
                 // Check the file directory if the config-path could not be read or not provided
@@ -222,7 +222,7 @@ fn execute() -> i32 {
                                                                        for {}",
                                                                       file.display()));
                     if let Some(path) = path_tmp.as_ref() {
-                        msg!("Using rustfmt config file {} for {}",
+                        println!("Using rustfmt config file {} for {}",
                              path.display(),
                              file.display());
                     }


### PR DESCRIPTION
rustfmt writes some messages like "Using rustfmt config file..." to stderr instead stdout, but it is not error.