### PR TITLE
Format items only if their spans intersect with file_lines

### DIFF
--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -114,32 +114,27 @@ impl FileLines {
 
     /// Returns true if `range` is fully contained in `self`.
     pub fn contains(&self, range: &LineRange) -> bool {
-        let map = match self.0 {
-            // `None` means "all lines in all files".
-            None => return true,
-            Some(ref map) => map,
-        };
-
-        canonicalize_path_string(range.file_name())
-            .ok()
-            .and_then(|canonical| map.get_vec(&canonical))
-            .map_or(false,
-                    |ranges| ranges.iter().any(|r| r.contains(Range::from(range))))
+        self.any_range(range.file_name(), |r| r.contains(Range::from(range)))
     }
 
     /// Returns true if any lines in `range` are in `self`.
     pub fn intersects(&self, range: &LineRange) -> bool {
+        self.any_range(range.file_name(), |r| r.intersects(Range::from(range)))
+    }
+
+    fn any_range<F>(&self, file_name: &str, f: F) -> bool
+        where F: FnMut(&Range) -> bool
+    {
         let map = match self.0 {
             // `None` means "all lines in all files".
             None => return true,
             Some(ref map) => map,
         };
 
-        canonicalize_path_string(range.file_name())
+        canonicalize_path_string(file_name)
             .ok()
             .and_then(|canonical| map.get_vec(&canonical))
-            .map_or(false,
-                    |ranges| ranges.iter().any(|r| r.intersects(Range::from(range))))
+            .map_or(false, |ranges| ranges.iter().any(f))
     }
 }
 

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -120,13 +120,11 @@ impl FileLines {
             Some(ref map) => map,
         };
 
-        match canonicalize_path_string(range.file_name()).and_then(|canonical| {
-                                                                       map.get_vec(&canonical)
-                                                                           .ok_or(())
-                                                                   }) {
-            Ok(ranges) => ranges.iter().any(|r| r.contains(Range::from(range))),
-            Err(_) => false,
-        }
+        canonicalize_path_string(range.file_name())
+            .ok()
+            .and_then(|canonical| map.get_vec(&canonical))
+            .map_or(false,
+                    |ranges| ranges.iter().any(|r| r.contains(Range::from(range))))
     }
 
     /// Returns true if any lines in `range` are in `self`.
@@ -137,10 +135,11 @@ impl FileLines {
             Some(ref map) => map,
         };
 
