### PR TITLE
Add a new block indent style "TabbedTwice"

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -45,6 +45,9 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
         BlockIndentStyle::Visual => offset,
         BlockIndentStyle::Inherit => context.block_indent,
         BlockIndentStyle::Tabbed => context.block_indent.block_indent(context.config),
+        BlockIndentStyle::TabbedTwice => {
+            context.block_indent.block_indent(context.config).block_indent(context.config)
+        }
     };
     let parent_context = &RewriteContext { block_indent: parent_block_indent, ..*context };
     let parent = subexpr_list.pop().unwrap();
@@ -59,6 +62,10 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
             BlockIndentStyle::Inherit => (context.block_indent, false),
             BlockIndentStyle::Tabbed => (context.block_indent.block_indent(context.config), false),
             BlockIndentStyle::Visual => (offset + Indent::new(context.config.tab_spaces, 0), false),
+            BlockIndentStyle::TabbedTwice => {
+                (context.block_indent.block_indent(context.config).block_indent(context.config),
+                 false)
+            }
         }
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,8 @@ configuration_option_enum! { BlockIndentStyle:
     Tabbed,
     // Aligned with block open.
     Visual,
+    // Two levels deeper than parent.
+    TabbedTwice,
 }
 
 configuration_option_enum! { Density:

--- a/src/items.rs
+++ b/src/items.rs
@@ -1568,6 +1568,9 @@ fn rewrite_args(context: &RewriteContext,
         BlockIndentStyle::Inherit => indent,
         BlockIndentStyle::Tabbed => indent.block_indent(context.config),
         BlockIndentStyle::Visual => arg_indent,
+        BlockIndentStyle::TabbedTwice => {
+            indent.block_indent(context.config).block_indent(context.config)
+        }
     };
 
     let tactic = definitive_tactic(&arg_items,
@@ -1674,6 +1677,9 @@ fn rewrite_generics(context: &RewriteContext,
     let offset = match context.config.generics_indent {
         BlockIndentStyle::Inherit => offset,
         BlockIndentStyle::Tabbed => offset.block_indent(context.config),
+        BlockIndentStyle::TabbedTwice => {
+            offset.block_indent(context.config).block_indent(context.config)
+        }
         // 1 = <
         BlockIndentStyle::Visual => generics_offset + 1,
     };
@@ -1750,11 +1756,16 @@ fn rewrite_where_clause(context: &RewriteContext,
     let extra_indent = match context.config.where_indent {
         BlockIndentStyle::Inherit => Indent::empty(),
         BlockIndentStyle::Tabbed | BlockIndentStyle::Visual => Indent::new(config.tab_spaces, 0),
+        BlockIndentStyle::TabbedTwice => Indent::new(config.tab_spaces * 2, 0),
     };
 
     let offset = match context.config.where_pred_indent {
         BlockIndentStyle::Inherit => indent + extra_indent,
         BlockIndentStyle::Tabbed => indent + extra_indent.block_indent(config),
+        BlockIndentStyle::TabbedTwice => {
+            extra_indent.block_indent(config);
+            indent + extra_indent.block_indent(config)
+        }
         // 6 = "where ".len()
         BlockIndentStyle::Visual => indent + extra_indent + 6,
     };


### PR DESCRIPTION
Most useful for use with 'fn_arg_indent = "TabbedTwice"'

Fixes #957 

Ideally we'd have something like `TabbedN(u32)` or similar, but the `configuration_option_enum!` doesn't appear to support that yet.