### PR TITLE
include license files into archive on crates.io (#1340)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang-nursery/rustfmt"
 readme = "README.md"
 license = "Apache-2.0/MIT"
-include = ["src/*.rs", "Cargo.toml", "build.rs"]
+include = ["src/*.rs", "Cargo.toml", "build.rs", "LICENSE-*"]
 build = "build.rs"
 categories = ["development-tools"]
 


### PR DESCRIPTION
ref : #1340

> ASL 2.0 requires text license to be present along with source. MIT doesn't require, but it's required by Fedora policies and it would not hurt as well.