### PR TITLE
Allow command line configs when running from stdin

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -196,6 +196,15 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
             // write_mode is always Plain for Stdin.
             config.write_mode = WriteMode::Plain;
 
+            let options = try!(CliOptions::from_matches(&matches));
+            options.apply_to(&mut config);
+            if config.write_mode != WriteMode::Plain {
+                return Err(FmtError::from(format!("When reading from stdin, only the \"Plain\" \
+                                                   write mode is supported (\"{:?}\" was \
+                                                   specified)",
+                                                  config.write_mode)));
+            }
+
             Ok(run(Input::Text(input), &config))
         }
         Operation::Format { files, config_path } => {


### PR DESCRIPTION
Parse configuration options from the command line when running from stdin.  Give an error on any attempt to set the write mode to something other than "Plain" (since that is not supported with stdin.)

Fixes #939, as an alternative to #966.  If this is merged without #966, an integration would need to specify `--skip-children` on the command line to avoid child modules in the output.  In my opinion #966 is better, since the output of the `Plain` write mode doesn't make any sense with child modules enabled.  But if #966 is rejected, then this change would at least allow them to be suppressed with an extra flag.

One could even merge both this and #966.  It would sort of make sense, but if #966 is merged then this PR isn't particularly useful.  All it would let you do with the command line on stdin is add the verbose flag, whose only effect would be to print `Formatting stdin` before the rest of the output.  But if some other CLI options were added later, then it might make sense to have this in place already...¯\\\_(ツ)\_/¯