### PR TITLE
Fixes #1184 where reordering import items could cause a panic.

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -275,14 +275,14 @@ enum CharClassesStatus {
     LineComment,
 }
 
-/// Distinguish between functionnal part of code and comments
+/// Distinguish between functional part of code and comments
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum CodeCharKind {
     Normal,
     Comment,
 }
 
-/// Distinguish between functionnal part of code and comments,
+/// Distinguish between functional part of code and comments,
 /// describing opening and closing of comments for ease when chunking
 /// code from tagged characters
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -158,7 +158,10 @@ impl<'a> FmtVisitor<'a> {
         // Find the location immediately before the first use item in the run. This must not lie
         // before the current `self.last_pos`
         let pos_before_first_use_item = use_items.first()
-            .map(|p_i| cmp::max(self.last_pos, p_i.span.lo))
+            .map(|p_i| {
+                cmp::max(self.last_pos,
+                         p_i.attrs.iter().map(|attr| attr.span.lo).min().unwrap_or(p_i.span.lo))
+            })
             .unwrap_or(self.last_pos);
         // Construct a list of pairs, each containing a `use` item and the start of span before
         // that `use` item.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -179,7 +179,7 @@ impl<'a> FmtVisitor<'a> {
     pub fn visit_item(&mut self, item: &ast::Item) {
         // This is where we bail out if there is a skip attribute. This is only
         // complex in the module case. It is complex because the module could be
-        // in a seperate file and there might be attributes in both files, but
+        // in a separate file and there might be attributes in both files, but
         // the AST lumps them all together.
         match item.node {
             ast::ItemKind::Mod(ref m) => {

--- a/tests/source/imports-reorder-lines-and-items.rs
+++ b/tests/source/imports-reorder-lines-and-items.rs
@@ -1,6 +1,7 @@
 // rustfmt-reorder_imports: true
 // rustfmt-reorder_imported_names: true
 
+/// This comment should stay with `use std::str;`
 use std::str;
 use std::cmp::{d, c, b, a};
 use std::ddd::aaa;

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -33,7 +33,7 @@ fn get_path_string(dir_entry: io::Result<fs::DirEntry>) -> String {
 
 // Integration tests. The files in the tests/source are formatted and compared
 // to their equivalent in tests/target. The target file and config can be
-// overriden by annotations in the source file. The input and output must match
+// overridden by annotations in the source file. The input and output must match
 // exactly.
 // FIXME(#28) would be good to check for error messages and fail on them, or at
 // least report.

--- a/tests/target/imports-reorder-lines-and-items.rs
+++ b/tests/target/imports-reorder-lines-and-items.rs
@@ -6,4 +6,5 @@ use std::ddd::{a, b, c as g, d as p};
 use std::ddd::aaa;
 // This comment should stay with `use std::ddd:bbb;`
 use std::ddd::bbb;
+/// This comment should stay with `use std::str;`
 use std::str;


### PR DESCRIPTION
Where the first `use` statement in a file is prefixed with an attribute or doc comment, this is not accounted for when calculating the start position for reordering imports for that file.

This PR uses the lowest position out of all the attributes for the first item, or the item's own lowest position if it has no attributes.

Without the fix, the amended test fails with the message:
```
thread 'system_tests' panicked at 'Request to format inverted span: Loc { file: FileMap(tests/source/imports-reorder-lines-and-items.rs), line: 5, col: CharPos(0) } to Loc { file: FileMap(tests/source/imports-reorder-lines-and-items.rs), line: 4, col: CharPos(0) }', src/missed_spans.rs:60
```