### PR TITLE
Don't emit filename in diff mode, add filename to diff metadata

### DIFF
--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -144,11 +144,11 @@ pub fn write_file<T>(text: &StringBuffer,
             try!(write_system_newlines(stdout, text, config));
         }
         WriteMode::Diff => {
-            println!("Diff of {}:\n", filename);
             if let Ok((ori, fmt)) = source_and_formatted_text(text, filename, config) {
                 let mismatch = make_diff(&ori, &fmt, 3);
                 let has_diff = !mismatch.is_empty();
-                print_diff(mismatch, |line_num| format!("\nDiff at line {}:", line_num));
+                print_diff(mismatch,
+                           |line_num| format!("Diff in {} at line {}:", filename, line_num));
                 return Ok(has_diff);
             }
         }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -350,3 +350,9 @@ fn rustfmt_diff_make_diff_tests() {
                                     DiffLine::Context("d".into())],
                     }]);
 }
+
+#[test]
+fn rustfmt_diff_no_diff_test() {
+    let diff = make_diff("a\nb\nc\nd", "a\nb\nc\nd", 3);
+    assert_eq!(diff, vec![]);
+}


### PR DESCRIPTION
Addresses #807 - the added test doesn't actually test the changed code, but since its a minor detail and this is not an issue about correctness then I thought it'd be ok.