### PR TITLE
README: Note that `rustfmt_skip` on non-inline `mod` quiets line length warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ options covering different styles. File an issue, or even better, submit a PR.
     #[rustfmt_skip]  // requires nightly and #![feature(custom_attribute)] in crate root
     #[cfg_attr(rustfmt, rustfmt_skip)]  // works in stable
     ```
+
+  Note that if one of these attributes is used on a `mod` item that references
+  a file (e.g., `mod foo;`), the referenced file will be ignored entirely,
+  whereas, in other skipped sections of code, rustfmt will warn on lines that
+  exceed the line length limit.
 * When you run rustfmt, place a file named `rustfmt.toml` or `.rustfmt.toml` in
   target file directory or its parents to override the default settings of
   rustfmt.


### PR DESCRIPTION
In the `README.md` document, note, after the introduction of the
`rustfmt_skip` attribute, that using that attribute on a non-inline
`mod` item will cause the file referenced by that item to be wholly
ignored by rustfmt, in contrast to the normal behavior of still
emitting warnings on lines in skipped sections of code that exceed the
line length limit.

My motivation for this change is my former confusion as to this
behavior, as shown in issue #1399.

(I suppose, however, that merging of this patch should wait on the
resolution of [solson's concerns].)

[solson's concerns]: <https://github.com/rust-lang-nursery/rustfmt/issues/1399#issuecomment-288898287>

