### PR TITLE
Made `type_punctuation_density` apply too all `+` in types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -370,6 +370,10 @@ impl Rewrite for ast::WherePredicate {
                                      .intersperse(Some(", ".to_string()))
                                      .collect());
 
+                    let joiner = match context.config.type_punctuation_density {
+                        TypeDensity::Compressed => "+",
+                        TypeDensity::Wide => " + ",
+                    };
                     // 6 = "for<> ".len()
                     let used_width = lifetime_str.len() + type_str.len() + colon.len() + 6;
                     let budget = try_opt!(shape.width.checked_sub(used_width));
@@ -379,7 +383,7 @@ impl Rewrite for ast::WherePredicate {
                                                                          Shape::legacy(budget,
                                                                          shape.indent + used_width))
                                                     })
-                                                    .intersperse(Some(" + ".to_string()))
+                                                    .intersperse(Some(joiner.to_string()))
                                                     .collect());
 
                     if context.config.spaces_within_angle_brackets && lifetime_str.len() > 0 {
@@ -392,6 +396,10 @@ impl Rewrite for ast::WherePredicate {
                         format!("for<{}> {}{}{}", lifetime_str, type_str, colon, bounds_str)
                     }
                 } else {
+                    let joiner = match context.config.type_punctuation_density {
+                        TypeDensity::Compressed => "+",
+                        TypeDensity::Wide => " + ",
+                    };
                     let used_width = type_str.len() + colon.len();
                     let budget = try_opt!(shape.width.checked_sub(used_width));
                     let bounds_str: String = try_opt!(bounds.iter()
@@ -400,7 +408,7 @@ impl Rewrite for ast::WherePredicate {
                                                                          Shape::legacy(budget,
                                                                          shape.indent + used_width))
                                                     })
-                                                    .intersperse(Some(" + ".to_string()))
+                                                    .intersperse(Some(joiner.to_string()))
                                                     .collect());
 
                     format!("{}{}{}", type_str, colon, bounds_str)
@@ -456,7 +464,11 @@ fn rewrite_bounded_lifetime<'b, I>(lt: &ast::Lifetime,
                                             .map(|b| b.rewrite(context, shape))
                                             .collect());
         let colon = type_bound_colon(context);
-        let result = format!("{}{}{}", result, colon, appendix.join(" + "));
+        let joiner = match context.config.type_punctuation_density {
+            TypeDensity::Compressed => "+",
+            TypeDensity::Wide => " + ",
+        };
+        let result = format!("{}{}{}", result, colon, appendix.join(joiner));
         wrap_str(result, context.config.max_width, shape)
     }
 }
@@ -509,12 +521,15 @@ impl Rewrite for ast::TyParam {
             if context.config.space_after_bound_colon {
                 result.push_str(" ");
             }
-
+            let joiner = match context.config.type_punctuation_density {
+                TypeDensity::Compressed => "+",
+                TypeDensity::Wide => " + ",
+            };
             let bounds: String =
                 try_opt!(self.bounds
                              .iter()
                              .map(|ty_bound| ty_bound.rewrite(context, shape))
-                             .intersperse(Some(" + ".to_string()))
+                             .intersperse(Some(joiner.to_string()))
                              .collect());
 
             result.push_str(&bounds);

--- a/tests/source/type-punctuation.rs
+++ b/tests/source/type-punctuation.rs
@@ -1,5 +1,32 @@
 // rustfmt-type_punctuation_density: Compressed
 
+struct Foo<T: Eq + Clone, U>
+    where U: Eq + Clone {
+    // body
+}
+
+trait Foo<'a, T = usize>
+    where T: 'a + Eq + Clone
+{
+    type Bar: Eq + Clone;
+}
+
+trait Foo: Eq + Clone {
+    // body
+}
+
+impl<T> Foo<'a> for Bar
+    where for<'a> T: 'a + Eq + Clone
+{
+    // body
+}
+
+fn foo<'a, 'b, 'c>()
+    where 'a: 'b + 'c
+{
+    // body
+}
+
 fn Foo<T = Foo, Output = Expr<'tcx> + Foo>() {
     let i = 6;
 }

--- a/tests/target/type-punctuation.rs
+++ b/tests/target/type-punctuation.rs
@@ -1,5 +1,32 @@
 // rustfmt-type_punctuation_density: Compressed
 
+struct Foo<T: Eq+Clone, U>
+    where U: Eq+Clone {
+    // body
+}
+
+trait Foo<'a, T=usize>
+    where T: 'a+Eq+Clone
+{
+    type Bar: Eq+Clone;
+}
+
+trait Foo: Eq+Clone {
+    // body
+}
+
+impl<T> Foo<'a> for Bar
+    where for<'a> T: 'a+Eq+Clone
+{
+    // body
+}
+
+fn foo<'a, 'b, 'c>()
+    where 'a: 'b+'c
+{
+    // body
+}
+
 fn Foo<T=Foo, Output=Expr<'tcx>+Foo>() {
     let i = 6;
 }


### PR DESCRIPTION
In its current form only occurrences of `+` in `Box<Copy+Sync>` were affected by `type_punctuation_density`.

This PR extends this behavior to all other occurrences, such as `struct Foo<T: Copy + Sync> { … }` as from a user's perspective they all look like a single thing: an intersection of traits.