### PR TITLE
fix path check

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -367,7 +367,16 @@ fn determine_operation(matches: &Matches) -> FmtResult<Operation> {
                   });
     }
 
-    let files: Vec<_> = matches.free.iter().map(PathBuf::from).collect();
+    let files: Vec<_> = matches
+        .free
+        .iter()
+        .map(|s| {
+                 let p = PathBuf::from(s);
+                 // we will do comparison later, so here tries to canonicalize first
+                 // to get the expected behavior.
+                 p.canonicalize().unwrap_or(p)
+             })
+        .collect();
 
     Ok(Operation::Format {
            files: files,


### PR DESCRIPTION
To be noted that `PathBuf::from("relative/path/to/test") != PathBuf::from("/absolute/path/to/test")`, so the check in https://github.com/rust-lang-nursery/rustfmt/blob/master/src/bin/rustfmt.rs#L239 may fail even all args are correct.