### PR TITLE
Fix #775: Off-by-one overrun in deeply nested function call

### DIFF
--- a/tests/source/tuple.rs
+++ b/tests/source/tuple.rs
@@ -32,3 +32,13 @@ fn issue550() {
     self.visitor.visit_volume(self.level.sector_id(sector), (floor_y,
     if is_sky_flat(ceil_tex) {from_wad_height(self.height_range.1)} else {ceil_y}));
 }
+
+fn issue775() {
+    if indent {
+        let a = mk_object(&[("a".to_string(), Boolean(true)),
+                            ("b".to_string(),
+                             Array(vec![mk_object(&[("c".to_string(),
+                                                     String("\x0c\r".to_string()))]),
+                                        mk_object(&[("d".to_string(), String("".to_string()))])]))]);
+    }
+}

--- a/tests/target/tuple.rs
+++ b/tests/target/tuple.rs
@@ -37,3 +37,14 @@ fn issue550() {
                                    ceil_y
                                }));
 }
+
+fn issue775() {
+    if indent {
+        let a = mk_object(&[("a".to_string(), Boolean(true)),
+                            ("b".to_string(),
+                             Array(vec![mk_object(&[("c".to_string(),
+                                                     String("\x0c\r".to_string()))]),
+                                        mk_object(&[("d".to_string(),
+                                                     String("".to_string()))])]))]);
+    }
+}


### PR DESCRIPTION
Fixes #775.

The actual problem was in the tuple formatting code, `rewrite_tuple` referred to `config.max_width` where `width` passed from caller should be used.