### PR TITLE
Preserve macro formatting if we can't rewrite it

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,7 +30,6 @@ use codemap::SpanUtils;
 use rewrite::{Rewrite, RewriteContext};
 use expr::{rewrite_call, rewrite_array};
 use comment::{FindUncommented, contains_comment};
-use utils::wrap_str;
 
 const FORCED_BRACKET_MACROS: &'static [&'static str] = &["vec!"];
 
@@ -141,10 +140,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
         }
         MacroStyle::Braces => {
             // Skip macro invocations with braces, for now.
-            wrap_str(context.snippet(mac.span),
-                     context.config.max_width,
-                     width,
-                     offset)
+            None
         }
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -66,7 +66,6 @@ impl<'a> FmtVisitor<'a> {
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, _macro_style, _) = **mac;
-                self.format_missing_with_indent(source!(self, stmt.span).lo);
                 self.visit_mac(mac, None);
             }
         }
@@ -281,7 +280,6 @@ impl<'a> FmtVisitor<'a> {
                 self.format_mod(module, &item.vis, item.span, item.ident);
             }
             ast::ItemKind::Mac(ref mac) => {
-                self.format_missing_with_indent(source!(self, item.span).lo);
                 self.visit_mac(mac, Some(item.ident));
             }
             ast::ItemKind::ForeignMod(ref foreign_mod) => {
@@ -418,7 +416,6 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(ii.span, rewrite);
             }
             ast::ImplItemKind::Macro(ref mac) => {
-                self.format_missing_with_indent(source!(self, ii.span).lo);
                 self.visit_mac(mac, Some(ii.ident));
             }
         }
@@ -428,11 +425,7 @@ impl<'a> FmtVisitor<'a> {
         // 1 = ;
         let width = self.config.max_width - self.block_indent.width() - 1;
         let rewrite = rewrite_macro(mac, ident, &self.get_context(), width, self.block_indent);
-
-        if let Some(res) = rewrite {
-            self.buffer.push_str(&res);
-            self.last_pos = source!(self, mac.span).hi;
-        }
+        self.push_rewrite(mac.span, rewrite);
     }
 
     fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -50,6 +50,11 @@ fn main() {
     some_macro!{
         // comment
     };
+
+    some_macro!(
+        // comment
+        not function like
+    );
 }
 
 impl X {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -53,6 +53,11 @@ fn main() {
     some_macro!{
         // comment
     };
+
+    some_macro!(
+        // comment
+        not function like
+    );
 }
 
 impl X {


### PR DESCRIPTION
Fixes #1149 