### PR TITLE
Avoid extra comma in vertical single-field struct patterns

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -13,8 +13,8 @@ use codemap::SpanUtils;
 use config::{IndentStyle, MultilineStyle};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{wrap_str, format_mutability};
-use lists::{format_item_list, itemize_list, ListItem, struct_lit_shape, struct_lit_tactic,
-            shape_for_tactic, struct_lit_formatting, write_list};
+use lists::{DefinitiveListTactic, format_item_list, itemize_list, ListItem, struct_lit_shape,
+            struct_lit_tactic, shape_for_tactic, struct_lit_formatting, write_list};
 use expr::{rewrite_unary_prefix, rewrite_pair};
 use types::{rewrite_path, PathContext};
 use super::Spanned;
@@ -167,7 +167,13 @@ fn rewrite_struct_pat(path: &ast::Path,
             fields_str.push_str("..");
         } else {
             if !fields_str.is_empty() {
-                fields_str.push_str(", ");
+                // there are preceeding struct fields being matched on
+                if fmt.tactic == DefinitiveListTactic::Vertical {
+                    // if the tactic is Vertical, write_list already added a trailing ,
+                    fields_str.push_str(" ");
+                } else {
+                    fields_str.push_str(", ");
+                }
             }
             fields_str.push_str("..");
         }

--- a/tests/target/issue-1397.rs
+++ b/tests/target/issue-1397.rs
@@ -1,0 +1,23 @@
+pub enum TransactionState {
+    Committed(i64),
+}
+
+pub enum Packet {
+    Transaction { state: TransactionState },
+}
+
+fn baz(p: Packet) {
+    loop {
+        loop {
+            loop {
+                loop {
+                    if let Packet::Transaction {
+                               state: TransactionState::Committed(ts, ..), ..
+                           } = p {
+                        unreachable!()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We previously double-added a trailing comma for single-member struct patterns that were arranged vertically. One was added by `write_list` (since such structs return true for `needs_trailing_separator`), and another is added by the if in `rewrite_struct_path`. This patch corrects this by checking for vertical layout before deciding whether to add a comma before `..`. This fixes #1397.