### PR TITLE
Fix wrap_match_arms resulting in a missing comma

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1316,7 +1316,7 @@ impl Rewrite for ast::Arm {
                 ("{", "}")
             }
         } else {
-            ("", "")
+            ("", ",")
         };
 
 
@@ -1335,16 +1335,13 @@ impl Rewrite for ast::Arm {
                          shape.indent.to_string(context.config),
                          body_suffix))
         } else {
-            // If the line isn't being wrapped, we don't need the empty new-line
-            assert!(shape.indent.to_string(context.config).trim().is_empty() &&
-                    body_suffix.is_empty());
-
-            Some(format!("{}{} =>{}{}{},",
+            Some(format!("{}{} =>{}{}{}{}",
                          attr_str.trim_left(),
                          pats_str,
                          block_sep,
                          indent_str,
-                         next_line_body))
+                         next_line_body,
+                         body_suffix))
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1319,18 +1319,33 @@ impl Rewrite for ast::Arm {
             ("", "")
         };
 
+
         let block_sep = match context.config.control_brace_style {
             ControlBraceStyle::AlwaysNextLine => alt_block_sep + body_prefix + "\n",
             _ => String::from(" ") + body_prefix + "\n",
         };
-        Some(format!("{}{} =>{}{}{}\n{}{}",
-                     attr_str.trim_left(),
-                     pats_str,
-                     block_sep,
-                     indent_str,
-                     next_line_body,
-                     shape.indent.to_string(context.config),
-                     body_suffix))
+
+        if context.config.wrap_match_arms {
+            Some(format!("{}{} =>{}{}{}\n{}{}",
+                         attr_str.trim_left(),
+                         pats_str,
+                         block_sep,
+                         indent_str,
+                         next_line_body,
+                         shape.indent.to_string(context.config),
+                         body_suffix))
+        } else {
+            // If the line isn't being wrapped, we don't need the empty new-line
+            assert!(shape.indent.to_string(context.config).trim().is_empty() &&
+                    body_suffix.is_empty());
+
+            Some(format!("{}{} =>{}{}{},",
+                         attr_str.trim_left(),
+                         pats_str,
+                         block_sep,
+                         indent_str,
+                         next_line_body))
+        }
     }
 }
 

--- a/tests/source/issue-1127.rs
+++ b/tests/source/issue-1127.rs
@@ -1,0 +1,23 @@
+// rustfmt-max_width:120
+// rustfmt-wrap_match_arms: false
+// rustfmt-match_block_trailing_comma: true
+
+fn a_very_very_very_very_very_very_very_very_very_very_very_long_function_name() -> i32 {
+    42
+}
+
+enum TestEnum {
+    AVeryVeryLongEnumName,
+    AnotherVeryLongEnumName,
+    TheLastVeryLongEnumName,
+}
+
+fn main() {
+    let var = TestEnum::AVeryVeryLongEnumName;
+    let num = match var {
+        TestEnum::AVeryVeryLongEnumName => a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+        TestEnum::AnotherVeryLongEnumName => a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+        TestEnum::TheLastVeryLongEnumName => a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+    };
+}
+

--- a/tests/target/issue-1127.rs
+++ b/tests/target/issue-1127.rs
@@ -1,0 +1,25 @@
+// rustfmt-max_width:120
+// rustfmt-wrap_match_arms: false
+// rustfmt-match_block_trailing_comma: true
+
+fn a_very_very_very_very_very_very_very_very_very_very_very_long_function_name() -> i32 {
+    42
+}
+
+enum TestEnum {
+    AVeryVeryLongEnumName,
+    AnotherVeryLongEnumName,
+    TheLastVeryLongEnumName,
+}
+
+fn main() {
+    let var = TestEnum::AVeryVeryLongEnumName;
+    let num = match var {
+        TestEnum::AVeryVeryLongEnumName => 
+            a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+        TestEnum::AnotherVeryLongEnumName => 
+            a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+        TestEnum::TheLastVeryLongEnumName => 
+            a_very_very_very_very_very_very_very_very_very_very_very_long_function_name(),
+    };
+}


### PR DESCRIPTION
This fixes issue #1127. This is my first dive into rustfmt, so I'll explain my changes to make sure they're agreeable. 

In terms of diagnosing the issue, I focused on the only 3 occurrences of `context.config.wrap_match_arms` (all are in `expr.rs`). 

The first was on [line 1256](https://github.com/rust-lang-nursery/rustfmt/blob/master/src/expr.rs#L1256). Removing the config condition had no effect on the output, so I stopped focusing on this section. 

The next occurrence was on [line 1284](https://github.com/rust-lang-nursery/rustfmt/blob/master/src/expr.rs#L1284), inside a block which starts at [line 1271](https://github.com/rust-lang-nursery/rustfmt/blob/master/src/expr.rs#L1271). This whole block would only effect match arms which could be formatted into a single line; so none of that block effects the case described in this bug. 

The only remaining use of this configuration variable is [line 1312](https://github.com/rust-lang-nursery/rustfmt/blob/master/src/expr.rs#L1312), near the end of the method. 

```rust
        let (body_prefix, body_suffix) = if context.config.wrap_match_arms {
            if context.config.match_block_trailing_comma {
                ("{", "},")
            } else {
                ("{", "}")
            }
        } else {
            ("", "")
        };

        /* ... */

        Some(format!("{}{} =>{}{}{}\n{}{}",
                     attr_str.trim_left(),
                     pats_str,
                     block_sep,
                     indent_str,
                     next_line_body,
                     shape.indent.to_string(context.config),
                     body_suffix))
```

It basically becomes clear that this bug is a missing comma before the newline in the format argument. In order to not start changing too many thing, I split the return into two different `format!` branches—the original, and a new one which removes the empty line this bug was producing. 