### PR TITLE
Lookup the last element of 'subexpr_list' instead of the first one

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -199,7 +199,8 @@ fn get_targets(workspace_hitlist: WorkspaceHitlist) -> Result<Vec<Target>, std::
     // is used inside a workspace.
     // To ensure backward compatability, we only use `cargo metadata` for workspaces.
     // TODO: Is it possible only use metadata or read-manifest
-    let output = Command::new("cargo").arg("metadata")
+    let output = Command::new("cargo")
+        .arg("metadata")
         .arg("--no-deps")
         .output()?;
     if output.status.success() {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -217,7 +217,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
 
     let first_connector = if extend || subexpr_list.is_empty() {
         ""
-    } else if let ast::ExprKind::Try(_) = subexpr_list[0].node {
+    } else if let ast::ExprKind::Try(_) = subexpr_list.last().unwrap().node {
         ""
     } else {
         &*connector

--- a/tests/source/chains-visual.rs
+++ b/tests/source/chains-visual.rs
@@ -115,3 +115,32 @@ fn issue587() {
 
     std::mem::transmute(dl.symbol::<()>("init").unwrap())
 }
+
+fn issue_1389() {
+    let names = String::from_utf8(names)?.split('|').map(str::to_owned).collect();
+}
+
+fn issue1217() -> Result<Mnemonic, Error> {
+let random_chars: String = OsRng::new()?
+    .gen_ascii_chars()
+    .take(self.bit_length)
+    .collect();
+
+    Ok(Mnemonic::new(&random_chars))
+}
+
+fn issue1236(options: Vec<String>) -> Result<Option<String>> {
+let process = Command::new("dmenu").stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .spawn()
+    .chain_err(|| "failed to spawn dmenu")?;
+}
+
+fn issue1434() {
+    for _ in 0..100 {
+        let prototype_id = PrototypeIdData::from_reader::<_, B>(&mut self.file_cursor).chain_err(|| {
+            format!("could not read prototype ID at offset {:#010x}",
+                    current_offset)
+        })?;
+    }
+}

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -134,3 +134,37 @@ fn issue587() {
 
     std::mem::transmute(dl.symbol::<()>("init").unwrap())
 }
+
+fn issue_1389() {
+    let names = String::from_utf8(names)?
+        .split('|')
+        .map(str::to_owned)
+        .collect();
+}
+
+fn issue1217() -> Result<Mnemonic, Error> {
+    let random_chars: String = OsRng::new()?
+        .gen_ascii_chars()
+        .take(self.bit_length)
+        .collect();
+
+    Ok(Mnemonic::new(&random_chars))
+}
+
+fn issue1236(options: Vec<String>) -> Result<Option<String>> {
+    let process = Command::new("dmenu")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .chain_err(|| "failed to spawn dmenu")?;
+}
+
+fn issue1434() {
+    for _ in 0..100 {
+        let prototype_id = PrototypeIdData::from_reader::<_, B>(&mut self.file_cursor)
+            .chain_err(|| {
+                           format!("could not read prototype ID at offset {:#010x}",
+                                   current_offset)
+                       })?;
+    }
+}


### PR DESCRIPTION
This commit closes #1389. `subexpr_list` is constructed in a FILO manner, so if
we want to know whether the first connector is `?` or not, we must look at the
tail of the `subexpr_list`.