### PR TITLE
Fix formatting empty block comments (`/**/`)

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -33,7 +33,7 @@ pub fn rewrite_comment(orig: &str,
         if block_style {
             ("/* ", " */", " * ")
         } else if !config.normalize_comments {
-            if orig.starts_with("/**") {
+            if orig.starts_with("/**") && !orig.starts_with("/**/") {
                 ("/** ", " **/", " ** ")
             } else if orig.starts_with("/*!") {
                 ("/*! ", " */", " * ")
@@ -46,7 +46,8 @@ pub fn rewrite_comment(orig: &str,
             } else {
                 ("// ", "", "// ")
             }
-        } else if orig.starts_with("///") || orig.starts_with("/**") {
+        } else if orig.starts_with("///") ||
+                  (orig.starts_with("/**") && !orig.starts_with("/**/")) {
             ("/// ", "", "/// ")
         } else if orig.starts_with("//!") || orig.starts_with("/*!") {
             ("//! ", "", "//! ")
@@ -130,7 +131,7 @@ fn left_trim_comment_line(line: &str) -> &str {
     } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
               line.starts_with("///") ||
               line.starts_with("** ") || line.starts_with("/*!") ||
-              line.starts_with("/**") {
+              (line.starts_with("/**") && !line.starts_with("/**/")) {
         &line[3..]
     } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//") ||
               line.starts_with("**") {
@@ -606,7 +607,8 @@ fn remove_comment_header(comment: &str) -> &str {
         &comment[3..]
     } else if comment.starts_with("//") {
         &comment[2..]
-    } else if comment.starts_with("/**") || comment.starts_with("/*!") {
+    } else if (comment.starts_with("/**") && !comment.starts_with("/**/")) ||
+              comment.starts_with("/*!") {
         &comment[3..comment.len() - 2]
     } else {
         assert!(comment.starts_with("/*"),

--- a/tests/source/comment.rs
+++ b/tests/source/comment.rs
@@ -43,6 +43,10 @@ fn chains() {
                 /* comment */ x })
 }
 
+fn issue_1086() {
+    /**/
+}
+
 /*
  * random comment */
 

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -45,6 +45,10 @@ fn chains() {
     })
 }
 
+fn issue_1086() {
+    //
+}
+
 // random comment
 
 fn main() {


### PR DESCRIPTION
#1086 

Fixes panic when formatting `/**/`.

Empty or whitespace comments next to patterns (the code in issue #1086) disappear, which seems to be another existing problem.

Both
```rust
match value {
    _ /* */ => {
        fn2();
    }
}
```
and
```rust
match value {
    _ /**/ => {
        fn2();
    }
}
```

are formatted as

```rust
match_ value {
    _ => {
        fn2();
    }
}
```
