### PR TITLE
Fix overlong function signature

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1358,9 +1358,9 @@ fn rewrite_fn_base(context: &RewriteContext,
             FnArgLayoutStyle::BlockAlways => false,
             _ => {
                 // If we've already gone multi-line, or the return type would push over the max
-                // width, then put the return type on a new line. The +1 for the signature length
-                // is to consider an additional space between the closing brace of the argument and
-                // the arrow '->'.
+                // width, then put the return type on a new line. With the +1 for the signature
+                // length an additional space between the closing brace of the argument and the
+                // arrow '->' is considered.
                 let mut sig_length = result.len() + indent.width() + ret_str_len + 1;
 
                 // If there is no where clause, take into account the space after the return type

--- a/src/items.rs
+++ b/src/items.rs
@@ -1359,8 +1359,8 @@ fn rewrite_fn_base(context: &RewriteContext,
             _ => {
                 // If we've already gone multi-line, or the return type would push over the max
                 // width, then put the return type on a new line. With the +1 for the signature
-                // length an additional space between the closing brace of the argument and the
-                // arrow '->' is considered.
+                // length an additional space between the closing parenthesis of the argument and
+                // the arrow '->' is considered.
                 let mut sig_length = result.len() + indent.width() + ret_str_len + 1;
 
                 // If there is no where clause, take into account the space after the return type

--- a/src/items.rs
+++ b/src/items.rs
@@ -1278,7 +1278,6 @@ fn rewrite_fn_base(context: &RewriteContext,
 
     let multi_line_ret_str = ret_str.contains('\n');
     let ret_str_len = if multi_line_ret_str { 0 } else { ret_str.len() };
-    println!("ret: \"{}\"", ret_str);
 
     // Args.
     let (mut one_line_budget, mut multi_line_budget, mut arg_indent) =

--- a/src/items.rs
+++ b/src/items.rs
@@ -1359,8 +1359,9 @@ fn rewrite_fn_base(context: &RewriteContext,
             _ => {
                 // If we've already gone multi-line, or the return type would push
                 // over the max width, then put the return type on a new line.
-                result.contains("\n") || multi_line_ret_str ||
-                result.len() + indent.width() + ret_str_len > context.config.max_width
+                let overlong_ret = result.len() + indent.width() + ret_str_len >
+                                   context.config.max_width - 1;
+                result.contains("\n") || multi_line_ret_str || overlong_ret
             }
         };
         let ret_indent = if ret_should_indent {
@@ -1388,10 +1389,8 @@ fn rewrite_fn_base(context: &RewriteContext,
         if multi_line_ret_str {
             // Now that we know the proper indent and width, we need to
             // re-layout the return type.
-
             let budget = try_opt!(context.config.max_width.checked_sub(ret_indent.width()));
-            let ret_str = try_opt!(fd.output
-                .rewrite(context, budget, ret_indent));
+            let ret_str = try_opt!(fd.output.rewrite(context, budget, ret_indent));
             result.push_str(&ret_str);
         } else {
             result.push_str(&ret_str);

--- a/tests/source/issue-1049.rs
+++ b/tests/source/issue-1049.rs
@@ -1,0 +1,6 @@
+// Test issue-1049
+pub unsafe fn reborrow_mut(&mut X: Abcde) -> Handle<NodeRef<marker::Mut, K, V, NodeType>, HandleType> {
+}
+
+pub fn merge(mut X: Abcdef) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
+}

--- a/tests/source/issue-1049.rs
+++ b/tests/source/issue-1049.rs
@@ -12,3 +12,5 @@ impl Handle {
 
 // Long function without return type that should not be reformated.
 fn veeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee, b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {}
+
+fn veeeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee, b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {}

--- a/tests/source/issue-1049.rs
+++ b/tests/source/issue-1049.rs
@@ -9,3 +9,6 @@ impl Handle {
     pub fn merge(a: Abcd) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
     }
 }
+
+// Long function without return type that should not be reformated.
+fn veeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee, b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {}

--- a/tests/source/issue-1049.rs
+++ b/tests/source/issue-1049.rs
@@ -4,3 +4,8 @@ pub unsafe fn reborrow_mut(&mut X: Abcde) -> Handle<NodeRef<marker::Mut, K, V, N
 
 pub fn merge(mut X: Abcdef) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
 }
+
+impl Handle {
+    pub fn merge(a: Abcd) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
+    }
+}

--- a/tests/source/issue-1049.rs
+++ b/tests/source/issue-1049.rs
@@ -1,4 +1,4 @@
-// Test issue-1049
+// Test overlong function signature
 pub unsafe fn reborrow_mut(&mut X: Abcde) -> Handle<NodeRef<marker::Mut, K, V, NodeType>, HandleType> {
 }
 

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -15,3 +15,7 @@ impl Handle {
 
 // Long function without return type that should not be reformated.
 fn veeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee, b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {}
+
+fn veeeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee,
+                                       b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {
+}

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -8,6 +8,7 @@ pub fn merge(mut X: Abcdef)
 }
 
 impl Handle {
-    pub fn merge(a: Abcd) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
+    pub fn merge(a: Abcd)
+                 -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
     }
 }

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -1,0 +1,8 @@
+// Test issue-1049
+pub unsafe fn reborrow_mut(&mut X: Abcde)
+                           -> Handle<NodeRef<marker::Mut, K, V, NodeType>, HandleType> {
+}
+
+pub fn merge(mut X: Abcdef)
+             -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
+}

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -12,3 +12,6 @@ impl Handle {
                  -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
     }
 }
+
+// Long function without return type that should not be reformated.
+fn veeeeeeeeeeeeeeeeeeeeery_long_name(a: FirstTypeeeeeeeeee, b: SecondTypeeeeeeeeeeeeeeeeeeeeeee) {}

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -6,3 +6,8 @@ pub unsafe fn reborrow_mut(&mut X: Abcde)
 pub fn merge(mut X: Abcdef)
              -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
 }
+
+impl Handle {
+    pub fn merge(a: Abcd) -> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::Edge> {
+    }
+}

--- a/tests/target/issue-1049.rs
+++ b/tests/target/issue-1049.rs
@@ -1,4 +1,4 @@
-// Test issue-1049
+// Test overlong function signature
 pub unsafe fn reborrow_mut(&mut X: Abcde)
                            -> Handle<NodeRef<marker::Mut, K, V, NodeType>, HandleType> {
 }


### PR DESCRIPTION
Fix off-by-one error in rewrite_fn_base.  #1049 

Also remove a line break.