### PR TITLE
Improve error message for missing source/target test file

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -332,10 +332,12 @@ fn handle_result(result: HashMap<String, String>,
     for (file_name, fmt_text) in result {
         // If file is in tests/source, compare to file with same name in tests/target.
         let target = get_target(&file_name, target);
-        let mut f = fs::File::open(&target).expect("Couldn't open target");
+        let open_error = format!("Couldn't open target {:?}", &target);
+        let mut f = fs::File::open(&target).expect(&open_error);
 
         let mut text = String::new();
-        f.read_to_string(&mut text).expect("Failed reading target");
+        let read_error = format!("Failed reading target {:?}", &target);
+        f.read_to_string(&mut text).expect(&read_error);
 
         if fmt_text != text {
             let diff = make_diff(&text, &fmt_text, DIFF_CONTEXT_SIZE);


### PR DESCRIPTION
The current error message for missing files does not include the actual file path.
As such one currently has to guess it from the last logged test case.