### PR TITLE
Add error_on_line_overflow option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -333,6 +333,7 @@ create_config! {
          via the --file-lines option";
     max_width: usize, 100, "Maximum width of each line";
     ideal_width: usize, 80, "Ideal width of each line";
+    error_on_line_overflow: bool, true, "Error if unable to get all lines within max_width";
     tab_spaces: usize, 4, "Number of spaces per tab";
     fn_call_width: usize, 60,
         "Maximum width of the args of a function call before falling back to vertical formatting";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,7 @@ fn format_lines(text: &mut StringBuffer, name: &str, config: &Config, report: &m
                 line_len -= b - lw;
             }
             // Check for any line width errors we couldn't correct.
-            if line_len > config.max_width {
+            if config.error_on_line_overflow && line_len > config.max_width {
                 errors.push(FormattingError {
                     line: cur_line,
                     kind: ErrorKind::LineOverflow(line_len, config.max_width),

--- a/tests/source/comment4.rs
+++ b/tests/source/comment4.rs
@@ -18,7 +18,7 @@ fn test() {
          * amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis
          * felis, pulvinar a semper sed, adipiscing id dolor. */
 
-    // Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment that should be split
+    // Very loooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment that should be split
 
                     // println!("{:?}", rewrite_comment(subslice,
                     //                                       false,

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -1,4 +1,5 @@
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 // Enums test
 
 #[atrr]

--- a/tests/source/file-lines-3.rs
+++ b/tests/source/file-lines-3.rs
@@ -1,4 +1,5 @@
-// rustfmt-file_lines: [{"file":"tests/source/file-lines-3.rs","range":[4,8]},{"file":"tests/source/file-lines-3.rs","range":[10,15]}]
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-3.rs","range":[5,9]},{"file":"tests/source/file-lines-3.rs","range":[11,16]}]
+// rustfmt-error_on_line_overflow: false
 
 fn floaters() {
     let x = Foo {

--- a/tests/source/hard-tabs.rs
+++ b/tests/source/hard-tabs.rs
@@ -2,6 +2,7 @@
 // rustfmt-single_line_if_else_max_width: 0
 // rustfmt-wrap_comments: true
 // rustfmt-hard_tabs: true
+// rustfmt-error_on_line_overflow: false
 
 fn main() {
 let x = Bar;

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -1,4 +1,5 @@
 // rustfmt-normalize_comments: true
+// rustfmt-error_on_line_overflow: false
 
 // Imports.
 

--- a/tests/source/issue-913.rs
+++ b/tests/source/issue-913.rs
@@ -1,3 +1,5 @@
+// rustfmt-error_on_line_overflow: false
+
 mod client {
     impl Client {
         fn test(self) -> Result<()> {
@@ -10,7 +12,7 @@ mod client {
             let next_state = match self.state {
                 State::V5(v5::State::Command(v5::comand::State::WriteVersion(ref mut response))) => {
                     // The pattern cannot be formatted in a way that the match stays
-                    // within the column limit. The rewrite should therefore be 
+                    // within the column limit. The rewrite should therefore be
                     // skipped.
                     let x =  dont . reformat . meeee();
                 }

--- a/tests/source/string-lit.rs
+++ b/tests/source/string-lit.rs
@@ -1,4 +1,5 @@
 // rustfmt-force_format_strings: true
+// rustfmt-error_on_line_overflow: false
 // Long string literals
 
 fn main() -> &'static str {

--- a/tests/source/string_punctuation.rs
+++ b/tests/source/string_punctuation.rs
@@ -1,4 +1,5 @@
 // rustfmt-format_strings: true
+// rustfmt-error_on_line_overflow: false
 
 fn main() {
     println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:Likethisssssssssssss");

--- a/tests/source/struct_lits.rs
+++ b/tests/source/struct_lits.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 // Struct literal expressions.
 
 fn main() {

--- a/tests/source/struct_lits_visual.rs
+++ b/tests/source/struct_lits_visual.rs
@@ -1,6 +1,7 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
+// rustfmt-error_on_line_overflow: false
 
 // Struct literal expressions.
 

--- a/tests/source/struct_lits_visual_multiline.rs
+++ b/tests/source/struct_lits_visual_multiline.rs
@@ -2,6 +2,7 @@
 // rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 // rustfmt-struct_lit_multiline_style: ForceMulti
+// rustfmt-error_on_line_overflow: false
 
 // Struct literal expressions.
 

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 
                                                                        /// A Doc comment
 #[AnAttribute]

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -179,6 +179,10 @@ fn check_files<I>(files: I) -> (Vec<FormatReport>, u32, u32)
         println!("Testing '{}'...", file_name);
 
         match idempotent_check(file_name) {
+            Ok(ref report) if report.has_warnings() => {
+                print!("{}", report);
+                fails += 1;
+            }
             Ok(report) => reports.push(report),
             Err(msg) => {
                 print_mismatches(msg);

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -18,7 +18,7 @@ fn test() {
      * amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis
      * felis, pulvinar a semper sed, adipiscing id dolor. */
 
-    // Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment that should be split
+    // Very loooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment that should be split
 
     // println!("{:?}", rewrite_comment(subslice,
     //                                       false,

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -1,4 +1,5 @@
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 // Enums test
 
 #[atrr]

--- a/tests/target/file-lines-3.rs
+++ b/tests/target/file-lines-3.rs
@@ -1,4 +1,5 @@
-// rustfmt-file_lines: [{"file":"tests/source/file-lines-3.rs","range":[4,8]},{"file":"tests/source/file-lines-3.rs","range":[10,15]}]
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-3.rs","range":[5,9]},{"file":"tests/source/file-lines-3.rs","range":[11,16]}]
+// rustfmt-error_on_line_overflow: false
 
 fn floaters() {
     let x = Foo {

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -2,6 +2,7 @@
 // rustfmt-single_line_if_else_max_width: 0
 // rustfmt-wrap_comments: true
 // rustfmt-hard_tabs: true
+// rustfmt-error_on_line_overflow: false
 
 fn main() {
 	let x = Bar;

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -1,4 +1,5 @@
 // rustfmt-normalize_comments: true
+// rustfmt-error_on_line_overflow: false
 
 // Imports.
 

--- a/tests/target/issue-913.rs
+++ b/tests/target/issue-913.rs
@@ -1,3 +1,5 @@
+// rustfmt-error_on_line_overflow: false
+
 mod client {
     impl Client {
         fn test(self) -> Result<()> {
@@ -10,7 +12,7 @@ mod client {
             let next_state = match self.state {
                 State::V5(v5::State::Command(v5::comand::State::WriteVersion(ref mut response))) => {
                     // The pattern cannot be formatted in a way that the match stays
-                    // within the column limit. The rewrite should therefore be 
+                    // within the column limit. The rewrite should therefore be
                     // skipped.
                     let x =  dont . reformat . meeee();
                 }

--- a/tests/target/string-lit.rs
+++ b/tests/target/string-lit.rs
@@ -1,4 +1,5 @@
 // rustfmt-force_format_strings: true
+// rustfmt-error_on_line_overflow: false
 // Long string literals
 
 fn main() -> &'static str {

--- a/tests/target/string_punctuation.rs
+++ b/tests/target/string_punctuation.rs
@@ -1,4 +1,5 @@
 // rustfmt-format_strings: true
+// rustfmt-error_on_line_overflow: false
 
 fn main() {
     println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:\

--- a/tests/target/struct_lits.rs
+++ b/tests/target/struct_lits.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 // Struct literal expressions.
 
 fn main() {

--- a/tests/target/struct_lits_visual.rs
+++ b/tests/target/struct_lits_visual.rs
@@ -1,6 +1,7 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
+// rustfmt-error_on_line_overflow: false
 
 // Struct literal expressions.
 

--- a/tests/target/struct_lits_visual_multiline.rs
+++ b/tests/target/struct_lits_visual_multiline.rs
@@ -2,6 +2,7 @@
 // rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 // rustfmt-struct_lit_multiline_style: ForceMulti
+// rustfmt-error_on_line_overflow: false
 
 // Struct literal expressions.
 

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-wrap_comments: true
+// rustfmt-error_on_line_overflow: false
 
 /// A Doc comment
 #[AnAttribute]


### PR DESCRIPTION
Makes it configurable whether to error if unable to get all lines within
the max_width.

Testing this option turned out to be impossible, because the tests currently do not take into account any encountered FormattingErrors, so I also changed that to make tests fail if a FormattingError is encountered, as well as modifying all tests so that they do not produce FormattingErrors (in almost all of the tests this is accomplished by setting error_on_line_overflow = false).