### PR TITLE
Change the logic around breaking multiple patterns in match arms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -87,7 +87,8 @@ impl Density {
     pub fn to_list_tactic(self) -> ListTactic {
         match self {
             Density::Compressed => ListTactic::Mixed,
-            Density::Tall | Density::CompressedIfEmpty => ListTactic::HorizontalVertical,
+            Density::Tall |
+            Density::CompressedIfEmpty => ListTactic::HorizontalVertical,
             Density::Vertical => ListTactic::Vertical,
         }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -58,7 +58,8 @@ pub fn rewrite_macro(mac: &ast::Mac,
                      -> Option<String> {
     let original_style = macro_style(mac, context);
     let macro_name = match extra_ident {
-        None | Some(ast::Ident { name: ast::Name(0), .. }) => format!("{}!", mac.node.path),
+        None |
+        Some(ast::Ident { name: ast::Name(0), .. }) => format!("{}!", mac.node.path),
         Some(ident) => format!("{}! {}", mac.node.path, ident),
     };
     let style = if FORCED_BRACKET_MACROS.contains(&&macro_name[..]) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -552,7 +552,8 @@ impl Rewrite for ast::Ty {
             ast::TyKind::BareFn(ref bare_fn) => {
                 rewrite_bare_fn(bare_fn, self.span, context, width, offset)
             }
-            ast::TyKind::Mac(..) | ast::TyKind::Typeof(..) => unreachable!(),
+            ast::TyKind::Mac(..) |
+            ast::TyKind::Typeof(..) => unreachable!(),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,6 +113,13 @@ pub fn last_line_width(s: &str) -> usize {
         None => s.len(),
     }
 }
+#[inline]
+pub fn trimmed_last_line_width(s: &str) -> usize {
+    match s.rfind('\n') {
+        Some(n) => s[(n + 1)..].trim().len(),
+        None => s.trim().len(),
+    }
+}
 
 #[inline]
 fn is_skip(meta_item: &MetaItem) -> bool {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -46,7 +46,8 @@ impl<'a> FmtVisitor<'a> {
                     self.push_rewrite(stmt.span, rewrite);
                 }
             }
-            ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
+            ast::StmtKind::Expr(..) |
+            ast::StmtKind::Semi(..) => {
                 let rewrite = stmt.rewrite(&self.get_context(),
                                            self.config.max_width - self.block_indent.width(),
                                            self.block_indent);

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -284,3 +284,13 @@ fn issue386() {
             false,
     }
 }
+
+fn guards() {
+    match foo {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if foooooooooooooo && barrrrrrrrrrrr => {}
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if foooooooooooooo && barrrrrrrrrrrr => {}
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            if fooooooooooooooooooooo &&
+               (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || cccccccccccccccccccccccccccccccccccccccc) => {}
+    }
+}

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -274,3 +274,13 @@ fn issue494() {
         }
     }
 }
+
+fn issue386() {
+    match foo {
+        BiEq | BiLt | BiLe | BiNe | BiGt | BiGe =>
+                    true,
+        BiAnd | BiOr | BiAdd | BiSub | BiMul | BiDiv | BiRem |
+        BiBitXor | BiBitAnd | BiBitOr | BiShl | BiShr =>
+            false,
+    }
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -221,9 +221,8 @@ fn issue355() {
 fn issue280() {
     {
         match x {
-            CompressionMode::DiscardNewline | CompressionMode::CompressWhitespaceNewline => {
-                ch == '\n'
-            }
+            CompressionMode::DiscardNewline |
+            CompressionMode::CompressWhitespaceNewline => ch == '\n',
             ast::ItemConst(ref typ, ref expr) => {
                 self.process_static_or_const_item(item, &typ, &expr)
             }
@@ -260,7 +259,8 @@ fn issue496() {
         {
             {
                 match def {
-                    def::DefConst(def_id) | def::DefAssociatedConst(def_id) => {
+                    def::DefConst(def_id) |
+                    def::DefAssociatedConst(def_id) => {
                         match const_eval::lookup_const_by_id(cx.tcx, def_id, Some(self.pat.id)) {
                             Some(const_expr) => x,
                         }
@@ -274,7 +274,8 @@ fn issue496() {
 fn issue494() {
     {
         match stmt.node {
-            hir::StmtExpr(ref expr, id) | hir::StmtSemi(ref expr, id) => {
+            hir::StmtExpr(ref expr, id) |
+            hir::StmtSemi(ref expr, id) => {
                 result.push(StmtRef::Mirror(Box::new(Stmt {
                     span: stmt.span,
                     kind: StmtKind::Expr {
@@ -284,5 +285,13 @@ fn issue494() {
                 })))
             }
         }
+    }
+}
+
+fn issue386() {
+    match foo {
+        BiEq | BiLt | BiLe | BiNe | BiGt | BiGe => true,
+        BiAnd | BiOr | BiAdd | BiSub | BiMul | BiDiv | BiRem | BiBitXor | BiBitAnd | BiBitOr |
+        BiShl | BiShr => false,
     }
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -295,3 +295,17 @@ fn issue386() {
         BiShl | BiShr => false,
     }
 }
+
+fn guards() {
+    match foo {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if foooooooooooooo &&
+                                                                      barrrrrrrrrrrr => {}
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if foooooooooooooo &&
+                                                                      barrrrrrrrrrrr => {}
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            if fooooooooooooooooooooo &&
+               (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
+                cccccccccccccccccccccccccccccccccccccccc) => {}
+    }
+}


### PR DESCRIPTION
Refactor to use the list code, don't preserve original stacking-ness, base vertical vs mixed formatting on complexity of the patterns.

Closes #386 

r? @marcusklaas 