### PR TITLE
Warn on unused config options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,15 @@ macro_rules! create_config {
             }
 
             pub fn from_toml(toml: &str) -> Config {
-                let parsed = toml.parse().expect("Could not parse TOML");
+                let parsed: toml::Value = toml.parse().expect("Could not parse TOML");
+                for (key, _) in parsed.as_table().expect("Parsed config was not table") {
+                    match &**key {
+                        $(
+                            stringify!($i) => (),
+                        )+
+                        _ => msg!("Warning: Unused configuration option {}", key),
+                    }
+                }
                 let parsed_config:ParsedConfig = match toml::decode(parsed) {
                     Some(decoded) => decoded,
                     None => {


### PR DESCRIPTION
This will make it clear if a user has misspelled a config option, or if
an option has been changed/removed.

I took the conservative path and made it warn on unused options, but it may make more sense to panic on unused options instead.