### PR TITLE
Omit space before '\n' + comment (fixes #457)

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -303,7 +303,9 @@ pub fn write_list<I, T>(items: I, formatting: &ListFormatting) -> Option<String>
                                                              Shape::legacy(width, offset),
                                                              formatting.config));
 
-            result.push(' ');
+            if !formatted_comment.starts_with('\n') {
+                result.push(' ');
+            }
             result.push_str(&formatted_comment);
         }
 

--- a/tests/source/space-not-before-newline.rs
+++ b/tests/source/space-not-before-newline.rs
@@ -1,0 +1,8 @@
+struct Foo {
+    a: (),       
+    // spaces ^^^ to be removed
+}
+enum Foo {
+    Bar,     
+    // spaces ^^^ to be removed
+}

--- a/tests/target/space-not-before-newline.rs
+++ b/tests/target/space-not-before-newline.rs
@@ -1,0 +1,8 @@
+struct Foo {
+    a: (),
+    // spaces ^^^ to be removed
+}
+enum Foo {
+    Bar,
+    // spaces ^^^ to be removed
+}


### PR DESCRIPTION
Consider the following code, which produced a `left behind trailing whitespace (sorry)` warning before.

```rust
enum Foo {
    Bar,
    // commented out: Baz
}
```

This commit prevents rustfmt from producing a trailing space after `Bar,`.