### PR TITLE
Add two new whitespace options (#1109)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -408,6 +408,9 @@ create_config! {
     match_wildcard_trailing_comma: bool, true, "Put a trailing comma after a wildcard arm";
     closure_block_indent_threshold: isize, 5, "How many lines a closure must have before it is \
                                                block indented. -1 means never use block indent.";
+    space_before_type_annotation: bool, false,
+        "Leave a space before the colon in a type annotation";
+    space_before_bound: bool, false, "Leave a space before the colon in a trait or lifetime bound";
     use_try_shorthand: bool, false, "Replace uses of the try! macro by the ? shorthand";
     write_mode: WriteMode, WriteMode::Replace,
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";

--- a/src/types.rs
+++ b/src/types.rs
@@ -406,7 +406,12 @@ fn rewrite_bounded_lifetime<'b, I>(lt: &ast::Lifetime,
         let appendix: Vec<_> = try_opt!(bounds.into_iter()
             .map(|b| b.rewrite(context, width, offset))
             .collect());
-        let result = format!("{}: {}", result, appendix.join(" + "));
+        let bound_spacing = if context.config.space_before_bound {
+            " "
+        } else {
+            ""
+        };
+        let result = format!("{}{}: {}", result, bound_spacing, appendix.join(" + "));
         wrap_str(result, context.config.max_width, width, offset)
     }
 }
@@ -449,6 +454,9 @@ impl Rewrite for ast::TyParam {
         let mut result = String::with_capacity(128);
         result.push_str(&self.ident.to_string());
         if !self.bounds.is_empty() {
+            if context.config.space_before_bound {
+                result.push_str(" ");
+            }
             result.push_str(": ");
 
             let bounds: String = try_opt!(self.bounds

--- a/tests/source/space-before-bound.rs
+++ b/tests/source/space-before-bound.rs
@@ -1,0 +1,4 @@
+// rustfmt-space_before_bound: true
+
+trait Trait {}
+fn f<'a, 'b: 'a, T: Trait>() {}

--- a/tests/source/space-before-type-annotation.rs
+++ b/tests/source/space-before-type-annotation.rs
@@ -1,0 +1,10 @@
+// rustfmt-space_before_type_annotation: true
+
+static staticVar: i32 = 42;
+const constVar: i32 = 42;
+fn foo(paramVar: i32) {
+    let localVar: i32 = 42;
+}
+struct S {
+    fieldVar: i32,
+}

--- a/tests/target/space-before-bound.rs
+++ b/tests/target/space-before-bound.rs
@@ -1,0 +1,4 @@
+// rustfmt-space_before_bound: true
+
+trait Trait {}
+fn f<'a, 'b : 'a, T : Trait>() {}

--- a/tests/target/space-before-type-annotation.rs
+++ b/tests/target/space-before-type-annotation.rs
@@ -1,0 +1,10 @@
+// rustfmt-space_before_type_annotation: true
+
+static staticVar : i32 = 42;
+const constVar : i32 = 42;
+fn foo(paramVar : i32) {
+    let localVar : i32 = 42;
+}
+struct S {
+    fieldVar : i32,
+}


### PR DESCRIPTION
* An option to leave a space before the colon in a type annotation

* An option to leave a space before the colon in a trait or lifetime bound