### PR TITLE
format_lines: fix line_len for config.max_width

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ fn format_lines(text: &mut StringBuffer, name: &str, config: &Config, report: &m
             // Check for (and record) trailing whitespace.
             if let Some(lw) = last_wspace {
                 trims.push((cur_line, lw, b));
-                line_len -= b - lw;
+                line_len -= 1;
             }
             // Check for any line width errors we couldn't correct.
             if config.error_on_line_overflow && line_len > config.max_width {
@@ -511,7 +511,7 @@ fn format_lines(text: &mut StringBuffer, name: &str, config: &Config, report: &m
             last_wspace = None;
         } else {
             newline_count = 0;
-            line_len += c.len_utf8();
+            line_len += 1;
             if c.is_whitespace() {
                 if last_wspace.is_none() {
                     last_wspace = Some(b);


### PR DESCRIPTION
In format_lines line length counted as bytes but config.max_width as characters count.

for line like (84 chars):

`// У типажей может существовать стандартная реализация для их функций, поэтому`

produced error:

`Rustfmt failed at /home/diabolo/src/rust/chat/src/main.rs:7: line exceeded maximum length (maximum: 100, found: 147) (sorry)`

this fix just replace line length for count chars in line (not bytes).