### PR TITLE
Add indent_match_arms option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -380,6 +380,8 @@ create_config! {
     wrap_match_arms: bool, true, "Wrap multiline match arms in blocks";
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
+    indent_match_arms: bool, true, "Indent match arms instead of keeping them at the same \
+                                    indentation level as the match keyword";
     closure_block_indent_threshold: isize, 7, "How many lines a closure must have before it is \
                                                block indented. -1 means never use block indent.";
     space_before_type_annotation: bool, false,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1137,7 +1137,12 @@ fn rewrite_match(context: &RewriteContext,
     };
     let mut result = format!("match {}{}{{", cond_str, block_sep);
 
-    let arm_shape = shape.block_indent(context.config.tab_spaces);
+    let arm_shape = if context.config.indent_match_arms {
+        shape.block_indent(context.config.tab_spaces)
+    } else {
+        shape.block_indent(0)
+    };
+
     let arm_indent_str = arm_shape.indent.to_string(context.config);
 
     let open_brace_pos = context.codemap.span_after(mk_sp(cond.span.hi, arm_start_pos(&arms[0])),

--- a/tests/source/indent_match_arms.rs
+++ b/tests/source/indent_match_arms.rs
@@ -1,0 +1,27 @@
+// rustfmt-indent_match_arms: false
+
+fn main() {
+    match x {
+        1 => "one",
+        2 => "two",
+        3 => "three",
+        4 => "four",
+        5 => "five",
+        _ => "something else",
+    }
+
+    match x {
+        1 => "one",
+        2 => "two",
+        3 => "three",
+        4 => "four",
+        5 => match y {
+            'a' => 'A',
+            'b' => 'B',
+            'c' => 'C',
+            _ => "Nope",
+        },
+        _ => "something else",
+    }
+
+}

--- a/tests/target/indent_match_arms.rs
+++ b/tests/target/indent_match_arms.rs
@@ -1,0 +1,29 @@
+// rustfmt-indent_match_arms: false
+
+fn main() {
+    match x {
+    1 => "one",
+    2 => "two",
+    3 => "three",
+    4 => "four",
+    5 => "five",
+    _ => "something else",
+    }
+
+    match x {
+    1 => "one",
+    2 => "two",
+    3 => "three",
+    4 => "four",
+    5 => {
+        match y {
+        'a' => 'A',
+        'b' => 'B',
+        'c' => 'C',
+        _ => "Nope",
+        }
+    }
+    _ => "something else",
+    }
+
+}


### PR DESCRIPTION
Makes it optional whether to indent arms in match expressions. Setting
this to false may be desirable for people wishing to avoid
double-indents, in that if the match arm is a block, the block will
cause an extra indentation level, and if it isn't a block but just a
single line, it's still easy to see the logic at a glance.

This style is preferred in certain other languages with switch
statements, e.g. Linux style C and the most common Java style.