### PR TITLE
Update Vim integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can run `rustfmt --help` for more information.
 
 ## Running Rustfmt from your editor
 
-* [Vim](http://johannh.me/blog/rustfmt-vim.html)
+* [Vim](https://github.com/rust-lang/rust.vim#enabling-autoformat)
 * [Emacs](https://github.com/fbergroth/emacs-rustfmt)
 * [Sublime Text 3](https://packagecontrol.io/packages/BeautifyRust)
 * [Atom](atom.md)


### PR DESCRIPTION
It seems as though the official Vim plugin has added the option to run rustfmt on save. This is probably much easier for users to enable than the previous instructions.