### PR TITLE
Do not count `\r` as part of line width.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,7 +481,6 @@ fn format_lines(text: &mut StringBuffer, name: &str, config: &Config, report: &m
 
     for (c, b) in text.chars() {
         if c == '\r' {
-            line_len += c.len_utf8();
             continue;
         }
 


### PR DESCRIPTION
Resolves #1335. Does not attempt to handle a `\r` not followed by a `\n` nor
attempt to handle Unicode intricacies (#6) including zero-width or multi-byte
characters.