### PR TITLE
macros: Cancel DiagnosticBuilder when not emitting error

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -82,7 +82,10 @@ pub fn rewrite_macro(mac: &ast::Mac,
         loop {
             expr_vec.push(match parser.parse_expr() {
                 Ok(expr) => expr,
-                Err(..) => return None,
+                Err(mut e) => {
+                    e.cancel();
+                    return None;
+                }
             });
 
             match parser.token {


### PR DESCRIPTION
The error handling in libsyntax changed to use a `DiagnosticBuilder`
type in the `Err` variant of `PResult`. This type has `emit()` and
`cancel()` methods. Once created, errors must be emitted or canceled; if
not, the `Drop` impl on `DiagnosticBuilder` will panic.

The first syntex_syntax release to include this change was v0.25.0. The
bump from v0.23.0 to v0.29.1 in #847 did not add any `cancel()` calls,
even though at least one was required. There may be others not caught in
this commit.