### PR TITLE
Add custom comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -64,7 +64,11 @@ pub fn rewrite_comment(orig: &str,
         } else if orig.starts_with("//!") || orig.starts_with("/*!") {
             ("//! ", "", "//! ")
         } else if is_custom_comment(orig) {
-            (&orig[0..4], "", &orig[0..4])
+            if orig.chars().nth(3) == Some(' ') {
+                (&orig[0..4], "", &orig[0..4])
+            } else {
+                (&orig[0..3], "", &orig[0..3])
+            }
         } else {
             ("// ", "", "// ")
         };
@@ -153,7 +157,7 @@ fn left_trim_comment_line(line: &str) -> &str {
        line.starts_with("/** ") {
         &line[4..]
     } else if is_custom_comment(line) {
-        if line.len() > 3 {
+        if line.len() > 3 && line.chars().nth(3) == Some(' ') {
             &line[4..]
         } else {
             &line[3..]

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -20,6 +20,18 @@ use rewrite::RewriteContext;
 use string::{StringFormat, rewrite_string};
 use utils::wrap_str;
 
+fn is_custom_comment(comment: &str) -> bool {
+    if !comment.starts_with("//") || comment.len() < 4 {
+        false
+    } else {
+        if let Some(c) = comment.chars().nth(2) {
+            !c.is_alphanumeric() && !c.is_whitespace()
+        } else {
+            false
+        }
+    }
+}
+
 pub fn rewrite_comment(orig: &str,
                        block_style: bool,
                        width: usize,
@@ -51,6 +63,8 @@ pub fn rewrite_comment(orig: &str,
             ("/// ", "", "/// ")
         } else if orig.starts_with("//!") || orig.starts_with("/*!") {
             ("//! ", "", "//! ")
+        } else if is_custom_comment(orig) {
+            (&orig[0..4], "", &orig[0..4])
         } else {
             ("// ", "", "// ")
         };
@@ -136,7 +150,7 @@ pub fn rewrite_comment(orig: &str,
 
 fn left_trim_comment_line(line: &str) -> &str {
     if line.starts_with("//! ") || line.starts_with("/// ") || line.starts_with("/*! ") ||
-       line.starts_with("/** ") {
+       line.starts_with("/** ") || is_custom_comment(line) {
         &line[4..]
     } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
               line.starts_with("///") ||

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -21,7 +21,7 @@ use string::{StringFormat, rewrite_string};
 use utils::wrap_str;
 
 fn is_custom_comment(comment: &str) -> bool {
-    if !comment.starts_with("//") || comment.len() < 4 {
+    if !comment.starts_with("//") {
         false
     } else {
         if let Some(c) = comment.chars().nth(2) {
@@ -150,8 +150,14 @@ pub fn rewrite_comment(orig: &str,
 
 fn left_trim_comment_line(line: &str) -> &str {
     if line.starts_with("//! ") || line.starts_with("/// ") || line.starts_with("/*! ") ||
-       line.starts_with("/** ") || is_custom_comment(line) {
+       line.starts_with("/** ") {
         &line[4..]
+    } else if is_custom_comment(line) {
+        if line.len() > 3 {
+            &line[4..]
+        } else {
+            &line[3..]
+        }
     } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
               line.starts_with("///") ||
               line.starts_with("** ") || line.starts_with("/*!") ||

--- a/tests/source/comment5.rs
+++ b/tests/source/comment5.rs
@@ -1,0 +1,5 @@
+// rustfmt-wrap_comments: true
+
+//@ special comment
+//@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+fn test() {}

--- a/tests/source/comment5.rs
+++ b/tests/source/comment5.rs
@@ -2,4 +2,5 @@
 
 //@ special comment
 //@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+//@
 fn test() {}

--- a/tests/source/comment5.rs
+++ b/tests/source/comment5.rs
@@ -3,4 +3,5 @@
 //@ special comment
 //@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
 //@
+//@foo
 fn test() {}

--- a/tests/target/comment5.rs
+++ b/tests/target/comment5.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+//@ special comment
+//@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam
+//@ lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+fn test() {}

--- a/tests/target/comment5.rs
+++ b/tests/target/comment5.rs
@@ -4,4 +4,5 @@
 //@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam
 //@ lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
 //@
+//@ foo
 fn test() {}

--- a/tests/target/comment5.rs
+++ b/tests/target/comment5.rs
@@ -3,4 +3,5 @@
 //@ special comment
 //@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec adiam
 //@ lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+//@
 fn test() {}


### PR DESCRIPTION
This allows users to use custom comments such as

```
//@ this is a custom comment
//@ with multiple lines
```

without having them destroyed by rustfmt.