### PR TITLE
Return failure exit code on found diffs (fix #906)

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -269,6 +269,9 @@ fn main() {
                 2
             } else if summary.has_formatting_errors() {
                 3
+            } else if summary.has_diff {
+                // should only happen in diff mode
+                4
             } else {
                 assert!(summary.has_no_errors());
                 0

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -82,7 +82,7 @@ pub fn write_file<T>(text: &StringBuffer,
                      filename: &str,
                      out: &mut T,
                      config: &Config)
-                     -> Result<Option<String>, io::Error>
+                     -> Result<bool, io::Error>
     where T: Write
 {
 
@@ -146,8 +146,10 @@ pub fn write_file<T>(text: &StringBuffer,
         WriteMode::Diff => {
             println!("Diff of {}:\n", filename);
             if let Ok((ori, fmt)) = source_and_formatted_text(text, filename, config) {
-                print_diff(make_diff(&ori, &fmt, 3),
-                           |line_num| format!("\nDiff at line {}:", line_num));
+                let mismatch = make_diff(&ori, &fmt, 3);
+                let has_diff = !mismatch.is_empty();
+                print_diff(mismatch, |line_num| format!("\nDiff at line {}:", line_num));
+                return Ok(has_diff);
             }
         }
         WriteMode::Checkstyle => {
@@ -156,5 +158,6 @@ pub fn write_file<T>(text: &StringBuffer,
         }
     }
 
-    Ok(None)
+    // when we are not in diff mode, don't indicate differing files
+    Ok(false)
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -9,6 +9,9 @@ pub struct Summary {
 
     // Code is valid, but it is impossible to format it properly.
     has_formatting_errors: bool,
+
+    // Formatted code differs from existing code (write-mode diff only).
+    pub has_diff: bool,
 }
 
 impl Summary {
@@ -17,6 +20,7 @@ impl Summary {
             has_operational_errors: false,
             has_parsing_errors: false,
             has_formatting_errors: false,
+            has_diff: false,
         }
     }
 
@@ -44,13 +48,19 @@ impl Summary {
         self.has_formatting_errors = true;
     }
 
+    pub fn add_diff(&mut self) {
+        self.has_diff = true;
+    }
+
     pub fn has_no_errors(&self) -> bool {
-        !(self.has_operational_errors || self.has_parsing_errors || self.has_formatting_errors)
+        !(self.has_operational_errors || self.has_parsing_errors || self.has_formatting_errors ||
+          self.has_diff)
     }
 
     pub fn add(&mut self, other: Summary) {
         self.has_operational_errors |= other.has_operational_errors;
         self.has_formatting_errors |= other.has_formatting_errors;
         self.has_parsing_errors |= other.has_parsing_errors;
+        self.has_diff |= other.has_diff;
     }
 }


### PR DESCRIPTION
This changes rustfmt to return the number
of found differences as exit code when run with
write mode diff.

Useful for CI to make sure your contributors actually ran rustfmt.