### PR TITLE
Fix issue 1124 - detect start of output rather than start of input file when writing output source file

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -185,21 +185,16 @@ impl<'a> FmtVisitor<'a> {
             Some(offset) if prev_span_str[..offset].trim().is_empty() => {
                 self.last_pos + BytePos(offset as u32)
             }
-            Some(_) => self.last_pos,
             None if prev_span_str.trim().is_empty() => pos_before_first_use_item,
-            None => self.last_pos,
+            _ => self.last_pos,
         };
         // Look for indent (the line part preceding the use is all whitespace) and excise that
         // from the prefix
         let span_end = match prev_span_str.rfind('\n') {
-            Some(offset) => {
-                if prev_span_str[offset..].trim().is_empty() {
-                    self.last_pos + BytePos(offset as u32)
-                } else {
-                    pos_before_first_use_item
-                }
+            Some(offset) if prev_span_str[offset..].trim().is_empty() => {
+                self.last_pos + BytePos(offset as u32)
             }
-            None => pos_before_first_use_item,
+            _ => pos_before_first_use_item,
         };
 
         self.last_pos = prefix_span_start;

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -178,9 +178,19 @@ impl<'a> FmtVisitor<'a> {
         // Order the imports by view-path & other import path properties
         ordered_use_items.sort_by(|a, b| compare_use_items(a.0, b.0).unwrap());
         // First, output the span before the first import
+        let prev_span_str = self.snippet(codemap::mk_sp(self.last_pos, pos_before_first_use_item));
+        // Look for purely trailing space at the start of the prefix snippet before a linefeed, or
+        // a prefix that's entirely horizontal whitespace.
+        let prefix_span_start = match prev_span_str.find('\n') {
+            Some(offset) if prev_span_str[..offset].trim().is_empty() => {
+                self.last_pos + BytePos(offset as u32)
+            }
+            Some(_) => self.last_pos,
+            None if prev_span_str.trim().is_empty() => pos_before_first_use_item,
+            None => self.last_pos,
+        };
         // Look for indent (the line part preceding the use is all whitespace) and excise that
         // from the prefix
-        let prev_span_str = self.snippet(codemap::mk_sp(self.last_pos, pos_before_first_use_item));
         let span_end = match prev_span_str.rfind('\n') {
             Some(offset) => {
                 if prev_span_str[offset..].trim().is_empty() {
@@ -191,6 +201,8 @@ impl<'a> FmtVisitor<'a> {
             }
             None => pos_before_first_use_item,
         };
+
+        self.last_pos = prefix_span_start;
         self.format_missing(span_end);
         for ordered in ordered_use_items {
             // Fake out the formatter by setting `self.last_pos` to the appropriate location before

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -14,6 +14,10 @@ use syntax::codemap::{self, BytePos, Span, Pos};
 use comment::{CodeCharKind, CommentCodeSlices, rewrite_comment};
 
 impl<'a> FmtVisitor<'a> {
+    fn output_at_start(&self) -> bool {
+        self.buffer.len == 0
+    }
+
     // TODO these format_missing methods are ugly. Refactor and add unit tests
     // for the central whitespace stripping loop.
     pub fn format_missing(&mut self, end: BytePos) {
@@ -25,7 +29,7 @@ impl<'a> FmtVisitor<'a> {
         let config = self.config;
         self.format_missing_inner(end, |this, last_snippet, snippet| {
             this.buffer.push_str(last_snippet.trim_right());
-            if last_snippet == snippet {
+            if last_snippet == snippet && !this.output_at_start() {
                 // No new lines in the snippet.
                 this.buffer.push_str("\n");
             }
@@ -41,7 +45,7 @@ impl<'a> FmtVisitor<'a> {
 
         if start == end {
             // Do nothing if this is the beginning of the file.
-            if start != self.codemap.lookup_char_pos(start).file.start_pos {
+            if !self.output_at_start() {
                 process_last_snippet(self, "", "");
             }
             return;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -559,7 +559,7 @@ impl<'a> FmtVisitor<'a> {
         self.last_pos = filemap.start_pos;
         self.block_indent = Indent::empty();
         self.walk_mod_items(m);
-        self.format_missing(filemap.end_pos);
+        self.format_missing_with_indent(filemap.end_pos);
     }
 
     pub fn get_context(&self) -> RewriteContext {

--- a/tests/config/issue-1124.toml
+++ b/tests/config/issue-1124.toml
@@ -1,0 +1,1 @@
+reorder_imports = true

--- a/tests/source/issue-1124.rs
+++ b/tests/source/issue-1124.rs
@@ -1,3 +1,13 @@
 use d; use c; use b; use a; 
+// The previous line has a space after the `use a;` 
 
 mod a { use d; use c; use b; use a; }
+
+use z;
+
+use y;
+
+
+
+use x;
+use a;

--- a/tests/source/issue-1124.rs
+++ b/tests/source/issue-1124.rs
@@ -1,0 +1,3 @@
+use d; use c; use b; use a; 
+
+mod a { use d; use c; use b; use a; }

--- a/tests/target/issue-1124.rs
+++ b/tests/target/issue-1124.rs
@@ -1,0 +1,11 @@
+use a;
+use b;
+use c;
+use d;
+
+mod a {
+    use a;
+    use b;
+    use c;
+    use d;
+}

--- a/tests/target/issue-1124.rs
+++ b/tests/target/issue-1124.rs
@@ -2,6 +2,7 @@ use a;
 use b;
 use c;
 use d;
+// The previous line has a space after the `use a;`
 
 mod a {
     use a;
@@ -9,3 +10,12 @@ mod a {
     use c;
     use d;
 }
+
+use a;
+
+
+
+use x;
+
+use y;
+use z;


### PR DESCRIPTION
Fix issue 1124 by detecting start of output rather than start of an input file to introduce a newline before a `use`. Also add in code to detect insertion of a span that either

1. contains whitespace directly before a `use`, or
2. contains whitespace running on from the last insertion before a `use` (as a newline will be inserted before the `use` is rendered, so the whitespace will become trailing whitespace on a line).