### PR TITLE
Remove comma from function definition with a single argument

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1752,7 +1752,8 @@ fn rewrite_call_inner<R>(context: &RewriteContext,
         tactic: tactic,
         separator: ",",
         trailing_separator: if force_no_trailing_comma ||
-                               context.config.fn_call_style == IndentStyle::Visual {
+                               context.config.fn_call_style == IndentStyle::Visual ||
+                               args.len() <= 1 {
             SeparatorTactic::Never
         } else {
             context.config.trailing_comma

--- a/src/items.rs
+++ b/src/items.rs
@@ -1628,7 +1628,8 @@ fn rewrite_fn_base(context: &RewriteContext,
                                         indent,
                                         arg_indent,
                                         args_span,
-                                        fd.variadic));
+                                        fd.variadic,
+                                        generics_str.contains('\n')));
 
     let multi_line_arg_str = arg_str.contains('\n');
 
@@ -1783,7 +1784,8 @@ fn rewrite_args(context: &RewriteContext,
                 indent: Indent,
                 arg_indent: Indent,
                 span: Span,
-                variadic: bool)
+                variadic: bool,
+                generics_str_contains_newline: bool)
                 -> Option<String> {
     let mut arg_item_strs =
         try_opt!(args.iter()
@@ -1868,6 +1870,9 @@ fn rewrite_args(context: &RewriteContext,
     }
 
     let (indent, trailing_comma, end_with_newline) = match context.config.fn_args_layout {
+        IndentStyle::Block if !generics_str_contains_newline && arg_items.len() <= 1 => {
+            (indent.block_indent(context.config), SeparatorTactic::Never, true)
+        }
         IndentStyle::Block => {
             (indent.block_indent(context.config), SeparatorTactic::Vertical, true)
         }

--- a/tests/source/configs-fn_call_style-block.rs
+++ b/tests/source/configs-fn_call_style-block.rs
@@ -3,4 +3,6 @@
 
 fn main() {
     lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit");
+    // #1501
+    let hyper = Arc::new(Client::with_connector(HttpsConnector::new(TlsClient::new())));
 }

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -12,4 +12,6 @@ fn main() {
         "adipiscing",
         "elit",
     );
+    // #1501
+    let hyper = Arc::new(Client::with_connector(HttpsConnector::new(TlsClient::new())));
 }

--- a/tests/target/expr-block.rs
+++ b/tests/target/expr-block.rs
@@ -101,7 +101,7 @@ fn arrays() {
             Weighted { weight: 1, item: 1 },
             Weighted { weight: x, item: 2 },
             Weighted { weight: 1, item: 3 },
-        ],
+        ]
     );
 
     let z = [

--- a/tests/target/fn-custom-7.rs
+++ b/tests/target/fn-custom-7.rs
@@ -4,7 +4,7 @@
 // rustfmt-fn_brace_style: AlwaysNextLine
 
 // Case with only one variable.
-fn foo(a: u8,) -> u8
+fn foo(a: u8) -> u8
 {
     bar()
 }
@@ -30,11 +30,11 @@ fn foo(
 }
 
 trait Test {
-    fn foo(a: u8,)
+    fn foo(a: u8)
     {
     }
 
-    fn bar(a: u8,) -> String
+    fn bar(a: u8) -> String
     {
     }
 }


### PR DESCRIPTION
This PR removes comma from function definition if it only has a single argument and the argument fits into a single line. Partially solves #1441?
Also this PR changes the output of test in `fn-custom-7.rs`, assuming that those commas are unnecessary. If it is preferable to preserve them, I will change this PR accordingly.