### PR TITLE
Format any statement whose span intersects file_lines

### DIFF
--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -140,9 +140,12 @@ impl FileLines {
             Some(ref map) => map,
         };
 
-        match map.get_vec(range.file_name()) {
-            None => false,
-            Some(ranges) => ranges.iter().any(|r| r.intersects(Range::from(range))),
+        match canonicalize_path_string(range.file_name()).and_then(|canonical| {
+                                                                       map.get_vec(&canonical)
+                                                                           .ok_or(())
+                                                                   }) {
+            Ok(ranges) => ranges.iter().any(|r| r.intersects(Range::from(range))),
+            Err(_) => false,
         }
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -50,7 +50,7 @@ impl<'a> FmtVisitor<'a> {
         // FIXME(#434): Move this check to somewhere more central, eg Rewrite.
         if !self.config
                 .file_lines
-                .contains(&self.codemap.lookup_line_range(stmt.span)) {
+                .intersects(&self.codemap.lookup_line_range(stmt.span)) {
             return;
         }
 


### PR DESCRIPTION
The `--file-lines` flag currently restricts formating only to statements that are entirely within the specified ranges. This means that if the user passes a single line but the statement on that line extends to the next, then the formatting operation will have no effect. The reverse, of formatting statements that overlap the line ranges seems more intuitive. In fact this is the technique used by clang-format for its `--lines` command line argument.