### PR TITLE
The --file_lines argument now supports "stdin"

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -217,16 +217,15 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
             // write_mode is always Plain for Stdin.
             config.write_mode = WriteMode::Plain;
 
+            // parse file_lines
+            if let Some(ref file_lines) = matches.opt_str("file-lines") {
+                config.file_lines = try!(file_lines.parse());
+            }
+
             Ok(run(Input::Text(input), &config))
         }
-        Operation::Format {
-            mut files,
-            config_path,
-        } => {
+        Operation::Format { files, config_path } => {
             let options = try!(CliOptions::from_matches(&matches));
-
-            // Add any additional files that were specified via `--file-lines`.
-            files.extend(options.file_lines.files().cloned().map(PathBuf::from));
 
             let mut config = Config::default();
             let mut path = None;
@@ -345,9 +344,8 @@ fn determine_operation(matches: &Matches) -> FmtResult<Operation> {
                       Some(dir)
                   });
 
-    // if no file argument is supplied and `--file-lines` is not specified, read from stdin
-    if matches.free.is_empty() && !matches.opt_present("file-lines") {
-
+    // if no file argument is supplied, read from stdin
+    if matches.free.is_empty() {
         let mut buffer = String::new();
         try!(io::stdin().read_to_string(&mut buffer));
 
@@ -357,7 +355,6 @@ fn determine_operation(matches: &Matches) -> FmtResult<Operation> {
                   });
     }
 
-    // We append files from `--file-lines` later in `execute()`.
     let files: Vec<_> = matches.free.iter().map(PathBuf::from).collect();
 
     Ok(Operation::Format {

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -220,12 +220,23 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
             // parse file_lines
             if let Some(ref file_lines) = matches.opt_str("file-lines") {
                 config.file_lines = try!(file_lines.parse());
+                for f in config.file_lines.files() {
+                    if f != "stdin" {
+                        println!("Warning: Extra file listed in file_lines option '{}'", f);
+                    }
+                }
             }
 
             Ok(run(Input::Text(input), &config))
         }
         Operation::Format { files, config_path } => {
             let options = try!(CliOptions::from_matches(&matches));
+
+            for f in options.file_lines.files() {
+                if !files.contains(&PathBuf::from(f)) {
+                    println!("Warning: Extra file listed in file_lines option '{}'", f);
+                }
+            }
 
             let mut config = Config::default();
             let mut path = None;

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -162,6 +162,10 @@ impl<'a> iter::Iterator for Files<'a> {
 }
 
 fn canonicalize_path_string(s: &str) -> Result<String, ()> {
+    if s == "stdin" {
+        return Ok(s.to_string());
+    }
+
     match path::PathBuf::from(s).canonicalize() {
         Ok(canonicalized) => canonicalized.to_str().map(|s| s.to_string()).ok_or(()),
         _ => Err(()),


### PR DESCRIPTION
This pull request adds the ability to restrict which lines get formatted when the input is provided on stdin.

The change also tweaks the behavior of the `--file_lines` argument in a different way. Previously, any files mentioned in `--file_lines` were added to the list of files to be formatted, and the mere presence of the flag meant that stdin would not be used as an input source. Now the determination of whether to use stdin is done solely on whether any files are passed on the command line, and extraneous files are ignored in `--file_lines`. 

This approach provides consistent behavior in the case that `--file_lines` contains both stdin and actual files, but it may be somewhat unintuitive to silently ignore files listed in `--file_lines`. 