### PR TITLE
try to add test for comma insertion in macros

### DIFF
--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -65,6 +65,21 @@ fn main() {
         // comment
         not function like
     );
+    
+    info!("Found {} code blocks (not all might have file names)", code_blocks.len());
+    
+    assert_eq!(
+        1,
+        hashmap
+            .values()
+            .filter(|v| v.upgrade().is_some())
+            .count()
+    );
+
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => bail!("Can't create file for code block, path has no parent directory"),
+    };
 }
 
 impl X {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -66,6 +66,20 @@ fn main() {
         // comment
         not function like
     );
+
+    info!("Found {} code blocks (not all might have file names)",
+          code_blocks.len());
+
+    assert_eq!(1,
+               hashmap
+                   .values()
+                   .filter(|v| v.upgrade().is_some())
+                   .count());
+
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => bail!("Can't create file for code block, path has no parent directory"),
+    };
 }
 
 impl X {


### PR DESCRIPTION
I tried to write a test for #1419 but the example given there appears to format correctly. 
So I added the examples from #1418 and #1425 but neither of those have a comma inserted when the tests are run either.

Maybe some previous code change has happened to fix this bug?