### PR TITLE
Stop extra newlines from being added after block comments

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -144,8 +144,13 @@ impl<'a> FmtVisitor<'a> {
                     line_start = offset + subslice.len();
 
                     if let Some('/') = subslice.chars().skip(1).next() {
-                        // Add a newline after line comments
-                        self.buffer.push_str("\n");
+                        // check that there are no contained block comments
+                        if !subslice.split('\n')
+                            .map(|s| s.trim_left())
+                            .any(|s| s.len() > 2 && &s[0..2] == "/*") {
+                            // Add a newline after line comments
+                            self.buffer.push_str("\n");
+                        }
                     } else if line_start <= snippet.len() {
                         // For other comments add a newline if there isn't one at the end already
                         match snippet[line_start..].chars().next() {

--- a/tests/source/issue-1177.rs
+++ b/tests/source/issue-1177.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Line Comment
+    /* Block Comment */
+
+    let d = 5;
+}

--- a/tests/target/issue-1177.rs
+++ b/tests/target/issue-1177.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Line Comment
+    // Block Comment
+
+    let d = 5;
+}


### PR DESCRIPTION
This PR closes #1177. Essentially rustfmt was reformatting the whole string of `// comment \n    /* block comment */`, but was only checking the beginning of that string to determine whether it was a line comment or not, and thus adding the extra newline.