### PR TITLE
Show exit codes' meanings with the rustfmt help message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rustfmt"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -202,6 +202,7 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
     match try!(determine_operation(&matches)) {
         Operation::Help => {
             print_usage(opts, "");
+            Summary::print_exit_codes();
             Ok(Summary::new())
         }
         Operation::Version => {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -63,4 +63,14 @@ impl Summary {
         self.has_parsing_errors |= other.has_parsing_errors;
         self.has_diff |= other.has_diff;
     }
+
+    pub fn print_exit_codes() {
+        let exit_codes = r#"Exit Codes:
+    0 = No errors
+    1 = Encountered operational errors e.g. an IO error
+    2 = Failed to reformat code because of parsing errors
+    3 = Code is valid, but it is impossible to format it properly
+    4 = Formatted code differs from existing code (write-mode diff only)"#;
+        println!("{}", exit_codes);
+    }
 }


### PR DESCRIPTION
Fixes #1343 