### PR TITLE
rustfmt: Make error handling more idiomatic

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -134,7 +134,7 @@ fn update_config(config: &mut Config, matches: &Matches) -> Result<(), String> {
     }
 }
 
-fn execute() -> i32 {
+fn make_opts() -> Options {
     let mut opts = Options::new();
     opts.optflag("h", "help", "show this message");
     opts.optflag("V", "version", "show version information");
@@ -153,6 +153,12 @@ fn execute() -> i32 {
                 "Recursively searches the given path for the rustfmt.toml config file. If not \
                  found reverts to the input file path",
                 "[Path for the configuration file]");
+
+    opts
+}
+
+fn execute() -> i32 {
+    let opts = make_opts();
 
     let matches = match opts.parse(env::args().skip(1)) {
         Ok(m) => m,

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -65,19 +65,17 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
     loop {
         let config_file = current.join("rustfmt.toml");
         match fs::metadata(&config_file) {
-            Ok(md) => {
-                // Properly handle unlikely situation of a directory named `rustfmt.toml`.
-                if md.is_file() {
-                    return Ok(Some(config_file));
-                }
-            }
-            // If it's not found, we continue searching; otherwise something went wrong and we
-            // return the error.
+            // Only return if it's a file to handle the unlikely situation of a directory named
+            // `rustfmt.toml`.
+            Ok(ref md) if md.is_file() => return Ok(Some(config_file)),
+            // Return the error if it's something other than `NotFound`; otherwise we didn't find
+            // the project file yet, and continue searching.
             Err(e) => {
                 if e.kind() != ErrorKind::NotFound {
                     return Err(FmtError::from(e));
                 }
             }
+            _ => {}
         }
 
         // If the current directory has no parent, we're done searching.


### PR DESCRIPTION
These commits improve error handling in the `rustfmt` binary more
idiomatic by
  - replacing the `Operation::InvalidInput` variant with `Result`
  - using the `try!()` macro instead of explicit matching
  - using guard patterns in a match expression