### PR TITLE
Handle multiline condition in let if else (fixes #1239)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -895,7 +895,7 @@ impl<'a> Rewrite for ControlFlow<'a> {
         let block_sep = if self.cond.is_none() && between_kwd_cond_comment.is_some() {
             ""
         } else if context.config.control_brace_style ==
-                                  ControlBraceStyle::AlwaysNextLine {
+                  ControlBraceStyle::AlwaysNextLine {
             alt_block_sep.as_str()
         } else {
             " "
@@ -912,6 +912,15 @@ impl<'a> Rewrite for ControlFlow<'a> {
                                  block_str);
 
         if let Some(else_block) = self.else_block {
+            // Since this is an else block, we should not indent for the assignment preceding
+            // the original if, so set shape.indent.alignment to 0.
+            let shape = Shape {
+                width: shape.width,
+                indent: Indent {
+                    block_indent: shape.indent.block_indent,
+                    alignment: 0,
+                },
+            };
             let mut last_in_chain = false;
             let rewrite = match else_block.node {
                 // If the else expression is another if-else expression, prevent it

--- a/tests/source/issue-1239.rs
+++ b/tests/source/issue-1239.rs
@@ -1,0 +1,9 @@
+fn foo() {
+    let with_alignment = if condition__uses_alignment_for_first_if__0 ||
+                            condition__uses_alignment_for_first_if__1 ||
+                            condition__uses_alignment_for_first_if__2 {
+    } else if condition__no_alignment_for_later_else__0 ||
+                                   condition__no_alignment_for_later_else__1 ||
+                                   condition__no_alignment_for_later_else__2 {
+    };
+}

--- a/tests/target/issue-1239.rs
+++ b/tests/target/issue-1239.rs
@@ -1,0 +1,9 @@
+fn foo() {
+    let with_alignment = if condition__uses_alignment_for_first_if__0 ||
+                            condition__uses_alignment_for_first_if__1 ||
+                            condition__uses_alignment_for_first_if__2 {
+    } else if condition__no_alignment_for_later_else__0 ||
+              condition__no_alignment_for_later_else__1 ||
+              condition__no_alignment_for_later_else__2 {
+    };
+}


### PR DESCRIPTION
Inside multiline conditions in nested else statements, remove the alignment due to the let binding before the original if statement. Fixes #1239.