### PR TITLE
Stripping trailing commas and spaces from `vec!` elements

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -114,7 +114,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
             parser.bump();
 
             if parser.token == Token::Eof {
-                if style == MacroStyle::Brackets {
+                if macro_name == "vec!" {
                     break;
                 } else {
                     return None;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -114,6 +114,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
             parser.bump();
 
             if parser.token == Token::Eof {
+                // vec! is a special case of bracket macro which should be formated as an array.
                 if macro_name == "vec!" {
                     break;
                 } else {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -114,7 +114,11 @@ pub fn rewrite_macro(mac: &ast::Mac,
             parser.bump();
 
             if parser.token == Token::Eof {
-                return None;
+                if style == MacroStyle::Brackets {
+                    break;
+                } else {
+                    return None;
+                }
             }
         }
     }

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -28,6 +28,11 @@ fn main() {
 
     vec! [a /* comment */];
 
+    // Trailing spaces after a comma
+    vec![
+    a,   
+    ];
+    
     foo(makro!(1,   3));
 
     hamkaas!{ () };

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -33,6 +33,10 @@ fn main() {
     a,   
     ];
     
+    unknown_bracket_macro__comma_should_not_be_stripped![
+    a,
+    ];
+    
     foo(makro!(1,   3));
 
     hamkaas!{ () };

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -37,6 +37,10 @@ fn main() {
     // Trailing spaces after a comma
     vec![a];
 
+    unknown_bracket_macro__comma_should_not_be_stripped![
+    a,
+    ];
+
     foo(makro!(1, 3));
 
     hamkaas!{ () };

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -34,6 +34,9 @@ fn main() {
 
     vec![a /* comment */];
 
+    // Trailing spaces after a comma
+    vec![a];
+
     foo(makro!(1, 3));
 
     hamkaas!{ () };


### PR DESCRIPTION
Fixes issues https://github.com/rust-lang-nursery/rustfmt/issues/878 and https://github.com/rust-lang-nursery/rustfmt/issues/1034