### PR TITLE
change  normalise spelling to American version - 

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -31,7 +31,7 @@ pub fn rewrite_comment(orig: &str,
     // Edge case: block comments. Let's not trim their lines (for now).
     let (opener, closer, line_start) = if block_style {
         ("/* ", " */", " * ")
-    } else if !config.normalise_comments {
+    } else if !config.normalize_comments {
         if orig.starts_with("/**") {
             ("/** ", " **/", " ** ")
         } else if orig.starts_with("/*!") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -385,7 +385,7 @@ create_config! {
     take_source_hints: bool, true, "Retain some formatting characteristics from the source code";
     hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";
     wrap_comments: bool, false, "Break comments to fit on the line";
-    normalise_comments: bool, true, "Convert /* */ comments to // comments where possible";
+    normalize_comments: bool, true, "Convert /* */ comments to // comments where possible";
     wrap_match_arms: bool, true, "Wrap multiline match arms in blocks";
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";

--- a/tests/source/comment4.rs
+++ b/tests/source/comment4.rs
@@ -1,4 +1,4 @@
-// rustfmt-normalise_comments: false
+// rustfmt-normalize_comments: false
 
 //! Doc comment
 fn test() {

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -1,4 +1,4 @@
-// rustfmt-normalise_comments: false
+// rustfmt-normalize_comments: false
 
 //! Doc comment
 fn test() {


### PR DESCRIPTION
Normalize as American english is more common across programming community