### PR TITLE
Remove duplicates

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -24,7 +24,7 @@ use lists::{write_list, itemize_list, ListFormatting, SeparatorTactic, ListTacti
 use string::{StringFormat, rewrite_string};
 use utils::{extra_offset, last_line_width, wrap_str, binary_search, first_line_width,
             semicolon_for_stmt, trimmed_last_line_width, left_most_sub_expr, stmt_expr,
-            place_spaces};
+            colon_spaces};
 use visitor::FmtVisitor;
 use config::{Config, IndentStyle, MultilineStyle, ControlBraceStyle};
 use comment::{FindUncommented, rewrite_comment, contains_comment, recover_comment_removed};
@@ -1891,8 +1891,9 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     // of space, we should fall back to BlockIndent.
 }
 
-pub fn type_annotation_separator(config: &Config) -> & str {
-    place_spaces (config.space_before_type_annotation, config.space_after_type_annotation_colon)
+pub fn type_annotation_separator(config: &Config) -> &str {
+    colon_spaces(config.space_before_type_annotation,
+                 config.space_after_type_annotation_colon)
 }
 
 fn rewrite_field(context: &RewriteContext, field: &ast::Field, shape: Shape) -> Option<String> {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -23,7 +23,8 @@ use lists::{write_list, itemize_list, ListFormatting, SeparatorTactic, ListTacti
             struct_lit_tactic, shape_for_tactic, struct_lit_formatting};
 use string::{StringFormat, rewrite_string};
 use utils::{extra_offset, last_line_width, wrap_str, binary_search, first_line_width,
-            semicolon_for_stmt, trimmed_last_line_width, left_most_sub_expr, stmt_expr};
+            semicolon_for_stmt, trimmed_last_line_width, left_most_sub_expr, stmt_expr,
+            place_spaces};
 use visitor::FmtVisitor;
 use config::{Config, IndentStyle, MultilineStyle, ControlBraceStyle};
 use comment::{FindUncommented, rewrite_comment, contains_comment, recover_comment_removed};
@@ -1890,13 +1891,8 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     // of space, we should fall back to BlockIndent.
 }
 
-pub fn type_annotation_separator(config: &Config) -> &str {
-    match (config.space_before_type_annotation, config.space_after_type_annotation_colon) {
-        (true, true) => " : ",
-        (true, false) => " :",
-        (false, true) => ": ",
-        (false, false) => ":",
-    }
+pub fn type_annotation_separator(config: &Config) -> & str {
+    place_spaces (config.space_before_type_annotation, config.space_after_type_annotation_colon)
 }
 
 fn rewrite_field(context: &RewriteContext, field: &ast::Field, shape: Shape) -> Option<String> {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -207,7 +207,7 @@ pub fn write_list<I, T>(items: I, formatting: &ListFormatting) -> Option<String>
         let item_sep_len = if separate { sep_len } else { 0 };
 
         // Item string may be multi-line. Its length (used for block comment alignment)
-        // Should be only the length of the last line.
+        // should be only the length of the last line.
         let item_last_line = if item.is_multiline() {
             inner_item.lines().last().unwrap_or("")
         } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,7 @@ use {Shape, Spanned};
 use codemap::SpanUtils;
 use lists::{format_item_list, itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
-use utils::{extra_offset, format_mutability, wrap_str};
+use utils::{extra_offset, format_mutability, place_spaces, wrap_str};
 use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple};
 use config::TypeDensity;
 use itertools::Itertools;
@@ -346,12 +346,7 @@ fn format_function_type<'a, I>(inputs: I,
 }
 
 fn type_bound_colon(context: &RewriteContext) -> &'static str {
-    match (context.config.space_before_bound, context.config.space_after_bound_colon) {
-        (true, true) => " : ",
-        (true, false) => " :",
-        (false, true) => ": ",
-        (false, false) => ":",
-    }
+    place_spaces(context.config.space_before_bound, context.config.space_after_bound_colon)
 }
 
 impl Rewrite for ast::WherePredicate {

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,7 @@ use {Shape, Spanned};
 use codemap::SpanUtils;
 use lists::{format_item_list, itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
-use utils::{extra_offset, format_mutability, place_spaces, wrap_str};
+use utils::{extra_offset, format_mutability, colon_spaces, wrap_str};
 use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple};
 use config::TypeDensity;
 use itertools::Itertools;
@@ -346,7 +346,8 @@ fn format_function_type<'a, I>(inputs: I,
 }
 
 fn type_bound_colon(context: &RewriteContext) -> &'static str {
-    place_spaces(context.config.space_before_bound, context.config.space_after_bound_colon)
+    colon_spaces(context.config.space_before_bound,
+                 context.config.space_after_bound_colon)
 }
 
 impl Rewrite for ast::WherePredicate {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -327,7 +327,7 @@ pub fn binary_search<C, T>(mut lo: usize, mut hi: usize, callback: C) -> Option<
 }
 
 #[inline]
-pub fn place_spaces(before: bool, after: bool) -> &'static str {
+pub fn colon_spaces(before: bool, after: bool) -> &'static str {
     match (before, after) {
         (true, true) => " : ",
         (true, false) => " :",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -326,6 +326,16 @@ pub fn binary_search<C, T>(mut lo: usize, mut hi: usize, callback: C) -> Option<
     None
 }
 
+#[inline]
+pub fn place_spaces(before: bool, after: bool) -> &'static str {
+    match (before, after) {
+        (true, true) => " : ",
+        (true, false) => " :",
+        (false, true) => ": ",
+        (false, false) => ":",
+    }
+}
+
 #[test]
 fn bin_search_test() {
     let closure = |i| match i {


### PR DESCRIPTION
This PR removes duplicated definitions of `type_annotation_separator` and `type_bound_colon`.
Also fixes a typo in the document of `src/lists.rs`.