### PR TITLE
Don't misplace the :: on associated items.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -33,7 +33,7 @@ pub fn rewrite_path(context: &RewriteContext,
                     -> Option<String> {
     let skip_count = qself.map_or(0, |x| x.position);
 
-    let mut result = if path.global {
+    let mut result = if path.global && qself.is_none() {
         "::".to_owned()
     } else {
         String::new()
@@ -48,6 +48,9 @@ pub fn rewrite_path(context: &RewriteContext,
 
         if skip_count > 0 {
             result.push_str(" as ");
+            if path.global {
+                result.push_str("::");
+            }
 
             let extra_offset = extra_offset(&result, offset);
             // 3 = ">::".len()

--- a/tests/target/associated-items.rs
+++ b/tests/target/associated-items.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", <bool as ::std::default::Default>::default());
+}


### PR DESCRIPTION
The rewritten location of the :: on global paths for qpaths was wrong.

Fixes #972.