### PR TITLE
Write each file as it is formatted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rustfmt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "diff 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -13,7 +13,6 @@
 
 use strings::string_buffer::StringBuffer;
 
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, Write, Read, stdout, BufWriter};
 
@@ -22,27 +21,26 @@ use rustfmt_diff::{make_diff, print_diff, Mismatch};
 use checkstyle::{output_header, output_footer, output_checkstyle_file};
 
 // A map of the files of a crate, with their new content
-pub type FileMap = HashMap<String, StringBuffer>;
+pub type FileMap = Vec<FileRecord>;
+
+pub type FileRecord = (String, StringBuffer);
 
 // Append a newline to the end of each file.
-pub fn append_newlines(file_map: &mut FileMap) {
-    for (_, s) in file_map.iter_mut() {
-        s.push_str("\n");
-    }
+pub fn append_newline(s: &mut StringBuffer) {
+    s.push_str("\n");
 }
 
 pub fn write_all_files<T>(file_map: &FileMap, out: &mut T, config: &Config) -> Result<(), io::Error>
     where T: Write
 {
     output_header(out, config.write_mode).ok();
-    for filename in file_map.keys() {
-        try!(write_file(&file_map[filename], filename, out, config));
+    for &(ref filename, ref text) in file_map {
+        try!(write_file(text, filename, out, config));
     }
     output_footer(out, config.write_mode).ok();
 
     Ok(())
 }
-
 
 // Prints all newlines either as `\n` or as `\r\n`.
 pub fn write_system_newlines<T>(writer: T,

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,4 +1,5 @@
 #[must_use]
+#[derive(Debug, Clone)]
 pub struct Summary {
     // Encountered e.g. an IO error.
     has_operational_errors: bool,


### PR DESCRIPTION
The old behaviour stored everything in memory until we were finished. Now we write as soon as we can.

This gives better behaviour when formatting large programs, since there is some progress indication. It also opens the door to optimising memory use by not storing everything in memory unless it is required (which it still might be). That is left as future work though.

r? @marcusklaas 
