### PR TITLE
Format nested mathces properly.

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -195,12 +195,19 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         if fits_single_line {
             fits_single_line = match expr.node {
                 ref e @ ast::ExprKind::MethodCall(..) => {
-                    rewrite_method_call_with_overflow(e,
-                                                      &mut last[0],
-                                                      almost_total,
-                                                      total_span,
-                                                      context,
-                                                      shape)
+                    if rewrite_method_call_with_overflow(e,
+                                                         &mut last[0],
+                                                         almost_total,
+                                                         total_span,
+                                                         context,
+                                                         shape) {
+                        // If the first line of the last method does not fit into a single line
+                        // after the others, allow new lines.
+                        let first_line = try_opt!(last[0].lines().nth(0));
+                        almost_total + first_line.len() < context.config.max_width
+                    } else {
+                        false
+                    }
                 }
                 _ => !last[0].contains('\n'),
             }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -203,8 +203,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
                                                          shape) {
                         // If the first line of the last method does not fit into a single line
                         // after the others, allow new lines.
-                        let first_line = try_opt!(last[0].lines().nth(0));
-                        almost_total + first_line.len() < context.config.max_width
+                        almost_total + first_line_width(&last[0]) < context.config.max_width
                     } else {
                         false
                     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1344,11 +1344,10 @@ impl Rewrite for ast::Arm {
         // 4 = ` => `.len()
         if shape.width > pat_width + comma.len() + 4 {
             let arm_shape = shape
-                .shrink_left(pat_width + 4)
+                .offset_left(pat_width + 4)
                 .unwrap()
                 .sub_width(comma.len())
-                .unwrap()
-                .block();
+                .unwrap();
             let rewrite = nop_block_collapse(body.rewrite(context, arm_shape), arm_shape.width);
             let is_block = if let ast::ExprKind::Block(..) = body.node {
                 true

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -194,9 +194,8 @@ impl JsonSpan {
     // To allow `collect()`ing into a `MultiMap`.
     fn into_tuple(self) -> Result<(String, Range), String> {
         let (lo, hi) = self.range;
-        let canonical = try!(canonicalize_path_string(&self.file).map_err(|_| {
-            format!("Can't canonicalize {}", &self.file)
-        }));
+        let canonical = try!(canonicalize_path_string(&self.file)
+                                 .map_err(|_| format!("Can't canonicalize {}", &self.file)));
         Ok((canonical, Range::new(lo, hi)))
     }
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -1326,12 +1326,13 @@ pub fn rewrite_associated_type(ident: ast::Ident,
 
     let type_bounds_str = if let Some(ty_param_bounds) = ty_param_bounds_opt {
         let bounds: &[_] = ty_param_bounds;
-        let bound_str = try_opt!(bounds.iter()
-            .map(|ty_bound| {
-                ty_bound.rewrite(context, Shape::legacy(context.config.max_width, indent))
-            })
-            .intersperse(Some(" + ".to_string()))
-            .collect::<Option<String>>());
+        let bound_str = try_opt!(bounds
+                                     .iter()
+                                     .map(|ty_bound| {
+            ty_bound.rewrite(context, Shape::legacy(context.config.max_width, indent))
+        })
+                                     .intersperse(Some(" + ".to_string()))
+                                     .collect::<Option<String>>());
         if bounds.len() > 0 {
             format!(": {}", bound_str)
         } else {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,12 +146,11 @@ pub fn rewrite_macro(mac: &ast::Mac,
         MacroStyle::Parens => {
             // Format macro invocation as function call, forcing no trailing
             // comma because not all macros support them.
-            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape, true).map(|rw| {
-                match position {
-                    MacroPosition::Item => format!("{};", rw),
-                    _ => rw,
-                }
-            })
+            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape, true)
+                .map(|rw| match position {
+                         MacroPosition::Item => format!("{};", rw),
+                         _ => rw,
+                     })
         }
         MacroStyle::Brackets => {
             // Format macro invocation as array literal.

--- a/src/types.rs
+++ b/src/types.rs
@@ -587,31 +587,34 @@ impl Rewrite for ast::Ty {
                 let mut_len = mut_str.len();
                 Some(match *lifetime {
                          Some(ref lifetime) => {
-                    let lt_budget = try_opt!(shape.width.checked_sub(2 + mut_len));
-                    let lt_str = try_opt!(lifetime.rewrite(context,
-                                                           Shape::legacy(lt_budget,
+                             let lt_budget = try_opt!(shape.width.checked_sub(2 + mut_len));
+                             let lt_str = try_opt!(lifetime.rewrite(context,
+                                                                    Shape::legacy(lt_budget,
+                                                                                  shape.indent +
+                                                                                  2 +
+                                                                                  mut_len)));
+                             let lt_len = lt_str.len();
+                             let budget = try_opt!(shape.width.checked_sub(2 + mut_len + lt_len));
+                             format!("&{} {}{}",
+                                     lt_str,
+                                     mut_str,
+                                     try_opt!(mt.ty
+                                                  .rewrite(context,
+                                                           Shape::legacy(budget,
                                                                          shape.indent + 2 +
-                                                                         mut_len)));
-                    let lt_len = lt_str.len();
-                    let budget = try_opt!(shape.width.checked_sub(2 + mut_len + lt_len));
-                    format!("&{} {}{}",
-                            lt_str,
-                            mut_str,
-                            try_opt!(mt.ty
-                                         .rewrite(context,
-                                                  Shape::legacy(budget,
-                                                                shape.indent + 2 + mut_len +
-                                                                lt_len))))
-                }
+                                                                         mut_len +
+                                                                         lt_len))))
+                         }
                          None => {
-                    let budget = try_opt!(shape.width.checked_sub(1 + mut_len));
-                    format!("&{}{}",
-                            mut_str,
-                            try_opt!(mt.ty
-                                         .rewrite(context,
-                                                  Shape::legacy(budget,
-                                                                shape.indent + 1 + mut_len))))
-                }
+                             let budget = try_opt!(shape.width.checked_sub(1 + mut_len));
+                             format!("&{}{}",
+                                     mut_str,
+                                     try_opt!(mt.ty
+                                                  .rewrite(context,
+                                                           Shape::legacy(budget,
+                                                                         shape.indent + 1 +
+                                                                         mut_len))))
+                         }
                      })
             }
             // FIXME: we drop any comments here, even though it's a silly place to put

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -295,3 +295,81 @@ fn guards() {
                (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || cccccccccccccccccccccccccccccccccccccccc) => {}
     }
 }
+
+fn issue1371() {
+    Some(match type_ {
+        sfEvtClosed => Closed,
+        sfEvtResized => {
+            let e = unsafe { *event.size.as_ref() };
+
+            Resized {
+                width: e.width,
+                height: e.height,
+            }
+        }
+        sfEvtLostFocus => LostFocus,
+        sfEvtGainedFocus => GainedFocus,
+        sfEvtTextEntered => {
+            TextEntered {
+                unicode: unsafe {
+                    ::std::char::from_u32((*event.text.as_ref()).unicode)
+                        .expect("Invalid unicode encountered on TextEntered event")
+                },
+            }
+        }
+        sfEvtKeyPressed => {
+            let e = unsafe { event.key.as_ref() };
+
+            KeyPressed {
+                code: unsafe { ::std::mem::transmute(e.code) },
+                alt: e.alt.to_bool(),
+                ctrl: e.control.to_bool(),
+                shift: e.shift.to_bool(),
+                system: e.system.to_bool(),
+            }
+        }
+        sfEvtKeyReleased => {
+            let e = unsafe { event.key.as_ref() };
+
+            KeyReleased {
+                code: unsafe { ::std::mem::transmute(e.code) },
+                alt: e.alt.to_bool(),
+                ctrl: e.control.to_bool(),
+                shift: e.shift.to_bool(),
+                system: e.system.to_bool(),
+            }
+        }
+    })
+}
+
+fn issue1395() {
+    let bar = Some(true);
+    let foo = Some(true);
+    let mut x = false;
+    bar.and_then(|_| {
+        match foo {
+            None => None,
+            Some(b) => {
+                x = true;
+                Some(b)
+            }
+        }
+    });
+}
+
+fn issue1456() {
+    Ok(Recording {
+        artists: match reader.evaluate(".//mb:recording/mb:artist-credit/mb:name-credit")? {
+            Nodeset(nodeset) => {
+                let res: Result<Vec<ArtistRef>, ReadError> = nodeset
+                    .iter()
+                    .map(|node| {
+                        XPathNodeReader::new(node, &context).and_then(|r| ArtistRef::from_xml(&r))
+                    })
+                    .collect();
+                res?
+            }
+            _ => Vec::new(),
+        },
+    })
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -310,3 +310,82 @@ fn guards() {
                 cccccccccccccccccccccccccccccccccccccccc) => {}
     }
 }
+
+fn issue1371() {
+    Some(match type_ {
+             sfEvtClosed => Closed,
+             sfEvtResized => {
+                 let e = unsafe { *event.size.as_ref() };
+
+                 Resized {
+                     width: e.width,
+                     height: e.height,
+                 }
+             }
+             sfEvtLostFocus => LostFocus,
+             sfEvtGainedFocus => GainedFocus,
+             sfEvtTextEntered => {
+                 TextEntered {
+                     unicode:
+                         unsafe {
+                             ::std::char::from_u32((*event.text.as_ref()).unicode)
+                                 .expect("Invalid unicode encountered on TextEntered event")
+                         },
+                 }
+             }
+             sfEvtKeyPressed => {
+                 let e = unsafe { event.key.as_ref() };
+
+                 KeyPressed {
+                     code: unsafe { ::std::mem::transmute(e.code) },
+                     alt: e.alt.to_bool(),
+                     ctrl: e.control.to_bool(),
+                     shift: e.shift.to_bool(),
+                     system: e.system.to_bool(),
+                 }
+             }
+             sfEvtKeyReleased => {
+                 let e = unsafe { event.key.as_ref() };
+
+                 KeyReleased {
+                     code: unsafe { ::std::mem::transmute(e.code) },
+                     alt: e.alt.to_bool(),
+                     ctrl: e.control.to_bool(),
+                     shift: e.shift.to_bool(),
+                     system: e.system.to_bool(),
+                 }
+             }
+         })
+}
+
+fn issue1395() {
+    let bar = Some(true);
+    let foo = Some(true);
+    let mut x = false;
+    bar.and_then(|_| match foo {
+                     None => None,
+                     Some(b) => {
+                         x = true;
+                         Some(b)
+                     }
+                 });
+}
+
+fn issue1456() {
+    Ok(Recording {
+           artists: match reader
+                     .evaluate(".//mb:recording/mb:artist-credit/mb:name-credit")? {
+               Nodeset(nodeset) => {
+                   let res: Result<Vec<ArtistRef>, ReadError> = nodeset
+                       .iter()
+                       .map(|node| {
+                                XPathNodeReader::new(node, &context)
+                                    .and_then(|r| ArtistRef::from_xml(&r))
+                            })
+                       .collect();
+                   res?
+               }
+               _ => Vec::new(),
+           },
+       })
+}


### PR DESCRIPTION
This PR closes #1371.

Input:
```rust
fn main() {
    Some(match type_ {
        sfEvtClosed => Closed,
        sfEvtResized => {
            let e = unsafe { *event.size.as_ref() };

            Resized {
                width: e.width,
                height: e.height,
            }
        }
        sfEvtLostFocus => LostFocus,
        sfEvtGainedFocus => GainedFocus,
        sfEvtTextEntered => {
            TextEntered {
                unicode: unsafe {
                    ::std::char::from_u32((*event.text.as_ref()).unicode)
                        .expect("Invalid unicode encountered on TextEntered event")
                },
            }
        }
        sfEvtKeyPressed => {
            let e = unsafe { event.key.as_ref() };

            KeyPressed {
                code: unsafe { ::std::mem::transmute(e.code) },
                alt: e.alt.to_bool(),
                ctrl: e.control.to_bool(),
                shift: e.shift.to_bool(),
                system: e.system.to_bool(),
            }
        }
        sfEvtKeyReleased => {
            let e = unsafe { event.key.as_ref() };

            KeyReleased {
                code: unsafe { ::std::mem::transmute(e.code) },
                alt: e.alt.to_bool(),
                ctrl: e.control.to_bool(),
                shift: e.shift.to_bool(),
                system: e.system.to_bool(),
            }
        }
    })
}
```
Output:
```rust
fn main() {
    Some(match type_ {
             sfEvtClosed => Closed,
             sfEvtResized => {
                 let e = unsafe { *event.size.as_ref() };

                 Resized {
                     width: e.width,
                     height: e.height,
                 }
             }
             sfEvtLostFocus => LostFocus,
             sfEvtGainedFocus => GainedFocus,
             sfEvtTextEntered => {
                 TextEntered {
                     unicode:
                         unsafe {
                             ::std::char::from_u32((*event.text.as_ref()).unicode)
                                 .expect("Invalid unicode encountered on TextEntered event")
                         },
                 }
             }
             sfEvtKeyPressed => {
                 let e = unsafe { event.key.as_ref() };

                 KeyPressed {
                     code: unsafe { ::std::mem::transmute(e.code) },
                     alt: e.alt.to_bool(),
                     ctrl: e.control.to_bool(),
                     shift: e.shift.to_bool(),
                     system: e.system.to_bool(),
                 }
             }
             sfEvtKeyReleased => {
                 let e = unsafe { event.key.as_ref() };

                 KeyReleased {
                     code: unsafe { ::std::mem::transmute(e.code) },
                     alt: e.alt.to_bool(),
                     ctrl: e.control.to_bool(),
                     shift: e.shift.to_bool(),
                     system: e.system.to_bool(),
                 }
             }
         })
}
```