### PR TITLE
Fix #1255 - incorrect removal of `default` on associated types

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1267,6 +1267,22 @@ pub fn rewrite_associated_type(ident: ast::Ident,
     }
 }
 
+pub fn rewrite_associated_impl_type(ident: ast::Ident,
+                                    defaultness: ast::Defaultness,
+                                    ty_opt: Option<&ptr::P<ast::Ty>>,
+                                    ty_param_bounds_opt: Option<&ast::TyParamBounds>,
+                                    context: &RewriteContext,
+                                    indent: Indent)
+                                    -> Option<String> {
+    let result =
+        try_opt!(rewrite_associated_type(ident, ty_opt, ty_param_bounds_opt, context, indent));
+
+    match defaultness {
+        ast::Defaultness::Default => Some(format!("default {}", result)),
+        _ => Some(result),
+    }
+}
+
 impl Rewrite for ast::FunctionRetTy {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         match *self {

--- a/src/items.rs
+++ b/src/items.rs
@@ -1240,11 +1240,11 @@ pub fn rewrite_associated_type(ident: ast::Ident,
     let type_bounds_str = if let Some(ty_param_bounds) = ty_param_bounds_opt {
         let bounds: &[_] = ty_param_bounds;
         let bound_str = try_opt!(bounds.iter()
-                                     .map(|ty_bound| {
-            ty_bound.rewrite(context, Shape::legacy(context.config.max_width, indent))
-        })
-                                     .intersperse(Some(" + ".to_string()))
-                                     .collect::<Option<String>>());
+            .map(|ty_bound| {
+                ty_bound.rewrite(context, Shape::legacy(context.config.max_width, indent))
+            })
+            .intersperse(Some(" + ".to_string()))
+            .collect::<Option<String>>());
         if bounds.len() > 0 {
             format!(": {}", bound_str)
         } else {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -21,7 +21,8 @@ use config::Config;
 use rewrite::{Rewrite, RewriteContext};
 use comment::rewrite_comment;
 use macros::{rewrite_macro, MacroPosition};
-use items::{rewrite_static, rewrite_associated_type, rewrite_type_alias, format_impl, format_trait};
+use items::{rewrite_static, rewrite_associated_type, rewrite_associated_impl_type,
+            rewrite_type_alias, format_impl, format_trait};
 
 fn is_use_item(item: &ast::Item) -> bool {
     match item.node {
@@ -411,11 +412,12 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(ii.span, rewrite);
             }
             ast::ImplItemKind::Type(ref ty) => {
-                let rewrite = rewrite_associated_type(ii.ident,
-                                                      Some(ty),
-                                                      None,
-                                                      &self.get_context(),
-                                                      self.block_indent);
+                let rewrite = rewrite_associated_impl_type(ii.ident,
+                                                           ii.defaultness,
+                                                           Some(ty),
+                                                           None,
+                                                           &self.get_context(),
+                                                           self.block_indent);
                 self.push_rewrite(ii.span, rewrite);
             }
             ast::ImplItemKind::Macro(ref mac) => {

--- a/tests/target/issue-1255.rs
+++ b/tests/target/issue-1255.rs
@@ -1,0 +1,10 @@
+// Test for issue #1255
+// Default annotation incorrectly removed on associated types
+#![feature(specialization)]
+
+trait Trait {
+    type Type;
+}
+impl<T> Trait for T {
+    default type Type = u64; // 'default' should not be removed
+}


### PR DESCRIPTION
This is a fix for issue #1255, and it's pretty much my first PR of any consequence, in Rust or any language, so I think I'd like to explain myself and what I've done.

Taking a look over the code (and taking a read of the Rust `ast`), I realised that `rustfmt` was treating `TraitItems` and `ImplItems` in the same way - passing them both over to `rewrite_associated_type`, which ignores the additional `defaultness` field on the impl item (hence the bug).

So I wrote a new function, `rewrite_associated_impl_type` (is this name right?), which can take the `defaultness` as an additional argument. This doesn't do anything more that prepend the result of the original function with `default` when appropriate.

I've covered this with an idempotence test - named with the issue number.

I'm sure this is far from perfect -- I'd really appreciate any feedback at all and I'm more than happy to commit some more time to this fix.