### PR TITLE
Don't print empty lines to stderr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,9 @@ pub enum Input {
 
 pub fn run(input: Input, config: &Config) -> Summary {
     let (mut summary, file_map, report) = format_input(input, config);
-    msg!("{}", report);
+    if report.has_warnings() {
+        msg!("{}", report);
+    }
 
     let mut out = stdout();
     let write_result = filemap::write_all_files(&file_map, &mut out, config);


### PR DESCRIPTION
if `rustffmt` is invoked like `rustfmt foo.rs bar.rs baz.rs`, it will print three blank lines to `stderr`. This fixes the behavior. 