### PR TITLE
Add support for spaces_within_parens config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -416,6 +416,7 @@ create_config! {
     space_after_bound_colon: bool, true,
         "Leave a space after the colon in a trait or lifetime bound";
     spaces_around_ranges: bool, false, "Put spaces around the  .. and ... range operators";
+    spaces_within_parens: bool, false, "Put spaces within non-empty parentheses";
     use_try_shorthand: bool, false, "Replace uses of the try! macro by the ? shorthand";
     write_mode: WriteMode, WriteMode::Replace,
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1536,11 +1536,11 @@ fn rewrite_call_inner<R>(context: &RewriteContext,
         None => return Err(Ordering::Less),
     };
 
-    if context.config.spaces_within_parens && list_str.len() > 0 {
-        Ok(format!("{}( {} )", callee_str, list_str))
+    Ok(if context.config.spaces_within_parens && list_str.len() > 0 {
+        format!("{}( {} )", callee_str, list_str)
     } else {
-        Ok(format!("{}({})", callee_str, list_str))
-    }
+        format!("{}({})", callee_str, list_str)
+    })
 }
 
 fn rewrite_paren(context: &RewriteContext,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1536,7 +1536,11 @@ fn rewrite_call_inner<R>(context: &RewriteContext,
         None => return Err(Ordering::Less),
     };
 
-    Ok(format!("{}({})", callee_str, list_str))
+    if context.config.spaces_within_parens && list_str.len() > 0 {
+        Ok(format!("{}( {} )", callee_str, list_str))
+    } else {
+        Ok(format!("{}({})", callee_str, list_str))
+    }
 }
 
 fn rewrite_paren(context: &RewriteContext,
@@ -1549,7 +1553,12 @@ fn rewrite_paren(context: &RewriteContext,
     // paren on the same line as the subexpr.
     let subexpr_str = subexpr.rewrite(context, try_opt!(width.checked_sub(2)), offset + 1);
     debug!("rewrite_paren, subexpr_str: `{:?}`", subexpr_str);
-    subexpr_str.map(|s| format!("({})", s))
+
+    subexpr_str.map(|s| if context.config.spaces_within_parens && s.len() > 0 {
+        format!("( {} )", s)
+    } else {
+        format!("({})", s)
+    })
 }
 
 fn rewrite_struct_lit<'a>(context: &RewriteContext,
@@ -1749,7 +1758,11 @@ pub fn rewrite_tuple<'a, I>(context: &RewriteContext,
         return items.next()
             .unwrap()
             .rewrite(&aligned, budget, indent)
-            .map(|s| format!("({},)", s));
+            .map(|s| if context.config.spaces_within_parens {
+                format!("( {}, )", s)
+            } else {
+                format!("({},)", s)
+            });
     }
 
     let list_lo = context.codemap.span_after(span, "(");
@@ -1764,7 +1777,11 @@ pub fn rewrite_tuple<'a, I>(context: &RewriteContext,
                              span.hi - BytePos(1));
     let list_str = try_opt!(format_item_list(items, budget, indent, context.config));
 
