### PR TITLE
don't silence error unnecessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,11 +422,7 @@ pub enum Input {
 
 pub fn run(input: Input, config: &Config) {
     let (file_map, report) = format_input(input, config);
-
-    let ignore_errors = config.write_mode == WriteMode::Plain;
-    if !ignore_errors {
-        msg!("{}", report);
-    }
+    msg!("{}", report);
 
     let mut out = stdout();
     let write_result = filemap::write_all_files(&file_map, &mut out, config);


### PR DESCRIPTION
This `if` was used to separate error output from the formatting output, when they both used stdout. It was useful for integration with tools, which can submit input to stdin and read pretty printed result from stdout without worrying about errors intermingled with the actual result. 

But now we write errors to `stderr`, so the problem disappears and we can safely remove this `if`.

Related to #907