### PR TITLE
Update example in travis section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ A minimal Travis setup could look like this:
 ```yaml
 language: rust
 cache: cargo
-before_script: (cargo install rustfmt || true)
+before_script:
+- export PATH="$PATH:$HOME/.cargo/bin"
+- which rustfmt || cargo install rustfmt
 script:
-- |
-  export PATH=$PATH:~/.cargo/bin &&
-  cargo fmt -- --write-mode=diff &&
-  cargo build &&
-  cargo test
+- cargo fmt -- --write-mode=diff
+- cargo build
+- cargo test
 ```
 
 Note that using `cache: cargo` is optional but highly recommended to speed up the installation.


### PR DESCRIPTION
This does not change the semantics of what is run in travis, but rather fixes the example so that the output in travis makes more sense.

In particular:
- This will no longer run `cargo install rustfmt` when rustfmt is already installed (and that command would error anyways)
  - Because of this, `|| true` is no longer needed, and is removed so that actual install errors for rustfmt are shown correctly
- This separates the combined script before into three separate commands, so that travis will output a "success" or "fail" for each individual command, rather than a combined "success" or "fail" for the entire thing (which is less helpful).