### PR TITLE
Always skip children when using Plain write mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,11 @@ fn format_ast(krate: &ast::Crate,
               config: &Config)
               -> FileMap {
     let mut file_map = FileMap::new();
+    // We always skip children for the "Plain" write mode, since there is
+    // nothing to distinguish the nested module contents.
+    let skip_children = config.skip_children || config.write_mode == config::WriteMode::Plain;
     for (path, module) in modules::list_files(krate, parse_session.codemap()) {
-        if config.skip_children && path.as_path() != main_file {
+        if skip_children && path.as_path() != main_file {
             continue;
         }
         let path = path.to_str().unwrap();


### PR DESCRIPTION
Outputting child module contents in the "Plain" write mode does not make sense, since there is no way to differentiate code that came from a child module from that which came from the parent file.

Fixes #939.  If this is merged, integrations that want to run a single file can send it on stdin and need not specify any flags--the output will contain only the reformatted code that was input.