### PR TITLE
fix #1216: panic on comment starting with //*

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -366,7 +366,13 @@ impl<'a, T, I, F1, F2, F3> Iterator for ListItems<'a, I, F1, F2, F3>
 
             let comment_end = match self.inner.peek() {
                 Some(..) => {
-                    let block_open_index = post_snippet.find("/*");
+                    let mut block_open_index = post_snippet.find("/*");
+                    // check if it realy is a block comment (and not //*)
+                    if let Some(i) = block_open_index {
+                        if i > 0 && &post_snippet[i - 1..i] == "/" {
+                            block_open_index = None;
+                        }
+                    }
                     let newline_index = post_snippet.find('\n');
                     let separator_index = post_snippet.find_uncommented(",").unwrap();
 

--- a/tests/source/issue-1216.rs
+++ b/tests/source/issue-1216.rs
@@ -1,0 +1,4 @@
+enum E {
+    A, //* I am not a block comment (caused panic)
+    B,
+}

--- a/tests/target/issue-1216.rs
+++ b/tests/target/issue-1216.rs
@@ -1,0 +1,4 @@
+enum E {
+    A, //* I am not a block comment (caused panic)
+    B,
+}


### PR DESCRIPTION
The problem is that the comment is interpreted as a block commend and it panics because there is no ending.

This fixes it, but I'm not sure if this is a good solution.
Please feel free to decline the request and suggest a better solution.

There does not seem to be a second place where a similar `find("/*")` appears.

Thx