### PR TITLE
Prefer line break at `=`/`in`

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -568,7 +568,7 @@ fn format_impl_ref_and_type(context: &RewriteContext,
                             split_at_for: bool)
                             -> Option<String> {
     if let ast::ItemKind::Impl(unsafety, polarity, ref generics, ref trait_ref, ref self_ty, _) =
-           item.node {
+        item.node {
         let mut result = String::new();
 
         result.push_str(&*format_visibility(&item.vis));
@@ -670,7 +670,7 @@ pub fn format_struct(context: &RewriteContext,
 
 pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) -> Option<String> {
     if let ast::ItemKind::Trait(unsafety, ref generics, ref type_param_bounds, ref trait_items) =
-           item.node {
+        item.node {
         let mut result = String::new();
         let header = format!("{}{}trait {}",
                              format_visibility(&item.vis),

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -285,3 +285,16 @@ fn complex_if_else() {
         yo();
     }
 }
+
+fn issue1106() {
+    {
+    if let hir::ItemEnum(ref enum_def, ref generics) = self.ast_map.expect_item(enum_node_id).node {
+    }
+    }
+
+    for entry in
+    WalkDir::new(path)
+        .into_iter()
+        .filter_entry(|entry| exclusions.filter_entry(entry)) {
+    }
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -55,8 +55,8 @@ fn foo() -> bool {
     }
 
     if let (some_very_large,
-            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1111 +
-                                                                                         2222 {}
+            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) =
+        1111 + 2222 {}
 
     if let (some_very_large,
             tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1 + 2 + 3 {
@@ -283,10 +283,23 @@ fn complex_if_else() {
     } else if xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx + xxxxxxxx {
         yo();
     } else if let Some(x) =
-                  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {
         ha();
     } else if xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx +
               xxxxxxxxx {
         yo();
+    }
+}
+
+fn issue1106() {
+    {
+        if let hir::ItemEnum(ref enum_def, ref generics) =
+            self.ast_map.expect_item(enum_node_id).node {
+        }
+    }
+
+    for entry in WalkDir::new(path)
+        .into_iter()
+        .filter_entry(|entry| exclusions.filter_entry(entry)) {
     }
 }

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -21,8 +21,8 @@ fn main() {
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
     }
 
-    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in some_iter(arg1,
-                                                                                        arg2) {
+    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in
+        some_iter(arg1, arg2) {
         // do smth
     }
 


### PR DESCRIPTION
Fixes #1106

```rust
    if let Some(entry) = WalkDir::new(path)
        .into_iter()
        .filter_entry(|entry| exclusions.filter_entry(entry))
        .next() {
    }
```