### PR TITLE
config: Rename ideal_width -> comment_width

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -150,7 +150,7 @@ for its configuration.
 
 Our visitor keeps track of the desired current indent due to blocks (
 `block_indent`). Each `visit_*` method reformats code according to this indent,
-`config.ideal_width` and `config.max_width`. Most reformatting done in the
+`config.comment_width` and `config.max_width`. Most reformatting done in the
 `visit_*` methods is a bit hackey and is meant to be temporary until it can be
 done properly.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -338,7 +338,6 @@ create_config! {
         "Lines to format; this is not supported in rustfmt.toml, and can only be specified \
          via the --file-lines option";
     max_width: usize, 100, "Maximum width of each line";
-    ideal_width: usize, 80, "Ideal width of each line";
     error_on_line_overflow: bool, true, "Error if unable to get all lines within max_width";
     tab_spaces: usize, 4, "Number of spaces per tab";
     fn_call_width: usize, 60,
@@ -396,6 +395,7 @@ create_config! {
     take_source_hints: bool, false, "Retain some formatting characteristics from the source code";
     hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";
     wrap_comments: bool, false, "Break comments to fit on the line";
+    comment_width: usize, 80, "Maximum length of comments. No effect unless wrap_comments = true";
     normalize_comments: bool, false, "Convert /* */ comments to // comments where possible";
     wrap_match_arms: bool, true, "Wrap multiline match arms in blocks";
     match_block_trailing_comma: bool, false,

--- a/src/items.rs
+++ b/src/items.rs
@@ -763,7 +763,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         // If the trait, generics, and trait bound cannot fit on the same line,
         // put the trait bounds on an indented new line
         if offset.width() + last_line_width(&result) + trait_bound_str.len() >
-           context.config.ideal_width {
+           context.config.comment_width {
             result.push('\n');
             let trait_indent = offset.block_only().block_indent(context.config);
             result.push_str(&trait_indent.to_string(context.config));
@@ -799,7 +799,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         // put the where clause on a new line
         if !where_clause_str.contains('\n') &&
            last_line_width(&result) + where_clause_str.len() + offset.width() >
-           context.config.ideal_width {
+           context.config.comment_width {
             result.push('\n');
             let width = offset.block_indent + context.config.tab_spaces - 1;
             let where_indent = Indent::new(0, width);

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -143,7 +143,7 @@ impl<'a> FmtVisitor<'a> {
                         self.buffer.push_str(" ");
                     }
 
-                    let comment_width = ::std::cmp::min(self.config.ideal_width,
+                    let comment_width = ::std::cmp::min(self.config.comment_width,
                                                         self.config.max_width -
                                                         self.block_indent.width());
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -594,7 +594,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                     let comment = try_opt!(rewrite_comment(comment,
                                                            false,
                                                            Shape::legacy(context.config
-                                                                             .ideal_width -
+                                                                             .comment_width -
                                                                          shape.indent.width(),
                                                                          shape.indent),
                                                            context.config));
@@ -610,7 +610,7 @@ impl<'a> Rewrite for [ast::Attribute] {
             if a_str.starts_with("//") {
                 a_str = try_opt!(rewrite_comment(&a_str,
                                                  false,
-                                                 Shape::legacy(context.config.ideal_width -
+                                                 Shape::legacy(context.config.comment_width -
                                                                shape.indent.width(),
                                                                shape.indent),
                                                  context.config));

--- a/tests/config/small_tabs.toml
+++ b/tests/config/small_tabs.toml
@@ -1,5 +1,5 @@
 max_width = 100
-ideal_width = 80
+comment_width = 80
 tab_spaces = 2
 newline_style = "Unix"
 fn_brace_style = "SameLineWhere"


### PR DESCRIPTION
Since the config option only affects comment widths, and the previous
name has led to some confusion (see #1321, #1152).