### PR TITLE
Issue 549 - format!-like macros formating

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1531,13 +1531,16 @@ fn rewrite_call_inner<R>(context: &RewriteContext,
         }
         (false, _, _) => {}
     }
+    
+    // 1 is for semicolon
+    let list_width = width.checked_sub(callee_str.len() + 1).unwrap_or(width);
 
     let fmt = ListFormatting {
         tactic: tactic,
         separator: ",",
         trailing_separator: SeparatorTactic::Never,
         indent: offset,
-        width: width,
+        width: list_width,
         ends_with_newline: false,
         config: context.config,
     };

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -35,6 +35,9 @@ use syntax::{ast, ptr};
 use syntax::codemap::{CodeMap, Span, BytePos, mk_sp};
 use syntax::parse::classify;
 
+const FORMAT_LIKE_MACROS: &'static [&'static str] = 
+    &["format!","format_args!", "panic!", "print!", "println!"];
+
 impl Rewrite for ast::Expr {
     fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String> {
         format_expr(self, ExprType::SubExpression, context, width, offset)
@@ -719,11 +722,7 @@ impl<'a> Rewrite for Loop<'a> {
             .rewrite(context, block_width, offset)
             .map(|result| {
                 format!("{}{}{}{}{}",
-                        label_string,
-                        self.keyword,
-                        pat_expr_string,
-                        block_sep,
-                        result)
+                        label_string, self.keyword, pat_expr_string, block_sep, result)
             })
     }
 }
@@ -745,8 +744,7 @@ fn extract_comment(span: Span,
         let comment =
             try_opt!(rewrite_comment(comment_str.trim(), false, width, offset, context.config));
         Some(format!("\n{indent}{}\n{indent}",
-                     comment,
-                     indent = offset.to_string(context.config)))
+                     comment, indent = offset.to_string(context.config)))
     } else {
         None
     }
@@ -816,10 +814,8 @@ fn rewrite_if_else(context: &RewriteContext,
         _ => " ",
     };
     let mut result = format!("if{}{}{}{}",
-                             between_if_cond_comment.as_ref().map_or(" ", |str| &**str),
-                             pat_expr_string,
-                             after_cond_comment.as_ref().map_or(after_sep, |str| &**str),
-                             if_block_string);
+                             between_if_cond_comment.as_ref().map_or(" ", |str| &**str), pat_expr_string,
+                             after_cond_comment.as_ref().map_or(after_sep, |str| &**str), if_block_string);
 
     if let Some(else_block) = else_block_opt {
         let mut last_in_chain = false;
@@ -920,9 +916,7 @@ fn single_line_if_else(context: &RewriteContext,
 
         if fits_line && !if_str.contains('\n') && !else_str.contains('\n') {
             return Some(format!("if {} {{ {} }} else {{ {} }}",
-                                pat_expr_str,
-                                if_str,
-                                else_str));
+                                pat_expr_str, if_str, else_str));
         }
     }
 
@@ -1517,10 +1511,14 @@ fn rewrite_call_inner<R>(context: &RewriteContext,
         }
     }
 
-    let tactic = definitive_tactic(&item_vec,
-                                   ListTactic::LimitedHorizontalVertical(context.config
-                                       .fn_call_width),
-                                   remaining_width);
+    
+    let list_tactic = if FORMAT_LIKE_MACROS.contains(&&callee_str[..]) {
+        ListTactic::FormatLikeMacroCall(context.config.fn_call_width)
+    } else {
+        ListTactic::LimitedHorizontalVertical(context.config.fn_call_width)
+    };
+
+    let tactic = definitive_tactic(&item_vec, list_tactic, remaining_width);
 
     // Replace the stub with the full overflowing last argument if the rewrite
     // succeeded and its first line fits with the other arguments.

--- a/tests/source/issue-549.rs
+++ b/tests/source/issue-549.rs
@@ -1,0 +1,13 @@
+fn main() {
+    format!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
+
+    format!("Many arguments: {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10", "arg11", "arg12", "arg13", "arg14", "arg15");
+
+    format_args!("This is one {} looooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
+    
+    panic!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
+    
+    print!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
+    
+    println!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
+}

--- a/tests/source/issue-549.rs
+++ b/tests/source/issue-549.rs
@@ -2,6 +2,8 @@ fn main() {
     format!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
 
     format!("Many arguments: {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10", "arg11", "arg12", "arg13", "arg14", "arg15");
+    
+    format!("Many short arguments to test wrap: {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", a, a, a, a, a, a);
 
     format_args!("This is one {} looooooooooooooooooooooooooooooooooooooooooooooooong {} for {}", "very", "string", "test");
     

--- a/tests/target/issue-549.rs
+++ b/tests/target/issue-549.rs
@@ -1,0 +1,20 @@
+fn main() {
+    format!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
+            "very", "string", "test");
+
+    format!("Many arguments: {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
+            "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10",
+            "arg11", "arg12", "arg13", "arg14", "arg15");
+
+    format_args!("This is one {} looooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
+                 "very", "string", "test");
+
+    panic!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
+           "very", "string", "test");
+
+    print!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
+           "very", "string", "test");
+
+    println!("This is one {} loooooooooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
+             "very", "string", "test");
+}

--- a/tests/target/issue-549.rs
+++ b/tests/target/issue-549.rs
@@ -6,6 +6,10 @@ fn main() {
             "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10",
             "arg11", "arg12", "arg13", "arg14", "arg15");
 
+    format!("Many short arguments to test wrap: {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
+            "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", a, a, a, a, a,
+            a);
+
     format_args!("This is one {} looooooooooooooooooooooooooooooooooooooooooooooooong {} for {}",
                  "very", "string", "test");
 

--- a/tests/target/string_punctuation.rs
+++ b/tests/target/string_punctuation.rs
@@ -2,11 +2,7 @@ fn main() {
     println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:\
               Likethisssssssssssss");
     format!("{}__{}__{}ItShouldOnlyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyNoticeSemicolonsPeriodsColonsAndCommasAndResortToMid-CharBreaksAfterPunctuation{}{}",
-            x,
-            y,
-            z,
-            a,
-            b);
+            x, y, z, a, b);
     println!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaalhijalfhiigjapdighjapdigjapdighdapighapdighpaidhg;\
               adopgihadoguaadbadgad,qeoihapethae8t0aet8haetadbjtaeg;\
               ooeouthaoeutgadlgajduabgoiuadogabudogubaodugbadgadgadga;adoughaoeugbaouea");


### PR DESCRIPTION
Format `format!`,`format_args!`, `panic!`, `print!`, `println!` calls as described in https://github.com/rust-lang-nursery/rustfmt/issues/549


