### PR TITLE
Add support for the `default` keyword

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -120,6 +120,7 @@ impl<'a> FmtVisitor<'a> {
                                               generics,
                                               ast::Unsafety::Normal,
                                               ast::Constness::NotConst,
+                                              ast::Defaultness::Final,
                                               // These are not actually rust functions,
                                               // but we format them as such.
                                               abi::Abi::Rust,
@@ -168,6 +169,7 @@ impl<'a> FmtVisitor<'a> {
                       generics: &ast::Generics,
                       unsafety: ast::Unsafety,
                       constness: ast::Constness,
+                      defaultness: ast::Defaultness,
                       abi: abi::Abi,
                       vis: &ast::Visibility,
                       span: Span,
@@ -187,6 +189,7 @@ impl<'a> FmtVisitor<'a> {
                                                                          generics,
                                                                          unsafety,
                                                                          constness,
+                                                                         defaultness,
                                                                          abi,
                                                                          vis,
                                                                          span,
@@ -231,6 +234,7 @@ impl<'a> FmtVisitor<'a> {
                                                        &sig.generics,
                                                        sig.unsafety,
                                                        sig.constness,
+                                                       ast::Defaultness::Final,
                                                        sig.abi,
                                                        &ast::Visibility::Inherited,
                                                        span,
@@ -1220,6 +1224,7 @@ fn rewrite_fn_base(context: &RewriteContext,
                    generics: &ast::Generics,
                    unsafety: ast::Unsafety,
                    constness: ast::Constness,
+                   defaultness: ast::Defaultness,
                    abi: abi::Abi,
                    vis: &ast::Visibility,
                    span: Span,
@@ -1235,6 +1240,10 @@ fn rewrite_fn_base(context: &RewriteContext,
     let mut result = String::with_capacity(1024);
     // Vis unsafety abi.
     result.push_str(&*format_visibility(vis));
+
+    if let ast::Defaultness::Default = defaultness {
+        result.push_str("default ");
+    }
 
     if let ast::Constness::Const = constness {
         result.push_str("const ");

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -141,7 +141,8 @@ impl<'a> FmtVisitor<'a> {
                 fd: &ast::FnDecl,
                 b: &ast::Block,
                 s: Span,
-                _: ast::NodeId) {
+                _: ast::NodeId,
+                defaultness: ast::Defaultness) {
         let indent = self.block_indent;
         let rewrite = match fk {
             visit::FnKind::ItemFn(ident, ref generics, unsafety, constness, abi, vis) => {
@@ -151,6 +152,7 @@ impl<'a> FmtVisitor<'a> {
                                 generics,
                                 unsafety,
                                 constness,
+                                defaultness,
                                 abi,
                                 vis,
                                 codemap::mk_sp(s.lo, b.span.lo),
@@ -163,6 +165,7 @@ impl<'a> FmtVisitor<'a> {
                                 &sig.generics,
                                 sig.unsafety,
                                 sig.constness,
+                                defaultness,
                                 sig.abi,
                                 vis.unwrap_or(&ast::Visibility::Inherited),
                                 codemap::mk_sp(s.lo, b.span.lo),
@@ -332,7 +335,8 @@ impl<'a> FmtVisitor<'a> {
                               decl,
                               body,
                               item.span,
-                              item.id)
+                              item.id,
+                              ast::Defaultness::Final)
             }
             ast::ItemKind::Ty(ref ty, ref generics) => {
                 let rewrite = rewrite_type_alias(&self.get_context(),
@@ -373,7 +377,8 @@ impl<'a> FmtVisitor<'a> {
                               &sig.decl,
                               &body,
                               ti.span,
-                              ti.id);
+                              ti.id,
+                              ast::Defaultness::Final);
             }
             ast::TraitItemKind::Type(ref type_param_bounds, _) => {
                 let rewrite = rewrite_associated_type(ti.ident,
@@ -397,7 +402,8 @@ impl<'a> FmtVisitor<'a> {
                               &sig.decl,
                               body,
                               ii.span,
-                              ii.id);
+                              ii.id,
+                              ii.defaultness);
             }
             ast::ImplItemKind::Const(ref ty, ref expr) => {
                 let rewrite = rewrite_static("const",

--- a/tests/source/issue-945.rs
+++ b/tests/source/issue-945.rs
@@ -1,0 +1,5 @@
+impl Bar { default const unsafe fn foo() { "hi" } }
+
+impl Baz { default unsafe extern "C" fn foo() { "hi" } }
+
+impl Foo for Bar { default fn foo() { "hi" } }

--- a/tests/target/issue-945.rs
+++ b/tests/target/issue-945.rs
@@ -1,0 +1,17 @@
+impl Bar {
+    default const unsafe fn foo() {
+        "hi"
+    }
+}
+
+impl Baz {
+    default unsafe extern "C" fn foo() {
+        "hi"
+    }
+}
+
+impl Foo for Bar {
+    default fn foo() {
+        "hi"
+    }
+}


### PR DESCRIPTION
Adds support for Defaultness on impl methods.
Fixes #945 

(3 of the tests don't pass on master right now on my machine: file-lines-1, file-lines-2, file-lines-3 and this PR doesn't change this behavior: the same tests pass on master and here, so hopefully everything is correct :)