### PR TITLE
Fix #1120 - rework how the use list prefix is determined.

### DIFF
--- a/tests/source/issue-1120.rs
+++ b/tests/source/issue-1120.rs
@@ -1,2 +1,9 @@
 // rustfmt-reorder_imports: true
+
+// Ensure that a use at the start of an inline module is correctly formatted.
 mod foo {use bar;}
+
+// Ensure that an indented `use` gets the correct indentation.
+mod foo {
+        use bar;
+}

--- a/tests/source/issue-1120.rs
+++ b/tests/source/issue-1120.rs
@@ -1,0 +1,2 @@
+// rustfmt-reorder_imports: true
+mod foo {use bar;}

--- a/tests/target/issue-1120.rs
+++ b/tests/target/issue-1120.rs
@@ -1,0 +1,4 @@
+// rustfmt-reorder_imports: true
+mod foo {
+    use bar;
+}

--- a/tests/target/issue-1120.rs
+++ b/tests/target/issue-1120.rs
@@ -1,4 +1,11 @@
 // rustfmt-reorder_imports: true
+
+// Ensure that a use at the start of an inline module is correctly formatted.
+mod foo {
+    use bar;
+}
+
+// Ensure that an indented `use` gets the correct indentation.
 mod foo {
     use bar;
 }


### PR DESCRIPTION
This fixes #1120, by ensuring that the start of the prefix before a list of `use` declarations cannot be before the last character processed by the formatter.

The prefix is also trimmed when we can detect that it ends with the indent whitespace of a `use` declaration within a block. 