### PR TITLE
Two improvements

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -71,6 +71,16 @@ pub fn rewrite_comment(orig: &str,
     let indent_str = offset.to_string(config);
     let line_breaks = s.chars().filter(|&c| c == '\n').count();
 
+    let num_bare_lines = s.lines()
+        .enumerate()
+        .map(|(_, line)| line.trim())
+        .filter(|l| !(l.starts_with('*') || l.starts_with("//") || l.starts_with("/*")))
+        .count();
+
+    if num_bare_lines > 0 && !config.normalize_comments {
+        return Some(orig.to_owned());
+    }
+
     let lines = s.lines()
         .enumerate()
         .map(|(i, mut line)| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -410,7 +410,12 @@ create_config! {
                                                block indented. -1 means never use block indent.";
     space_before_type_annotation: bool, false,
         "Leave a space before the colon in a type annotation";
+    space_after_type_annotation_colon: bool, true,
+        "Leave a space after the colon in a type annotation";
     space_before_bound: bool, false, "Leave a space before the colon in a trait or lifetime bound";
+    space_after_bound_colon: bool, true,
+        "Leave a space after the colon in a trait or lifetime bound";
+    spaces_around_ranges: bool, false, "Put spaces around the  .. and ... range operators";
     use_try_shorthand: bool, false, "Replace uses of the try! macro by the ? shorthand";
     write_mode: WriteMode, WriteMode::Replace,
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -219,13 +219,28 @@ fn format_expr(expr: &ast::Expr,
 
             match (lhs.as_ref().map(|x| &**x), rhs.as_ref().map(|x| &**x)) {
                 (Some(ref lhs), Some(ref rhs)) => {
-                    rewrite_pair(&**lhs, &**rhs, "", delim, "", context, width, offset)
+                    let sp_delim = if context.config.spaces_around_ranges {
+                        format!(" {} ", delim)
+                    } else {
+                        delim.into()
+                    };
+                    rewrite_pair(&**lhs, &**rhs, "", &sp_delim, "", context, width, offset)
                 }
                 (None, Some(ref rhs)) => {
-                    rewrite_unary_prefix(context, delim, &**rhs, width, offset)
+                    let sp_delim = if context.config.spaces_around_ranges {
+                        format!("{} ", delim)
+                    } else {
+                        delim.into()
+                    };
+                    rewrite_unary_prefix(context, &sp_delim, &**rhs, width, offset)
                 }
                 (Some(ref lhs), None) => {
-                    rewrite_unary_suffix(context, delim, &**lhs, width, offset)
+                    let sp_delim = if context.config.spaces_around_ranges {
+                        format!(" {}", delim)
+                    } else {
+                        delim.into()
+                    };
+                    rewrite_unary_suffix(context, &sp_delim, &**lhs, width, offset)
                 }
                 (None, None) => wrap_str(delim.into(), context.config.max_width, width, offset),
             }
@@ -1672,10 +1687,11 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
 }
 
 pub fn type_annotation_separator(config: &Config) -> &str {
-    if config.space_before_type_annotation {
-        " : "
-    } else {
-        ": "
+    match (config.space_before_type_annotation, config.space_after_type_annotation_colon) {
+        (true, true) => " : ",
+        (true, false) => " :",
+        (false, true) => ": ",
+        (false, false) => ":",
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -405,12 +405,21 @@ fn rewrite_bounded_lifetime<'b, I>(lt: &ast::Lifetime,
         let appendix: Vec<_> = try_opt!(bounds.into_iter()
             .map(|b| b.rewrite(context, width, offset))
             .collect());
-        let bound_spacing = if context.config.space_before_bound {
+        let bound_spacing_before = if context.config.space_before_bound {
             " "
         } else {
             ""
         };
-        let result = format!("{}{}: {}", result, bound_spacing, appendix.join(" + "));
+        let bound_spacing_after = if context.config.space_after_bound_colon {
+            " "
+        } else {
+            ""
+        };
+        let result = format!("{}{}:{}{}",
+                             result,
+                             bound_spacing_before,
+                             bound_spacing_after,
+                             appendix.join(" + "));
         wrap_str(result, context.config.max_width, width, offset)
     }
 }
@@ -456,7 +465,10 @@ impl Rewrite for ast::TyParam {
             if context.config.space_before_bound {
                 result.push_str(" ");
             }
-            result.push_str(": ");
+            result.push_str(":");
+            if context.config.space_after_bound_colon {
+                result.push_str(" ");
+            }
 
             let bounds: String = try_opt!(self.bounds
                 .iter()

--- a/tests/source/comment4.rs
+++ b/tests/source/comment4.rs
@@ -33,3 +33,15 @@ fn test() {
   /// test123
 fn doc_comment() {
 }
+
+/*
+Regression test for issue #956
+
+(some very important text)
+*/
+
+/*
+fn debug_function() {
+    println!("hello");
+}
+// */

--- a/tests/source/space-not-after-type-annotation-colon.rs
+++ b/tests/source/space-not-after-type-annotation-colon.rs
@@ -1,0 +1,14 @@
+// rustfmt-space_before_type_annotation: true
+// rustfmt-space_after_type_annotation_colon: false
+
+static staticVar: i32 = 42;
+const constVar: i32 = 42;
+fn foo(paramVar: i32) {
+    let localVar: i32 = 42;
+}
+struct S {
+    fieldVar: i32,
+}
+fn f() {
+    S { fieldVar: 42 }
+}

--- a/tests/source/space-not-before-bound-colon.rs
+++ b/tests/source/space-not-before-bound-colon.rs
@@ -1,0 +1,5 @@
+// rustfmt-space_before_bound: true
+// rustfmt-space_after_bound_colon: false
+
+trait Trait {}
+fn f<'a, 'b: 'a, T: Trait>() {}

--- a/tests/source/spaces-around-ranges.rs
+++ b/tests/source/spaces-around-ranges.rs
@@ -1,0 +1,15 @@
+// rustfmt-spaces_around_ranges: true
+
+fn bar(v: &[u8]) {}
+
+fn foo() {
+    let a = vec![0; 20];
+    for j in 0...20 {
+        for i in 0..3 {
+            bar(a[i..j]);
+            bar(a[i..]);
+            bar(a[..j]);
+            bar(a[...(j + 1)]);
+        }
+    }
+}

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -32,3 +32,15 @@ fn test() {
 
 /// test123
 fn doc_comment() {}
+
+/*
+Regression test for issue #956
+
+(some very important text)
+*/
+
+/*
+fn debug_function() {
+    println!("hello");
+}
+// */

--- a/tests/target/space-not-after-type-annotation-colon.rs
+++ b/tests/target/space-not-after-type-annotation-colon.rs
@@ -1,0 +1,14 @@
+// rustfmt-space_before_type_annotation: true
+// rustfmt-space_after_type_annotation_colon: false
+
+static staticVar :i32 = 42;
+const constVar :i32 = 42;
+fn foo(paramVar :i32) {
+    let localVar :i32 = 42;
+}
+struct S {
+    fieldVar :i32,
+}
+fn f() {
+    S { fieldVar :42 }
+}

--- a/tests/target/space-not-before-bound-colon.rs
+++ b/tests/target/space-not-before-bound-colon.rs
@@ -1,0 +1,5 @@
+// rustfmt-space_before_bound: true
+// rustfmt-space_after_bound_colon: false
+
+trait Trait {}
+fn f<'a, 'b :'a, T :Trait>() {}

--- a/tests/target/spaces-around-ranges.rs
+++ b/tests/target/spaces-around-ranges.rs
@@ -1,0 +1,15 @@
+// rustfmt-spaces_around_ranges: true
+
+fn bar(v: &[u8]) {}
+
+fn foo() {
+    let a = vec![0; 20];
+    for j in 0 ... 20 {
+        for i in 0 .. 3 {
+            bar(a[i .. j]);
+            bar(a[i ..]);
+            bar(a[.. j]);
+            bar(a[... (j + 1)]);
+        }
+    }
+}


### PR DESCRIPTION
First commit: add new options for where to put spaces. I think its not necessary to differentiate between space before range operator and space after, as generally people will want either spaces before and after, or neither.

Second commit is a bugfix for #956