-    Some(format!("({})", list_str))
+    if context.config.spaces_within_parens && list_str.len() > 0 {
+        Some(format!("( {} )", list_str))
+    } else {
+        Some(format!("({})", list_str))
+    }
 }
 
 fn rewrite_binary_op(context: &RewriteContext,

--- a/src/items.rs
+++ b/src/items.rs
@@ -961,7 +961,17 @@ fn format_tuple_struct(context: &RewriteContext,
                              context.codemap.span_after(span, "("),
                              span.hi);
     let body = try_opt!(format_item_list(items, item_budget, item_indent, context.config));
+
+    if context.config.spaces_within_parens && body.len() > 0 {
+        result.push(' ');
+    }
+
     result.push_str(&body);
+
+    if context.config.spaces_within_parens && body.len() > 0 {
+        result.push(' ');
+    }
+
     result.push(')');
 
     if !where_clause_str.is_empty() && !where_clause_str.contains('\n') &&
@@ -1386,12 +1396,18 @@ fn rewrite_fn_base(context: &RewriteContext,
             result.push_str(&arg_indent.to_string(context.config));
             arg_indent = arg_indent + 1; // extra space for `(`
             result.push('(');
+            if context.config.spaces_within_parens && fd.inputs.len() > 0 {
+                result.push(' ')
+            }
         } else {
             result.push_str("(\n");
             result.push_str(&arg_indent.to_string(context.config));
         }
     } else {
         result.push('(');
+        if context.config.spaces_within_parens && fd.inputs.len() > 0 {
+            result.push(' ')
+        }
     }
 
     if multi_line_ret_str {
@@ -1432,6 +1448,9 @@ fn rewrite_fn_base(context: &RewriteContext,
         result.push(')');
     } else {
         result.push_str(&arg_str);
+        if context.config.spaces_within_parens && fd.inputs.len() > 0 {
+            result.push(' ')
+        }
         result.push(')');
     }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -234,10 +234,20 @@ fn rewrite_tuple_pat(pats: &[ptr::P<ast::Pat>],
         let list = try_opt!(format_item_list(items, width, offset, context.config));
 
         match path_str {
-            Some(path_str) => Some(format!("{}({})", path_str, list)),
+            Some(path_str) => {
+                if context.config.spaces_within_parens {
+                    Some(format!("{}( {} )", path_str, list))
+                } else {
+                    Some(format!("{}({})", path_str, list))
+                }
+            }
             None => {
                 let comma = if add_comma { "," } else { "" };
-                Some(format!("({}{})", list, comma))
+                if context.config.spaces_within_parens {
+                    Some(format!("( {}{} )", list, comma))
+                } else {
+                    Some(format!("({}{})", list, comma))
+                }
             }
         }
     }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -235,19 +235,19 @@ fn rewrite_tuple_pat(pats: &[ptr::P<ast::Pat>],
 
         match path_str {
             Some(path_str) => {
-                if context.config.spaces_within_parens {
-                    Some(format!("{}( {} )", path_str, list))
+                Some(if context.config.spaces_within_parens {
+                    format!("{}( {} )", path_str, list)
                 } else {
-                    Some(format!("{}({})", path_str, list))
-                }
+                    format!("{}({})", path_str, list)
+                })
             }
             None => {
                 let comma = if add_comma { "," } else { "" };
-                if context.config.spaces_within_parens {
-                    Some(format!("( {}{} )", list, comma))
+                Some(if context.config.spaces_within_parens {
+                    format!("( {}{} )", list, comma)
                 } else {
-                    Some(format!("({}{})", list, comma))
-                }
+                    format!("({}{})", list, comma)
+                })
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -311,11 +311,11 @@ fn format_function_type<'a, I>(inputs: I,
         String::new()
     };
 
-    if context.config.spaces_within_parens {
-        Some(format!("( {} ){}{}", list_str, infix, output))
+    Some(if context.config.spaces_within_parens {
+        format!("( {} ){}{}", list_str, infix, output)
     } else {
-        Some(format!("({}){}{}", list_str, infix, output))
-    }
+        format!("({}){}{}", list_str, infix, output)
+    })
 }
 
 impl Rewrite for ast::WherePredicate {

--- a/src/types.rs
+++ b/src/types.rs
@@ -311,7 +311,11 @@ fn format_function_type<'a, I>(inputs: I,
         String::new()
     };
 
-    Some(format!("({}){}{}", list_str, infix, output))
+    if context.config.spaces_within_parens {
+        Some(format!("( {} ){}{}", list_str, infix, output))
+    } else {
+        Some(format!("({}){}{}", list_str, infix, output))
+    }
 }
 
 impl Rewrite for ast::WherePredicate {
@@ -575,7 +579,12 @@ impl Rewrite for ast::Ty {
             // comments.
             ast::TyKind::Paren(ref ty) => {
                 let budget = try_opt!(width.checked_sub(2));
-                ty.rewrite(context, budget, offset + 1).map(|ty_str| format!("({})", ty_str))
+                ty.rewrite(context, budget, offset + 1)
+                    .map(|ty_str| if context.config.spaces_within_parens {
+                        format!("( {} )", ty_str)
+                    } else {
+                        format!("({})", ty_str)
+                    })
             }
             ast::TyKind::Vec(ref ty) => {
                 let budget = try_opt!(width.checked_sub(2));

--- a/tests/source/spaces-within-parens.rs
+++ b/tests/source/spaces-within-parens.rs
@@ -7,6 +7,10 @@ enum E {
     D(),
 }
 
+struct TupleStruct0();
+struct TupleStruct1(u32);
+struct TupleStruct2(u32, u32);
+
 fn fooEmpty() {}
 
 fn foo(e: E, _: u32) -> (u32, u32) {
@@ -15,6 +19,10 @@ fn foo(e: E, _: u32) -> (u32, u32) {
     let t1 = ();
     let t2 = (1,);
     let t3 = (1, 2);
+
+    let ts0 = TupleStruct0();
+    let ts1 = TupleStruct1(1);
+    let ts2 = TupleStruct2(1, 2);
 
     // Tuple pattern
     let (a,b,c) = (1,2,3);

--- a/tests/source/spaces-within-parens.rs
+++ b/tests/source/spaces-within-parens.rs
@@ -1,0 +1,38 @@
+// rustfmt-spaces_within_parens: true
+
+enum E {
+    A(u32),
+    B(u32, u32),
+    C(u32, u32, u32),
+    D(),
+}
+
+fn fooEmpty() {}
+
+fn foo(e: E, _: u32) -> (u32, u32) {
+
+    // Tuples
+    let t1 = ();
+    let t2 = (1,);
+    let t3 = (1, 2);
+
+    // Tuple pattern
+    let (a,b,c) = (1,2,3);
+
+    // Expressions
+    let x = (1 + 2) * (3);
+
+    // Function call
+    fooEmpty();
+    foo(1, 2);
+
+    // Pattern matching
+    match e {
+        A(_) => (),
+        B(_, _) => (),
+        C(..) => (),
+        D => (),
+    }
+
+    (1,2)
+}

--- a/tests/target/spaces-within-parens.rs
+++ b/tests/target/spaces-within-parens.rs
@@ -1,0 +1,38 @@
+// rustfmt-spaces_within_parens: true
+
+enum E {
+    A( u32 ),
+    B( u32, u32 ),
+    C( u32, u32, u32 ),
+    D(),
+}
+
+fn fooEmpty() {}
+
+fn foo( e: E, _: u32 ) -> ( u32, u32 ) {
+
+    // Tuples
+    let t1 = ();
+    let t2 = ( 1, );
+    let t3 = ( 1, 2 );
+
+    // Tuple pattern
+    let ( a, b, c ) = ( 1, 2, 3 );
+
+    // Expressions
+    let x = ( 1 + 2 ) * ( 3 );
+
+    // Function call
+    fooEmpty();
+    foo( 1, 2 );
+
+    // Pattern matching
+    match e {
+        A( _ ) => (),
+        B( _, _ ) => (),
+        C( .. ) => (),
+        D => (),
+    }
+
+    ( 1, 2 )
+}

--- a/tests/target/spaces-within-parens.rs
+++ b/tests/target/spaces-within-parens.rs
@@ -7,6 +7,10 @@ enum E {
     D(),
 }
 
+struct TupleStruct0();
+struct TupleStruct1( u32 );
+struct TupleStruct2( u32, u32 );
+
 fn fooEmpty() {}
 
 fn foo( e: E, _: u32 ) -> ( u32, u32 ) {
@@ -15,6 +19,10 @@ fn foo( e: E, _: u32 ) -> ( u32, u32 ) {
     let t1 = ();
     let t2 = ( 1, );
     let t3 = ( 1, 2 );
+
+    let ts0 = TupleStruct0();
+    let ts1 = TupleStruct1( 1 );
+    let ts2 = TupleStruct2( 1, 2 );
 
     // Tuple pattern
     let ( a, b, c ) = ( 1, 2, 3 );


### PR DESCRIPTION
Adds rule for enforcing spaces with parentheses.

I feel the implementation is a bit noisy - requiring config checks in several places thanks to the parentheses being written in several places.

Also if there's some test cases I missed, please mention those and I'll add 'em.

```
let x = (1 + 2)
// into
let x = ( 1 + 2 )

foo(1, 2, 3)
// into
foo( 1, 2, 3 )

let (a, b, c) = (d, e, f)
// into
let ( a, b, c ) = ( d, e, f )
```

but

```rust
foo()
()
```