### PR TITLE
honor type_punctuation_density for assoc. types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -161,7 +161,10 @@ impl<'a> Rewrite for SegmentParam<'a> {
             SegmentParam::LifeTime(lt) => lt.rewrite(context, shape),
             SegmentParam::Type(ty) => ty.rewrite(context, shape),
             SegmentParam::Binding(binding) => {
-                let mut result = format!("{} = ", binding.ident);
+                let mut result = match context.config.type_punctuation_density {
+                    TypeDensity::Wide => format!("{} = ", binding.ident),
+                    TypeDensity::Compressed => format!("{}=", binding.ident),
+                };
                 let budget = try_opt!(shape.width.checked_sub(result.len()));
                 let rewrite = try_opt!(binding.ty
                     .rewrite(context, Shape::legacy(budget, shape.indent + result.len())));


### PR DESCRIPTION
I think there are still a few places that unconditionally use <tt>&nbsp;=&nbsp;</tt> as a separator.