### PR TITLE
Fix #977

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -34,6 +34,12 @@ impl<'a> FmtVisitor<'a> {
         })
     }
 
+    pub fn format_missing_no_indent(&mut self, end: BytePos) {
+        self.format_missing_inner(end, |this, last_snippet, _| {
+            this.buffer.push_str(last_snippet.trim_right());
+        })
+    }
+
     fn format_missing_inner<F: Fn(&mut FmtVisitor, &str, &str)>(&mut self,
                                                                 end: BytePos,
                                                                 process_last_snippet: F) {

--- a/tests/source/issue-977.rs
+++ b/tests/source/issue-977.rs
@@ -1,0 +1,7 @@
+// FIXME(#919)
+
+trait NameC { /* comment */ }
+struct FooC { /* comment */ }
+enum MooC { /* comment */ }
+mod BarC { /* comment */ }
+extern { /* comment */ }

--- a/tests/target/issue-977.rs
+++ b/tests/target/issue-977.rs
@@ -1,0 +1,15 @@
+// FIXME(#919)
+
+trait NameC {
+    // comment
+}
+struct FooC { /* comment */ }
+enum MooC {
+    // comment
+}
+mod BarC {
+    // comment
+}
+extern "C" {
+    // comment
+}


### PR DESCRIPTION
#977

Maybe we need to format all blocks with a single block-comment like #919, but at least the garbage space before `enum`'s `}` and the missing `{` of `extern` are fixed.