-        match map.get_vec(range.file_name()) {
-            None => false,
-            Some(ranges) => ranges.iter().any(|r| r.intersects(Range::from(range))),
-        }
+        canonicalize_path_string(range.file_name())
+            .ok()
+            .and_then(|canonical| map.get_vec(&canonical))
+            .map_or(false,
+                    |ranges| ranges.iter().any(|r| r.intersects(Range::from(range))))
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -33,6 +33,7 @@ fn is_use_item(item: &ast::Item) -> bool {
 macro_rules! check_file_lines_intersect {
     ($this:expr, $node:expr) => {
         if !$this.config.file_lines.intersects(&$this.codemap.lookup_line_range($node.span)) {
+            $this.push_rewrite($node.span, None);
             return;
         }
     }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -30,6 +30,7 @@ fn is_use_item(item: &ast::Item) -> bool {
     }
 }
 
+// FIXME(#434): Move this check to somewhere more central, eg Rewrite.
 macro_rules! check_file_lines_intersect {
     ($this:expr, $node:expr) => {
         if !$this.config.file_lines.intersects(&$this.codemap.lookup_line_range($node.span)) {
@@ -57,6 +58,7 @@ impl<'a> FmtVisitor<'a> {
 
         // FIXME(#434): Move this check to somewhere more central, eg Rewrite.
         if !self.config.file_lines.contains(&self.codemap.lookup_line_range(stmt.span)) {
+            self.push_rewrite(stmt.span, None);
             return;
         }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -30,6 +30,14 @@ fn is_use_item(item: &ast::Item) -> bool {
     }
 }
 
+macro_rules! check_file_lines_intersect {
+    ($this:expr, $node:expr) => {
+        if !$this.config.file_lines.intersects(&$this.codemap.lookup_line_range($node.span)) {
+            return;
+        }
+    }
+}
+
 pub struct FmtVisitor<'a> {
     pub parse_session: &'a ParseSess,
     pub codemap: &'a CodeMap,
@@ -180,9 +188,7 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_item(&mut self, item: &ast::Item) {
-        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(item.span)) {
-            return;
-        }
+        check_file_lines_intersect!(self, item);
 
         // This is where we bail out if there is a skip attribute. This is only
         // complex in the module case. It is complex because the module could be
@@ -346,9 +352,7 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
-        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(ti.span)) {
-            return;
-        }
+        check_file_lines_intersect!(self, ti);
 
         if self.visit_attrs(&ti.attrs) {
             self.push_rewrite(ti.span, None);
@@ -394,9 +398,7 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
-        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(ii.span)) {
-            return;
-        }
+        check_file_lines_intersect!(self, ii);
 
         if self.visit_attrs(&ii.attrs) {
             self.push_rewrite(ii.span, None);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -180,6 +180,10 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_item(&mut self, item: &ast::Item) {
+        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(item.span)) {
+            return;
+        }
+
         // This is where we bail out if there is a skip attribute. This is only
         // complex in the module case. It is complex because the module could be
         // in a separate file and there might be attributes in both files, but
@@ -342,6 +346,10 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
+        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(ti.span)) {
+            return;
+        }
+
         if self.visit_attrs(&ti.attrs) {
             self.push_rewrite(ti.span, None);
             return;
@@ -386,6 +394,10 @@ impl<'a> FmtVisitor<'a> {
     }
 
     pub fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
+        if !self.config.file_lines.intersects(&self.codemap.lookup_line_range(ii.span)) {
+            return;
+        }
+
         if self.visit_attrs(&ii.attrs) {
             self.push_rewrite(ii.span, None);
             return;

--- a/tests/source/file-lines-5.rs
+++ b/tests/source/file-lines-5.rs
@@ -1,4 +1,4 @@
-// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]}]
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]},{"file":"tests/source/file-lines-5.rs","range":[29,33]}]
 // rustfmt-error_on_line_overflow: false
 
 impl A {
@@ -26,6 +26,11 @@ fn main() {
 }
 
 fn bar() {
+    {
+        {
+            // comment
+        }
+    }
     {
         {
             // comment

--- a/tests/source/file-lines-5.rs
+++ b/tests/source/file-lines-5.rs
@@ -1,0 +1,26 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]}]
+// rustfmt-error_on_line_overflow: false
+
+impl A {
+    fn foo() {
+    }
+}
+
+impl B {
+    fn foo() {
+    }
+}
+
+trait C {
+    fn foo() {
+    }
+}
+
+fn main() {
+    let y = if cond {
+            val1
+        } else {
+            val2
+        }
+            .method_call();
+}

--- a/tests/source/file-lines-5.rs
+++ b/tests/source/file-lines-5.rs
@@ -24,3 +24,11 @@ fn main() {
         }
             .method_call();
 }
+
+fn bar() {
+    {
+        {
+            // comment
+        }
+    }
+}

--- a/tests/target/file-lines-5.rs
+++ b/tests/target/file-lines-5.rs
@@ -18,3 +18,11 @@ trait C {
 fn main() {
     let y = if cond { val1 } else { val2 }.method_call();
 }
+
+fn bar() {
+    {
+        {
+            // comment
+        }
+    }
+}

--- a/tests/target/file-lines-5.rs
+++ b/tests/target/file-lines-5.rs
@@ -1,4 +1,4 @@
-// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]}]
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]},{"file":"tests/source/file-lines-5.rs","range":[29,33]}]
 // rustfmt-error_on_line_overflow: false
 
 impl A {
@@ -20,6 +20,11 @@ fn main() {
 }
 
 fn bar() {
+    {
+        {
+            // comment
+        }
+    }
     {
         {
             // comment

--- a/tests/target/file-lines-5.rs
+++ b/tests/target/file-lines-5.rs
@@ -1,0 +1,20 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[9,10]},{"file":"tests/source/file-lines-5.rs","range":[20,25]}]
+// rustfmt-error_on_line_overflow: false
+
+impl A {
+    fn foo() {
+    }
+}
+
+impl B {
+    fn foo() {}
+}
+
+trait C {
+    fn foo() {
+    }
+}
+
+fn main() {
+    let y = if cond { val1 } else { val2 }.method_call();
+}


### PR DESCRIPTION
This will reduce unintentionally formatted lines.