### PR TITLE
print_diff: Don't print color codes if output is not a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,8 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,6 +17,7 @@ dependencies = [
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,10 @@ env_logger = "0.3"
 getopts = "0.2"
 itertools = "0.4.15"
 multimap = "0.3"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.11"
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"
+winapi = "0.2.7"


### PR DESCRIPTION
On unix, `term::stdout()` just reads the `TERM` environment variable to
decide what features are available. It does not check if the output file
descriptor is in fact a tty. This resulted in printing escape codes when
redirecting output.