### PR TITLE
Multiple config file names feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ notes above on running rustfmt.
 ## Configuring Rustfmt
 
 Rustfmt is designed to be very configurable. You can create a TOML file called
-rustfmt.toml, place it in the project directory and it will apply the options
-in that file. See `rustfmt --config-help` for the options which are available,
-or if you prefer to see source code, [src/config.rs](src/config.rs).
+`rustfmt.toml` or `.rustfmt.toml`, place it in the project or any other parent
+directory and it will apply the options in that file. See `rustfmt
+--config-help` for the options which are available, or if you prefer to see
+source code, [src/config.rs](src/config.rs).
 
 By default, Rustfmt uses a style which (mostly) conforms to the
 [Rust style guidelines](https://github.com/rust-lang/rust/tree/master/src/doc/style).
@@ -148,8 +149,9 @@ options covering different styles. File an issue, or even better, submit a PR.
     #[rustfmt_skip]  // requires nightly and #![feature(custom_attribute)] in crate root
     #[cfg_attr(rustfmt, rustfmt_skip)]  // works in stable
     ```
-* When you run rustfmt, place a file named rustfmt.toml in target file
-  directory or its parents to override the default settings of rustfmt.
+* When you run rustfmt, place a file named `rustfmt.toml` or `.rustfmt.toml` in
+  target file directory or its parents to override the default settings of
+  rustfmt.
 * After successful compilation, a `rustfmt` executable can be found in the
   target directory.
 * If you're having issues compiling Rustfmt (or compile errors when trying to

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -109,27 +109,37 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
 
     current = try!(fs::canonicalize(current));
 
+
+    let config_file_names = [".rustfmt.toml", "rustfmt.toml"];
+
     loop {
-        let config_file = current.join("rustfmt.toml");
-        match fs::metadata(&config_file) {
-            // Only return if it's a file to handle the unlikely situation of a directory named
-            // `rustfmt.toml`.
-            Ok(ref md) if md.is_file() => return Ok(Some(config_file)),
-            // Return the error if it's something other than `NotFound`; otherwise we didn't find
-            // the project file yet, and continue searching.
-            Err(e) => {
-                if e.kind() != ErrorKind::NotFound {
-                    return Err(FmtError::from(e));
+        for config_file_name in &config_file_names {
+            println!("{}", config_file_name);
+            let config_file = current.join(config_file_name);
+            // println!("{}", config_file);
+            match fs::metadata(&config_file) {
+                // Only return if it's a file to handle the unlikely situation of a directory named
+                // `rustfmt.toml`.
+                Ok(ref md) if md.is_file() => return Ok(Some(config_file)),
+                // Return the error if it's something other than `NotFound`; otherwise we didn't
+                // find the project file yet, and continue searching.
+                Err(e) => {
+                    if e.kind() != ErrorKind::NotFound {
+                        return Err(FmtError::from(e));
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
         // If the current directory has no parent, we're done searching.
         if !current.pop() {
-            return Ok(None);
+            break;
+            // return Ok(None);
         }
     }
+
+    return Ok(None);
 }
 
 /// Resolve the config for input in `dir`.

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -114,9 +114,7 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
 
     loop {
         for config_file_name in &config_file_names {
-            println!("{}", config_file_name);
             let config_file = current.join(config_file_name);
-            // println!("{}", config_file);
             match fs::metadata(&config_file) {
                 // Only return if it's a file to handle the unlikely situation of a directory named
                 // `rustfmt.toml`.
@@ -134,12 +132,9 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
 
         // If the current directory has no parent, we're done searching.
         if !current.pop() {
-            break;
-            // return Ok(None);
+            return Ok(None);
         }
     }
-
-    return Ok(None);
 }
 
 /// Resolve the config for input in `dir`.

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -109,7 +109,6 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
 
     current = try!(fs::canonicalize(current));
 
-
     const CONFIG_FILE_NAMES: [&'static str; 2] = [".rustfmt.toml", "rustfmt.toml"];
 
     loop {

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -110,10 +110,10 @@ fn lookup_project_file(dir: &Path) -> FmtResult<Option<PathBuf>> {
     current = try!(fs::canonicalize(current));
 
 
-    let config_file_names = [".rustfmt.toml", "rustfmt.toml"];
+    const CONFIG_FILE_NAMES: [&'static str; 2] = [".rustfmt.toml", "rustfmt.toml"];
 
     loop {
-        for config_file_name in &config_file_names {
+        for config_file_name in &CONFIG_FILE_NAMES {
             let config_file = current.join(config_file_name);
             match fs::metadata(&config_file) {
                 // Only return if it's a file to handle the unlikely situation of a directory named


### PR DESCRIPTION
Now is possible to have a *hidden* file with name `.rustfmt.toml`. Also due to the parent directory searching it is possible to keep a global `.rustfmt.toml` file in the *home* directory if preferred.

With this **rustfmt** will look for files named either `rustfmt.toml` or `.rustfmt.toml`; But new file names can be easily added if needed.