### PR TITLE
Fix #1258

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -839,7 +839,18 @@ fn format_struct_struct(context: &RewriteContext,
 
     // FIXME(#919): properly format empty structs and their comments.
     if fields.is_empty() {
-        result.push_str(&context.snippet(mk_sp(body_lo, span.hi)));
+        let snippet = context.snippet(mk_sp(body_lo, span.hi - BytePos(1)));
+        if snippet.trim().is_empty() {
+            // `struct S {}`
+        } else if snippet.trim_right_matches(&[' ', '\t'][..]).ends_with('\n') {
+            // fix indent
+            result.push_str(&snippet.trim_right());
+            result.push('\n');
+            result.push_str(&offset.to_string(context.config));
+        } else {
+            result.push_str(&snippet);
+        }
+        result.push('}');
         return Some(result);
     }
 

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -158,4 +158,10 @@ struct Foo {
 struct Foo {
     // comment
     }
+struct Foo {
+    // trailing space ->    
+
+
+    }
+struct Foo { /* comment */ }
 struct Foo();

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -153,4 +153,9 @@ struct Issue677 {
 }
 
 struct Foo {}
+struct Foo {
+    }
+struct Foo {
+    // comment
+    }
 struct Foo();

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -165,4 +165,8 @@ struct Foo {}
 struct Foo {
     // comment
 }
+struct Foo {
+    // trailing space ->
+}
+struct Foo { /* comment */ }
 struct Foo();

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -161,4 +161,8 @@ struct Issue677 {
 }
 
 struct Foo {}
+struct Foo {}
+struct Foo {
+    // comment
+}
 struct Foo();


### PR DESCRIPTION
#1258

Checking if newline exists to preserve this code as is (tested in `issue-977.rs`).

```rust
struct Foo { /* comment */ }
```