### PR TITLE
add codeclimate engine output writer

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -174,7 +174,7 @@ fn make_opts() -> Options {
     opts.optopt("",
                 "write-mode",
                 "mode to write in (not usable when piping from stdin)",
-                "[replace|overwrite|display|diff|coverage|checkstyle]");
+                "[replace|overwrite|display|diff|coverage|checkstyle|codeclimate]");
     opts.optflag("", "skip-children", "don't reformat child modules");
 
     opts.optflag("",

--- a/src/codeclimate.rs
+++ b/src/codeclimate.rs
@@ -1,0 +1,54 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use rustfmt_diff::{Mismatch, DiffLine};
+use std::io::{self, Write};
+
+pub fn output_codeclimate<T>(mut writer: T,
+                             filename: &str,
+                             diff: Vec<Mismatch>)
+                             -> Result<(), io::Error>
+    where T: Write
+{
+    for mismatch in diff {
+        for line in mismatch.lines {
+            if let DiffLine::Expected(ref exp) = line {
+                try!(write!(writer,
+                            "{{\"type\": \"issue\",\
+                    \"check_name\":  \"Style\",\
+                    \"description\": \"Should be `{exp}`\",\
+                    \"categories\":  [\"Style\"],\
+                    \"location\": {{\
+                        \"path\": \"{filename}\",\
+                        \"lines\": {{\
+                            \"begin\": {line},\
+                            \"end\":   {line}\
+                        }}\
+                    }}\
+                }}\r\n\0",
+                            filename = filename,
+                            exp = json_escape_str(exp),
+                            line = mismatch.line_number));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn json_escape_str(string: &str) -> String {
+    let mut out = String::new();
+    for c in string.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(c),
+        }
+    }
+    out
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,8 @@ configuration_option_enum! { WriteMode:
     Plain,
     // Outputs a checkstyle XML file.
     Checkstyle,
+    // Outputs to stdout in codeclimate-engine format
+    Codeclimate,
 }
 
 /// Trait for types that can be used in `Config`.

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -19,6 +19,7 @@ use std::io::{self, Write, Read, BufWriter};
 use config::{NewlineStyle, Config, WriteMode};
 use rustfmt_diff::{make_diff, print_diff, Mismatch};
 use checkstyle::{output_header, output_footer, output_checkstyle_file};
+use codeclimate::output_codeclimate;
 
 // A map of the files of a crate, with their new content
 pub type FileMap = Vec<FileRecord>;
@@ -151,6 +152,10 @@ pub fn write_file<T>(text: &StringBuffer,
         WriteMode::Checkstyle => {
             let diff = try!(create_diff(filename, text, config));
             try!(output_checkstyle_file(out, filename, diff));
+        }
+        WriteMode::Codeclimate => {
+            let diff = try!(create_diff(filename, text, config));
+            try!(output_codeclimate(out, filename, diff));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod filemap;
 pub mod file_lines;
 pub mod visitor;
 mod checkstyle;
+mod codeclimate;
 mod items;
 mod missed_spans;
 mod lists;


### PR DESCRIPTION
This adds a writemode that is usable inside a codeclimate engine.
Format is according to the engine spec:
https://github.com/codeclimate/spec/blob/master/SPEC.md

This is used inside https://github.com/aep/codeclimate-rustfmt to add rustfmt to codeclimate

Signed-off-by: Arvid E. Picciani <aep@exys.org>