### PR TITLE
Add source/target tests for each config option

### DIFF
--- a/tests/source/configs-array_layout-block.rs
+++ b/tests/source/configs-array_layout-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-array_layout: Block
+// Array layout
+
+fn main() {
+    let lorem = vec!["ipsum","dolor","sit","amet","consectetur","adipiscing","elit"];
+}

--- a/tests/source/configs-array_layout-visual.rs
+++ b/tests/source/configs-array_layout-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-array_layout: Visual
+// Array layout
+
+fn main() {
+    let lorem = vec!["ipsum","dolor","sit","amet","consectetur","adipiscing","elit"];
+}

--- a/tests/source/configs-array_width-above.rs
+++ b/tests/source/configs-array_width-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-array_width: 10
+// Array width
+
+fn main() {
+    let lorem = vec!["ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit"];
+}

--- a/tests/source/configs-array_width-below.rs
+++ b/tests/source/configs-array_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-array_width: 100
+// Array width
+
+fn main() {
+    let lorem = vec!["ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit"];
+}

--- a/tests/source/configs-chain_indent-block.rs
+++ b/tests/source/configs-chain_indent-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-chain_indent: Block
+// Chain indent
+
+fn main() {
+    let lorem = ipsum.dolor().sit().amet().consectetur().adipiscing().elit();
+}

--- a/tests/source/configs-chain_indent-visual.rs
+++ b/tests/source/configs-chain_indent-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-chain_indent: Visual
+// Chain indent
+
+fn main() {
+    let lorem = ipsum.dolor().sit().amet().consectetur().adipiscing().elit();
+}

--- a/tests/source/configs-chain_one_line_max-above.rs
+++ b/tests/source/configs-chain_one_line_max-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-chain_one_line_max: 10
+// Chain one line max
+
+fn main() {
+    let lorem = ipsum.dolor().sit().amet().consectetur().adipiscing().elit();
+}

--- a/tests/source/configs-chain_one_line_max-below.rs
+++ b/tests/source/configs-chain_one_line_max-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-chain_one_line_max: 100
+// Chain one line max
+
+fn main() {
+    let lorem = ipsum.dolor().sit().amet().consectetur().adipiscing().elit();
+}

--- a/tests/source/configs-closure_block_indent_threshold-10.rs
+++ b/tests/source/configs-closure_block_indent_threshold-10.rs
@@ -1,0 +1,12 @@
+// rustfmt-closure_block_indent_threshold: 10
+// Closure block indent threshold
+
+fn main() {
+    lorem_ipsum(|| {
+        println!("lorem");
+        println!("ipsum");
+        println!("dolor");
+        println!("sit");
+        println!("amet");
+    });
+}

--- a/tests/source/configs-closure_block_indent_threshold-2.rs
+++ b/tests/source/configs-closure_block_indent_threshold-2.rs
@@ -1,0 +1,12 @@
+// rustfmt-closure_block_indent_threshold: 2
+// Closure block indent threshold
+
+fn main() {
+    lorem_ipsum(|| {
+        println!("lorem");
+        println!("ipsum");
+        println!("dolor");
+        println!("sit");
+        println!("amet");
+    });
+}

--- a/tests/source/configs-comment_width-above.rs
+++ b/tests/source/configs-comment_width-above.rs
@@ -1,0 +1,7 @@
+// rustfmt-comment_width: 40
+// rustfmt-wrap_comments: true
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+}

--- a/tests/source/configs-comment_width-below.rs
+++ b/tests/source/configs-comment_width-below.rs
@@ -1,0 +1,7 @@
+// rustfmt-comment_width: 80
+// rustfmt-wrap_comments: true
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+}

--- a/tests/source/configs-comment_width-ignore.rs
+++ b/tests/source/configs-comment_width-ignore.rs
@@ -1,0 +1,7 @@
+// rustfmt-comment_width: 40
+// rustfmt-wrap_comments: false
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+}

--- a/tests/source/configs-condense_wildcard_suffices-false.rs
+++ b/tests/source/configs-condense_wildcard_suffices-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-condense_wildcard_suffices: false
+// Condense wildcard suffices
+
+fn main() {
+    let (lorem, ipsum, _, _) = (1, 2, 3, 4);
+}

--- a/tests/source/configs-condense_wildcard_suffices-true.rs
+++ b/tests/source/configs-condense_wildcard_suffices-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-condense_wildcard_suffices: true
+// Condense wildcard suffices
+
+fn main() {
+    let (lorem, ipsum, _, _) = (1, 2, 3, 4);
+}

--- a/tests/source/configs-control_brace_style-always_next_line.rs
+++ b/tests/source/configs-control_brace_style-always_next_line.rs
@@ -1,0 +1,6 @@
+// rustfmt-control_brace_style: AlwaysNextLine
+// Control brace style
+
+fn main() {
+    if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+}

--- a/tests/source/configs-control_brace_style-always_same_line.rs
+++ b/tests/source/configs-control_brace_style-always_same_line.rs
@@ -1,0 +1,6 @@
+// rustfmt-control_brace_style: AlwaysSameLine
+// Control brace style
+
+fn main() {
+    if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+}

--- a/tests/source/configs-control_brace_style-closing_next_line.rs
+++ b/tests/source/configs-control_brace_style-closing_next_line.rs
@@ -1,0 +1,6 @@
+// rustfmt-control_brace_style: ClosingNextLine
+// Control brace style
+
+fn main() {
+    if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+}

--- a/tests/source/configs-disable_all_formatting-false.rs
+++ b/tests/source/configs-disable_all_formatting-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-disable_all_formatting: false
+// Disable all formatting
+
+fn main() {
+    if lorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/source/configs-disable_all_formatting-true.rs
+++ b/tests/source/configs-disable_all_formatting-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-disable_all_formatting: true
+// Disable all formatting
+
+fn main() {
+    iflorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/source/configs-error_on_line_overflow-false.rs
+++ b/tests/source/configs-error_on_line_overflow-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-error_on_line_overflow: false
+// Error on line overflow
+
+fn main() {
+    let lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit;
+}

--- a/tests/source/configs-fn_args_density-compressed.rs
+++ b/tests/source/configs-fn_args_density-compressed.rs
@@ -1,0 +1,16 @@
+// rustfmt-fn_args_density: Compressed
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit) {
+        // body
+    }
+}

--- a/tests/source/configs-fn_args_density-compressed_if_empty.rs
+++ b/tests/source/configs-fn_args_density-compressed_if_empty.rs
@@ -1,0 +1,20 @@
+// rustfmt-fn_args_density: CompressedIfEmpty
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit);
+
+    // FIXME: Previous line should be formatted like this:
+    // fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur,
+    //          adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit) {
+        // body
+    }
+}

--- a/tests/source/configs-fn_args_density-tall.rs
+++ b/tests/source/configs-fn_args_density-tall.rs
@@ -1,0 +1,16 @@
+// rustfmt-fn_args_density: Tall
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit) {
+        // body
+    }
+}

--- a/tests/source/configs-fn_args_density-vertical.rs
+++ b/tests/source/configs-fn_args_density-vertical.rs
@@ -1,0 +1,16 @@
+// rustfmt-fn_args_density: Vertical
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur, adipiscing: Adipiscing, elit: Elit) {
+        // body
+    }
+}

--- a/tests/source/configs-fn_args_layout-block.rs
+++ b/tests/source/configs-fn_args_layout-block.rs
@@ -1,0 +1,10 @@
+// rustfmt-fn_args_layout: Block
+// Function arguments layout
+
+fn lorem() {}
+
+fn lorem(ipsum: usize) {}
+
+fn lorem(ipsum: usize, dolor: usize, sit: usize, amet: usize, consectetur: usize, adipiscing: usize, elit: usize) {
+    // body
+}

--- a/tests/source/configs-fn_args_layout-visual.rs
+++ b/tests/source/configs-fn_args_layout-visual.rs
@@ -1,0 +1,10 @@
+// rustfmt-fn_args_layout: Visual
+// Function arguments layout
+
+fn lorem() {}
+
+fn lorem(ipsum: usize) {}
+
+fn lorem(ipsum: usize, dolor: usize, sit: usize, amet: usize, consectetur: usize, adipiscing: usize, elit: usize) {
+    // body
+}

--- a/tests/source/configs-fn_args_paren_newline-false.rs
+++ b/tests/source/configs-fn_args_paren_newline-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_args_paren_newline: false
+// Function arguments parenthesis on a newline
+
+fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) -> DolorSitAmetConsecteturAdipiscingElitLoremIpsumDolorSitAmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-fn_args_paren_newline-true.rs
+++ b/tests/source/configs-fn_args_paren_newline-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_args_paren_newline: true
+// Function arguments parenthesis on a newline
+
+fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) -> DolorSitAmetConsecteturAdipiscingElitLoremIpsumDolorSitAmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-fn_brace_style-always_next_line.rs
+++ b/tests/source/configs-fn_brace_style-always_next_line.rs
@@ -1,0 +1,14 @@
+// rustfmt-fn_brace_style: AlwaysNextLine
+// Function brace style
+
+fn lorem() {
+    // body
+}
+
+fn lorem(ipsum: usize) {
+    // body
+}
+
+fn lorem<T>(ipsum: T) where T: Add + Sub + Mul + Div {
+    // body
+}

--- a/tests/source/configs-fn_brace_style-prefer_same_line.rs
+++ b/tests/source/configs-fn_brace_style-prefer_same_line.rs
@@ -1,0 +1,14 @@
+// rustfmt-fn_brace_style: PreferSameLine
+// Function brace style
+
+fn lorem() {
+    // body
+}
+
+fn lorem(ipsum: usize) {
+    // body
+}
+
+fn lorem<T>(ipsum: T) where T: Add + Sub + Mul + Div {
+    // body
+}

--- a/tests/source/configs-fn_brace_style-same_line_where.rs
+++ b/tests/source/configs-fn_brace_style-same_line_where.rs
@@ -1,0 +1,14 @@
+// rustfmt-fn_brace_style: SameLineWhere
+// Function brace style
+
+fn lorem() {
+    // body
+}
+
+fn lorem(ipsum: usize) {
+    // body
+}
+
+fn lorem<T>(ipsum: T) where T: Add + Sub + Mul + Div {
+    // body
+}

--- a/tests/source/configs-fn_call_style-block.rs
+++ b/tests/source/configs-fn_call_style-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_call_style: Block
+// Function call style
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit");
+}

--- a/tests/source/configs-fn_call_style-visual.rs
+++ b/tests/source/configs-fn_call_style-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_call_style: Visual
+// Function call style
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit");
+}

--- a/tests/source/configs-fn_call_width-above.rs
+++ b/tests/source/configs-fn_call_width-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_call_width: 10
+// Function call width
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit");
+}

--- a/tests/source/configs-fn_call_width-below.rs
+++ b/tests/source/configs-fn_call_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_call_width: 100
+// Function call width
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor");
+}

--- a/tests/source/configs-fn_empty_single_line-false.rs
+++ b/tests/source/configs-fn_empty_single_line-false.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_empty_single_line: false
+// Empty function on single line
+
+fn lorem() {
+}
+
+fn lorem() {
+
+}

--- a/tests/source/configs-fn_empty_single_line-true.rs
+++ b/tests/source/configs-fn_empty_single_line-true.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_empty_single_line: true
+// Empty function on single line
+
+fn lorem() {
+}
+
+fn lorem() {
+
+}

--- a/tests/source/configs-fn_return_indent-with_args.rs
+++ b/tests/source/configs-fn_return_indent-with_args.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_return_indent: WithArgs
+// Function return type indent
+
+fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: Consectetur, adipiscing: Adipiscing) -> Elit where Ipsum: Eq {
+    // body
+}

--- a/tests/source/configs-fn_return_indent-with_where_clause.rs
+++ b/tests/source/configs-fn_return_indent-with_where_clause.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_return_indent: WithWhereClause
+// Function return type indent
+
+fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: Consectetur, adipiscing: Adipiscing) -> Elit where Ipsum: Eq {
+    // body
+}

--- a/tests/source/configs-fn_single_line-false.rs
+++ b/tests/source/configs-fn_single_line-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-fn_single_line: false
+// Single-expression function on single line
+
+fn lorem() -> usize {
+    42
+}
+
+fn lorem() -> usize {
+    let ipsum = 42;
+    ipsum
+}

--- a/tests/source/configs-fn_single_line-true.rs
+++ b/tests/source/configs-fn_single_line-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-fn_single_line: true
+// Single-expression function on single line
+
+fn lorem() -> usize {
+    42
+}
+
+fn lorem() -> usize {
+    let ipsum = 42;
+    ipsum
+}

--- a/tests/source/configs-force_explicit_abi-false.rs
+++ b/tests/source/configs-force_explicit_abi-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-force_explicit_abi: false
+// Force explicit abi
+
+extern {
+    pub static lorem: c_int;
+}

--- a/tests/source/configs-force_explicit_abi-true.rs
+++ b/tests/source/configs-force_explicit_abi-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-force_explicit_abi: true
+// Force explicit abi
+
+extern {
+    pub static lorem: c_int;
+}

--- a/tests/source/configs-force_format_strings-false.rs
+++ b/tests/source/configs-force_format_strings-false.rs
@@ -1,0 +1,9 @@
+// rustfmt-force_format_strings: false
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/source/configs-force_format_strings-true.rs
+++ b/tests/source/configs-force_format_strings-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-force_format_strings: true
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/source/configs-format_strings-false.rs
+++ b/tests/source/configs-format_strings-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/source/configs-format_strings-true.rs
+++ b/tests/source/configs-format_strings-true.rs
@@ -1,0 +1,7 @@
+// rustfmt-format_strings: true
+// rustfmt-max_width: 50
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/source/configs-generics_indent-block.rs
+++ b/tests/source/configs-generics_indent-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-generics_indent: Block
+// Generics indent
+
+fn lorem<Ipsum: Eq = usize, Dolor: Eq = usize, Sit: Eq = usize, Amet: Eq = usize, Adipiscing: Eq = usize, Consectetur: Eq = usize, Elit: Eq = usize>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, adipiscing: Adipiscing, consectetur: Consectetur, elit: Elit) -> T {
+    // body
+}

--- a/tests/source/configs-generics_indent-visual.rs
+++ b/tests/source/configs-generics_indent-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-generics_indent: Visual
+// Generics indent
+
+fn lorem<Ipsum: Eq = usize, Dolor: Eq = usize, Sit: Eq = usize, Amet: Eq = usize, Adipiscing: Eq = usize, Consectetur: Eq = usize, Elit: Eq = usize>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, adipiscing: Adipiscing, consectetur: Consectetur, elit: Elit) -> T {
+    // body
+}

--- a/tests/source/configs-hard_tabs-false.rs
+++ b/tests/source/configs-hard_tabs-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-hard_tabs: false
+// Hard tabs
+
+fn lorem() -> usize {
+42 // spaces before 42
+}

--- a/tests/source/configs-hard_tabs-true.rs
+++ b/tests/source/configs-hard_tabs-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-hard_tabs: true
+// Hard tabs
+
+fn lorem() -> usize {
+42 // spaces before 42
+}

--- a/tests/source/configs-impl_empty_single_line-false.rs
+++ b/tests/source/configs-impl_empty_single_line-false.rs
@@ -1,0 +1,10 @@
+// rustfmt-impl_empty_single_line: false
+// Empty impl on single line
+
+impl Lorem {
+
+}
+
+impl Ipsum {
+
+}

--- a/tests/source/configs-impl_empty_single_line-true.rs
+++ b/tests/source/configs-impl_empty_single_line-true.rs
@@ -1,0 +1,10 @@
+// rustfmt-impl_empty_single_line: true
+// Empty impl on single line
+
+impl Lorem {
+
+}
+
+impl Ipsum {
+
+}

--- a/tests/source/configs-indent_match_arms-false.rs
+++ b/tests/source/configs-indent_match_arms-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-indent_match_arms: false
+// Indent match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => (), Lorem::Dolor => (), Lorem::Sit => (), Lorem::Amet => (),
+    }
+}

--- a/tests/source/configs-indent_match_arms-true.rs
+++ b/tests/source/configs-indent_match_arms-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-indent_match_arms: true
+// Indent match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => (), Lorem::Dolor => (), Lorem::Sit => (), Lorem::Amet => (),
+    }
+}

--- a/tests/source/configs-item_brace_style-always_next_line.rs
+++ b/tests/source/configs-item_brace_style-always_next_line.rs
@@ -1,0 +1,10 @@
+// rustfmt-item_brace_style: AlwaysNextLine
+// Item brace style
+
+struct Lorem {
+    ipsum: bool,
+}
+
+struct Dolor<T> where T: Eq {
+    sit: T,
+}

--- a/tests/source/configs-item_brace_style-prefer_same_line.rs
+++ b/tests/source/configs-item_brace_style-prefer_same_line.rs
@@ -1,0 +1,10 @@
+// rustfmt-item_brace_style: PreferSameLine
+// Item brace style
+
+struct Lorem {
+    ipsum: bool,
+}
+
+struct Dolor<T> where T: Eq {
+    sit: T,
+}

--- a/tests/source/configs-item_brace_style-same_line_where.rs
+++ b/tests/source/configs-item_brace_style-same_line_where.rs
@@ -1,0 +1,10 @@
+// rustfmt-item_brace_style: SameLineWhere
+// Item brace style
+
+struct Lorem {
+    ipsum: bool,
+}
+
+struct Dolor<T> where T: Eq {
+    sit: T,
+}

--- a/tests/source/configs-match_block_trailing_comma-false.rs
+++ b/tests/source/configs-match_block_trailing_comma-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-match_block_trailing_comma: false
+// Match block trailing comma
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        }
+        Lorem::Dolor => println!("dolor"),
+    }
+}

--- a/tests/source/configs-match_block_trailing_comma-true.rs
+++ b/tests/source/configs-match_block_trailing_comma-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-match_block_trailing_comma: true
+// Match block trailing comma
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        }
+        Lorem::Dolor => println!("dolor"),
+    }
+}

--- a/tests/source/configs-normalize_comments-false.rs
+++ b/tests/source/configs-normalize_comments-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-normalize_comments: false
+// Normalize comments
+
+// Lorem ipsum:
+fn dolor() -> usize {}
+
+/* sit amet: */
+fn adipiscing() -> usize {}

--- a/tests/source/configs-normalize_comments-true.rs
+++ b/tests/source/configs-normalize_comments-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-normalize_comments: true
+// Normalize comments
+
+// Lorem ipsum:
+fn dolor() -> usize {}
+
+/* sit amet: */
+fn adipiscing() -> usize {}

--- a/tests/source/configs-reorder_imported_names-false.rs
+++ b/tests/source/configs-reorder_imported_names-false.rs
@@ -1,0 +1,4 @@
+// rustfmt-reorder_imported_names: false
+// Reorder imported names
+
+use super::{lorem, ipsum, dolor, sit};

--- a/tests/source/configs-reorder_imported_names-true.rs
+++ b/tests/source/configs-reorder_imported_names-true.rs
@@ -1,0 +1,4 @@
+// rustfmt-reorder_imported_names: true
+// Reorder imported names
+
+use super::{lorem, ipsum, dolor, sit};

--- a/tests/source/configs-reorder_imports-false.rs
+++ b/tests/source/configs-reorder_imports-false.rs
@@ -1,0 +1,7 @@
+// rustfmt-reorder_imports: false
+// Reorder imports
+
+use lorem;
+use ipsum;
+use dolor;
+use sit;

--- a/tests/source/configs-reorder_imports-true.rs
+++ b/tests/source/configs-reorder_imports-true.rs
@@ -1,0 +1,7 @@
+// rustfmt-reorder_imports: true
+// Reorder imports
+
+use lorem;
+use ipsum;
+use dolor;
+use sit;

--- a/tests/source/configs-single_line_if_else_max_width-above.rs
+++ b/tests/source/configs-single_line_if_else_max_width-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-single_line_if_else_max_width: 10
+// Single line if-else max width
+
+fn main() {
+    let lorem = if ipsum { dolor } else { sit };
+}

--- a/tests/source/configs-single_line_if_else_max_width-below.rs
+++ b/tests/source/configs-single_line_if_else_max_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-single_line_if_else_max_width: 100
+// Single line if-else max width
+
+fn main() {
+    let lorem = if ipsum { dolor } else { sit };
+}

--- a/tests/source/configs-space_after_bound_colon-false.rs
+++ b/tests/source/configs-space_after_bound_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_bound_colon: false
+// Space after bound colon
+
+fn lorem<T:Eq>(t:T) {
+    // body
+}

--- a/tests/source/configs-space_after_bound_colon-true.rs
+++ b/tests/source/configs-space_after_bound_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_bound_colon: true
+// Space after bound colon
+
+fn lorem<T:Eq>(t:T) {
+    // body
+}

--- a/tests/source/configs-space_after_type_annotation_colon-false.rs
+++ b/tests/source/configs-space_after_type_annotation_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_type_annotation_colon: false
+// Space after type annotation colon
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-space_after_type_annotation_colon-true.rs
+++ b/tests/source/configs-space_after_type_annotation_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_type_annotation_colon: true
+// Space after type annotation colon
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-space_before_bound-false.rs
+++ b/tests/source/configs-space_before_bound-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_bound: false
+// Space before bound
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-space_before_bound-true.rs
+++ b/tests/source/configs-space_before_bound-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_bound: true
+// Space before bound
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-space_before_type_annotation-false.rs
+++ b/tests/source/configs-space_before_type_annotation-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_type_annotation: false
+// Space before type-annotation
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-space_before_type_annotation-true.rs
+++ b/tests/source/configs-space_before_type_annotation-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_type_annotation: true
+// Space before type-annotation
+
+fn lorem<T:Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/source/configs-spaces_around_ranges-false.rs
+++ b/tests/source/configs-spaces_around_ranges-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_around_ranges: false
+// Spaces around ranges
+
+fn main() {
+    let lorem = 0..10;
+}

--- a/tests/source/configs-spaces_around_ranges-true.rs
+++ b/tests/source/configs-spaces_around_ranges-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_around_ranges: true
+// Spaces around ranges
+
+fn main() {
+    let lorem = 0..10;
+}

--- a/tests/source/configs-spaces_within_angle_brackets-false.rs
+++ b/tests/source/configs-spaces_within_angle_brackets-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_angle_brackets: false
+// Spaces within angle-brackets
+
+fn lorem<T: Eq>(t: T) {
+    // body
+}

--- a/tests/source/configs-spaces_within_angle_brackets-true.rs
+++ b/tests/source/configs-spaces_within_angle_brackets-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_angle_brackets: true
+// Spaces within angle-brackets
+
+fn lorem<T: Eq>(t: T) {
+    // body
+}

--- a/tests/source/configs-spaces_within_parens-false.rs
+++ b/tests/source/configs-spaces_within_parens-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_parens: false
+// Spaces within parens
+
+fn lorem<T: Eq>(t: T) {
+    let lorem = (ipsum, dolor);
+}

--- a/tests/source/configs-spaces_within_parens-true.rs
+++ b/tests/source/configs-spaces_within_parens-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_parens: true
+// Spaces within parens
+
+fn lorem<T: Eq>(t: T) {
+    let lorem = (ipsum, dolor);
+}

--- a/tests/source/configs-spaces_within_square_brackets-false.rs
+++ b/tests/source/configs-spaces_within_square_brackets-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_square_brackets: false
+// Spaces within square-brackets
+
+fn main() {
+    let lorem: [usize; 2] = [ipsum, dolor];
+}

--- a/tests/source/configs-spaces_within_square_brackets-true.rs
+++ b/tests/source/configs-spaces_within_square_brackets-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_square_brackets: true
+// Spaces within square-brackets
+
+fn main() {
+    let lorem: [usize; 2] = [ipsum, dolor];
+}

--- a/tests/source/configs-struct_lit_multiline_style-force_multi.rs
+++ b/tests/source/configs-struct_lit_multiline_style-force_multi.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_multiline_style: ForceMulti
+// Struct literal multiline-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_lit_multiline_style-prefer_single.rs
+++ b/tests/source/configs-struct_lit_multiline_style-prefer_single.rs
@@ -1,0 +1,7 @@
+// rustfmt-struct_lit_multiline_style: PreferSingle
+// rustfmt-struct_lit_width: 100
+// Struct literal multiline-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_lit_style-block.rs
+++ b/tests/source/configs-struct_lit_style-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_style: Block
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_lit_style-visual.rs
+++ b/tests/source/configs-struct_lit_style-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_style: Visual
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_lit_width-above.rs
+++ b/tests/source/configs-struct_lit_width-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_width: 10
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_lit_width-below.rs
+++ b/tests/source/configs-struct_lit_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_width: 100
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/source/configs-struct_variant_width-above.rs
+++ b/tests/source/configs-struct_variant_width-above.rs
@@ -1,0 +1,8 @@
+// rustfmt-struct_variant_width: 10
+// Struct variant width
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit { amet: Consectetur, adipiscing: Elit, },
+}

--- a/tests/source/configs-struct_variant_width-below.rs
+++ b/tests/source/configs-struct_variant_width-below.rs
@@ -1,0 +1,8 @@
+// rustfmt-struct_variant_width: 100
+// Struct variant width
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit { amet: Consectetur, adipiscing: Elit },
+}

--- a/tests/source/configs-tab_spaces-2.rs
+++ b/tests/source/configs-tab_spaces-2.rs
@@ -1,0 +1,11 @@
+// rustfmt-tab_spaces: 2
+// rustfmt-max_width: 30
+// rustfmt-array_layout: Block
+// Tab spaces
+
+fn lorem() {
+let ipsum = dolor();
+let sit = vec![
+"amet", "consectetur", "adipiscing", "elit."
+];
+}

--- a/tests/source/configs-tab_spaces-4.rs
+++ b/tests/source/configs-tab_spaces-4.rs
@@ -1,0 +1,11 @@
+// rustfmt-tab_spaces: 4
+// rustfmt-max_width: 30
+// rustfmt-array_layout: Block
+// Tab spaces
+
+fn lorem() {
+let ipsum = dolor();
+let sit = vec![
+"amet", "consectetur", "adipiscing", "elit."
+];
+}

--- a/tests/source/configs-trailing_comma-always.rs
+++ b/tests/source/configs-trailing_comma-always.rs
@@ -1,0 +1,7 @@
+// rustfmt-trailing_comma: Always
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit, } = amet;
+    let Lorem { ipsum, dolor, sit, amet, consectetur, adipiscing } = elit;
+}

--- a/tests/source/configs-trailing_comma-never.rs
+++ b/tests/source/configs-trailing_comma-never.rs
@@ -1,0 +1,7 @@
+// rustfmt-trailing_comma: Never
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit, } = amet;
+    let Lorem { ipsum, dolor, sit, amet, consectetur, adipiscing } = elit;
+}

--- a/tests/source/configs-trailing_comma-vertical.rs
+++ b/tests/source/configs-trailing_comma-vertical.rs
@@ -1,0 +1,7 @@
+// rustfmt-trailing_comma: Vertical
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit, } = amet;
+    let Lorem { ipsum, dolor, sit, amet, consectetur, adipiscing } = elit;
+}

--- a/tests/source/configs-type_punctuation_density-compressed.rs
+++ b/tests/source/configs-type_punctuation_density-compressed.rs
@@ -1,0 +1,7 @@
+// rustfmt-type_punctuation_density: Compressed
+// Type punctuation density
+
+// FIXME: remove whitespace around `+`:
+fn lorem<Ipsum:Dolor+Sit=Amet>() {
+    // body
+}

--- a/tests/source/configs-type_punctuation_density-wide.rs
+++ b/tests/source/configs-type_punctuation_density-wide.rs
@@ -1,0 +1,6 @@
+// rustfmt-type_punctuation_density: Wide
+// Type punctuation density
+
+fn lorem<Ipsum:Dolor+Sit=Amet>() {
+    // body
+}

--- a/tests/source/configs-use_try_shorthand-false.rs
+++ b/tests/source/configs-use_try_shorthand-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-use_try_shorthand: false
+// Use try! shorthand
+
+fn main() {
+    let lorem = try!(ipsum.map(|dolor| dolor.sit()));
+}

--- a/tests/source/configs-use_try_shorthand-true.rs
+++ b/tests/source/configs-use_try_shorthand-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-use_try_shorthand: true
+// Use try! shorthand
+
+fn main() {
+    let lorem = try!(ipsum.map(|dolor| dolor.sit()));
+}

--- a/tests/source/configs-where_density-compressed.rs
+++ b/tests/source/configs-where_density-compressed.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_density: Compressed
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq {
+        // body
+    }
+}

--- a/tests/source/configs-where_density-compressed_if_empty.rs
+++ b/tests/source/configs-where_density-compressed_if_empty.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_density: CompressedIfEmpty
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq {
+        // body
+    }
+}

--- a/tests/source/configs-where_density-tall.rs
+++ b/tests/source/configs-where_density-tall.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_density: Tall
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq {
+        // body
+    }
+}

--- a/tests/source/configs-where_density-vertical.rs
+++ b/tests/source/configs-where_density-vertical.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_density: Vertical
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq {
+        // body
+    }
+}

--- a/tests/source/configs-where_layout-horizontal.rs
+++ b/tests/source/configs-where_layout-horizontal.rs
@@ -1,0 +1,11 @@
+// rustfmt-where_layout: Horizontal
+// rustfmt-error_on_line_overflow: false
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur {
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur, Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-where_layout-horizontal_vertical.rs
+++ b/tests/source/configs-where_layout-horizontal_vertical.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_layout: HorizontalVertical
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur {
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur, Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-where_layout-mixed.rs
+++ b/tests/source/configs-where_layout-mixed.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_layout: Mixed
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur {
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur, Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-where_layout-vertical.rs
+++ b/tests/source/configs-where_layout-vertical.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_layout: Vertical
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur {
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur, Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/source/configs-where_pred_indent-block.rs
+++ b/tests/source/configs-where_pred_indent-block.rs
@@ -1,0 +1,6 @@
+// rustfmt-where_pred_indent: Block
+// Where predicate indent
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T where Ipsum: Eq, Dolor: Eq, Sit: Eq, Amet: Eq {
+    // body
+}

--- a/tests/source/configs-where_pred_indent-visual.rs
+++ b/tests/source/configs-where_pred_indent-visual.rs
@@ -1,0 +1,6 @@
+// rustfmt-where_pred_indent: Visual
+// Where predicate indent
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T where Ipsum: Eq, Dolor: Eq, Sit: Eq, Amet: Eq {
+    // body
+}

--- a/tests/source/configs-where_style-default.rs
+++ b/tests/source/configs-where_style-default.rs
@@ -1,0 +1,6 @@
+// rustfmt-where_style: Default
+// Where style
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T where Ipsum: Eq, Dolor: Eq, Sit: Eq, Amet: Eq {
+    // body
+}

--- a/tests/source/configs-where_style-rfc.rs
+++ b/tests/source/configs-where_style-rfc.rs
@@ -1,0 +1,6 @@
+// rustfmt-where_style: Rfc
+// Where style
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T where Ipsum: Eq, Dolor: Eq, Sit: Eq, Amet: Eq {
+    // body
+}

--- a/tests/source/configs-wrap_comments-false.rs
+++ b/tests/source/configs-wrap_comments-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Wrap comments
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+}

--- a/tests/source/configs-wrap_comments-true.rs
+++ b/tests/source/configs-wrap_comments-true.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 50
+// Wrap comments
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+}

--- a/tests/source/configs-wrap_match_arms-false.rs
+++ b/tests/source/configs-wrap_match_arms-false.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_match_arms: false
+// Wrap match-arms
+
+fn main() {
+    match lorem {
+        true => {
+            let ipsum = dolor;
+            println!("{:?}", ipsum);
+        }
+        false => {
+            println!("{}", sit)
+        }
+    }
+}

--- a/tests/source/configs-wrap_match_arms-true.rs
+++ b/tests/source/configs-wrap_match_arms-true.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_match_arms: true
+// Wrap match-arms
+
+fn main() {
+    match lorem {
+        true => {
+            let ipsum = dolor;
+            println!("{}", ipsum);
+        }
+        false => {
+            println!("{}", sit)
+        }
+    }
+}

--- a/tests/target/configs-array_layout-block.rs
+++ b/tests/target/configs-array_layout-block.rs
@@ -1,0 +1,14 @@
+// rustfmt-array_layout: Block
+// Array layout
+
+fn main() {
+    let lorem = vec![
+        "ipsum",
+        "dolor",
+        "sit",
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit",
+    ];
+}

--- a/tests/target/configs-array_layout-visual.rs
+++ b/tests/target/configs-array_layout-visual.rs
@@ -1,0 +1,12 @@
+// rustfmt-array_layout: Visual
+// Array layout
+
+fn main() {
+    let lorem = vec!["ipsum",
+                     "dolor",
+                     "sit",
+                     "amet",
+                     "consectetur",
+                     "adipiscing",
+                     "elit"];
+}

--- a/tests/target/configs-array_width-above.rs
+++ b/tests/target/configs-array_width-above.rs
@@ -1,0 +1,12 @@
+// rustfmt-array_width: 10
+// Array width
+
+fn main() {
+    let lorem = vec!["ipsum",
+                     "dolor",
+                     "sit",
+                     "amet",
+                     "consectetur",
+                     "adipiscing",
+                     "elit"];
+}

--- a/tests/target/configs-array_width-below.rs
+++ b/tests/target/configs-array_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-array_width: 100
+// Array width
+
+fn main() {
+    let lorem = vec!["ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit"];
+}

--- a/tests/target/configs-chain_indent-block.rs
+++ b/tests/target/configs-chain_indent-block.rs
@@ -1,0 +1,12 @@
+// rustfmt-chain_indent: Block
+// Chain indent
+
+fn main() {
+    let lorem = ipsum
+        .dolor()
+        .sit()
+        .amet()
+        .consectetur()
+        .adipiscing()
+        .elit();
+}

--- a/tests/target/configs-chain_indent-visual.rs
+++ b/tests/target/configs-chain_indent-visual.rs
@@ -1,0 +1,11 @@
+// rustfmt-chain_indent: Visual
+// Chain indent
+
+fn main() {
+    let lorem = ipsum.dolor()
+                     .sit()
+                     .amet()
+                     .consectetur()
+                     .adipiscing()
+                     .elit();
+}

--- a/tests/target/configs-chain_one_line_max-above.rs
+++ b/tests/target/configs-chain_one_line_max-above.rs
@@ -1,0 +1,12 @@
+// rustfmt-chain_one_line_max: 10
+// Chain one line max
+
+fn main() {
+    let lorem = ipsum
+        .dolor()
+        .sit()
+        .amet()
+        .consectetur()
+        .adipiscing()
+        .elit();
+}

--- a/tests/target/configs-chain_one_line_max-below.rs
+++ b/tests/target/configs-chain_one_line_max-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-chain_one_line_max: 100
+// Chain one line max
+
+fn main() {
+    let lorem = ipsum.dolor().sit().amet().consectetur().adipiscing().elit();
+}

--- a/tests/target/configs-closure_block_indent_threshold-10.rs
+++ b/tests/target/configs-closure_block_indent_threshold-10.rs
@@ -1,0 +1,12 @@
+// rustfmt-closure_block_indent_threshold: 10
+// Closure block indent threshold
+
+fn main() {
+    lorem_ipsum(|| {
+                    println!("lorem");
+                    println!("ipsum");
+                    println!("dolor");
+                    println!("sit");
+                    println!("amet");
+                });
+}

--- a/tests/target/configs-closure_block_indent_threshold-2.rs
+++ b/tests/target/configs-closure_block_indent_threshold-2.rs
@@ -1,0 +1,12 @@
+// rustfmt-closure_block_indent_threshold: 2
+// Closure block indent threshold
+
+fn main() {
+    lorem_ipsum(|| {
+        println!("lorem");
+        println!("ipsum");
+        println!("dolor");
+        println!("sit");
+        println!("amet");
+    });
+}

--- a/tests/target/configs-comment_width-above.rs
+++ b/tests/target/configs-comment_width-above.rs
@@ -1,0 +1,8 @@
+// rustfmt-comment_width: 40
+// rustfmt-wrap_comments: true
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet,
+    // consectetur adipiscing elit.
+}

--- a/tests/target/configs-comment_width-below.rs
+++ b/tests/target/configs-comment_width-below.rs
@@ -1,0 +1,7 @@
+// rustfmt-comment_width: 80
+// rustfmt-wrap_comments: true
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+}

--- a/tests/target/configs-comment_width-ignore.rs
+++ b/tests/target/configs-comment_width-ignore.rs
@@ -1,0 +1,7 @@
+// rustfmt-comment_width: 40
+// rustfmt-wrap_comments: false
+// Comment width
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+}

--- a/tests/target/configs-condense_wildcard_suffices-false.rs
+++ b/tests/target/configs-condense_wildcard_suffices-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-condense_wildcard_suffices: false
+// Condense wildcard suffices
+
+fn main() {
+    let (lorem, ipsum, _, _) = (1, 2, 3, 4);
+}

--- a/tests/target/configs-condense_wildcard_suffices-true.rs
+++ b/tests/target/configs-condense_wildcard_suffices-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-condense_wildcard_suffices: true
+// Condense wildcard suffices
+
+fn main() {
+    let (lorem, ipsum, ..) = (1, 2, 3, 4);
+}

--- a/tests/target/configs-control_brace_style-always_next_line.rs
+++ b/tests/target/configs-control_brace_style-always_next_line.rs
@@ -1,0 +1,13 @@
+// rustfmt-control_brace_style: AlwaysNextLine
+// Control brace style
+
+fn main() {
+    if lorem
+    {
+        println!("ipsum!");
+    }
+    else
+    {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs-control_brace_style-always_same_line.rs
+++ b/tests/target/configs-control_brace_style-always_same_line.rs
@@ -1,0 +1,10 @@
+// rustfmt-control_brace_style: AlwaysSameLine
+// Control brace style
+
+fn main() {
+    if lorem {
+        println!("ipsum!");
+    } else {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs-control_brace_style-closing_next_line.rs
+++ b/tests/target/configs-control_brace_style-closing_next_line.rs
@@ -1,0 +1,11 @@
+// rustfmt-control_brace_style: ClosingNextLine
+// Control brace style
+
+fn main() {
+    if lorem {
+        println!("ipsum!");
+    }
+    else {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs-disable_all_formatting-false.rs
+++ b/tests/target/configs-disable_all_formatting-false.rs
@@ -1,0 +1,10 @@
+// rustfmt-disable_all_formatting: false
+// Disable all formatting
+
+fn main() {
+    if lorem {
+        println!("ipsum!");
+    } else {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs-disable_all_formatting-true.rs
+++ b/tests/target/configs-disable_all_formatting-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-disable_all_formatting: true
+// Disable all formatting
+
+fn main() {
+    if lorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/target/configs-error_on_line_overflow-false.rs
+++ b/tests/target/configs-error_on_line_overflow-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-error_on_line_overflow: false
+// Error on line overflow
+
+fn main() {
+    let lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit;
+}

--- a/tests/target/configs-fn_args_density-compressed.rs
+++ b/tests/target/configs-fn_args_density-compressed.rs
@@ -1,0 +1,18 @@
+// rustfmt-fn_args_density: Compressed
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur,
+             adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur,
+             adipiscing: Adipiscing, elit: Elit) {
+        // body
+    }
+}

--- a/tests/target/configs-fn_args_density-compressed_if_empty.rs
+++ b/tests/target/configs-fn_args_density-compressed_if_empty.rs
@@ -1,0 +1,32 @@
+// rustfmt-fn_args_density: CompressedIfEmpty
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit);
+
+    // FIXME: Previous line should be formatted like this:
+    // fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet, consectetur: onsectetur,
+    //          adipiscing: Adipiscing, elit: Elit);
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit) {
+        // body
+    }
+}

--- a/tests/target/configs-fn_args_density-tall.rs
+++ b/tests/target/configs-fn_args_density-tall.rs
@@ -1,0 +1,28 @@
+// rustfmt-fn_args_density: Tall
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet);
+
+    fn lorem(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit);
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit) {
+        // body
+    }
+}

--- a/tests/target/configs-fn_args_density-vertical.rs
+++ b/tests/target/configs-fn_args_density-vertical.rs
@@ -1,0 +1,34 @@
+// rustfmt-fn_args_density: Vertical
+// Function arguments density
+
+trait Lorem {
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet);
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet) {
+        // body
+    }
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit);
+
+    fn lorem(ipsum: Ipsum,
+             dolor: Dolor,
+             sit: Sit,
+             amet: Amet,
+             consectetur: onsectetur,
+             adipiscing: Adipiscing,
+             elit: Elit) {
+        // body
+    }
+}

--- a/tests/target/configs-fn_args_layout-block.rs
+++ b/tests/target/configs-fn_args_layout-block.rs
@@ -1,0 +1,18 @@
+// rustfmt-fn_args_layout: Block
+// Function arguments layout
+
+fn lorem() {}
+
+fn lorem(ipsum: usize) {}
+
+fn lorem(
+    ipsum: usize,
+    dolor: usize,
+    sit: usize,
+    amet: usize,
+    consectetur: usize,
+    adipiscing: usize,
+    elit: usize,
+) {
+    // body
+}

--- a/tests/target/configs-fn_args_layout-visual.rs
+++ b/tests/target/configs-fn_args_layout-visual.rs
@@ -1,0 +1,16 @@
+// rustfmt-fn_args_layout: Visual
+// Function arguments layout
+
+fn lorem() {}
+
+fn lorem(ipsum: usize) {}
+
+fn lorem(ipsum: usize,
+         dolor: usize,
+         sit: usize,
+         amet: usize,
+         consectetur: usize,
+         adipiscing: usize,
+         elit: usize) {
+    // body
+}

--- a/tests/target/configs-fn_args_paren_newline-false.rs
+++ b/tests/target/configs-fn_args_paren_newline-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-fn_args_paren_newline: false
+// Function arguments parenthesis on a newline
+
+fn lorem(
+    ipsum: Ipsum,
+    dolor: Dolor,
+    sit: Sit,
+    amet: Amet)
+    -> DolorSitAmetConsecteturAdipiscingElitLoremIpsumDolorSitAmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/target/configs-fn_args_paren_newline-true.rs
+++ b/tests/target/configs-fn_args_paren_newline-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-fn_args_paren_newline: true
+// Function arguments parenthesis on a newline
+
+fn lorem
+    (ipsum: Ipsum,
+     dolor: Dolor,
+     sit: Sit,
+     amet: Amet)
+     -> DolorSitAmetConsecteturAdipiscingElitLoremIpsumDolorSitAmetConsecteturAdipiscingElit {
+    // body
+}

--- a/tests/target/configs-fn_brace_style-always_next_line.rs
+++ b/tests/target/configs-fn_brace_style-always_next_line.rs
@@ -1,0 +1,18 @@
+// rustfmt-fn_brace_style: AlwaysNextLine
+// Function brace style
+
+fn lorem()
+{
+    // body
+}
+
+fn lorem(ipsum: usize)
+{
+    // body
+}
+
+fn lorem<T>(ipsum: T)
+    where T: Add + Sub + Mul + Div
+{
+    // body
+}

--- a/tests/target/configs-fn_brace_style-prefer_same_line.rs
+++ b/tests/target/configs-fn_brace_style-prefer_same_line.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_brace_style: PreferSameLine
+// Function brace style
+
+fn lorem() {
+    // body
+}
+
+fn lorem(ipsum: usize) {
+    // body
+}
+
+fn lorem<T>(ipsum: T)
+    where T: Add + Sub + Mul + Div {
+    // body
+}

--- a/tests/target/configs-fn_brace_style-same_line_where.rs
+++ b/tests/target/configs-fn_brace_style-same_line_where.rs
@@ -1,0 +1,16 @@
+// rustfmt-fn_brace_style: SameLineWhere
+// Function brace style
+
+fn lorem() {
+    // body
+}
+
+fn lorem(ipsum: usize) {
+    // body
+}
+
+fn lorem<T>(ipsum: T)
+    where T: Add + Sub + Mul + Div
+{
+    // body
+}

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_style: Block
+// Function call style
+
+fn main() {
+    lorem(
+        "lorem",
+        "ipsum",
+        "dolor",
+        "sit",
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit",
+    );
+}

--- a/tests/target/configs-fn_call_style-visual.rs
+++ b/tests/target/configs-fn_call_style-visual.rs
@@ -1,0 +1,13 @@
+// rustfmt-fn_call_style: Visual
+// Function call style
+
+fn main() {
+    lorem("lorem",
+          "ipsum",
+          "dolor",
+          "sit",
+          "amet",
+          "consectetur",
+          "adipiscing",
+          "elit");
+}

--- a/tests/target/configs-fn_call_width-above.rs
+++ b/tests/target/configs-fn_call_width-above.rs
@@ -1,0 +1,13 @@
+// rustfmt-fn_call_width: 10
+// Function call width
+
+fn main() {
+    lorem("lorem",
+          "ipsum",
+          "dolor",
+          "sit",
+          "amet",
+          "consectetur",
+          "adipiscing",
+          "elit");
+}

--- a/tests/target/configs-fn_call_width-below.rs
+++ b/tests/target/configs-fn_call_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_call_width: 100
+// Function call width
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor");
+}

--- a/tests/target/configs-fn_empty_single_line-false.rs
+++ b/tests/target/configs-fn_empty_single_line-false.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_empty_single_line: false
+// Empty function on single line
+
+fn lorem() {
+}
+
+fn lorem() {
+
+}

--- a/tests/target/configs-fn_empty_single_line-true.rs
+++ b/tests/target/configs-fn_empty_single_line-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-fn_empty_single_line: true
+// Empty function on single line
+
+fn lorem() {}
+
+fn lorem() {}

--- a/tests/target/configs-fn_return_indent-with_args.rs
+++ b/tests/target/configs-fn_return_indent-with_args.rs
@@ -1,0 +1,14 @@
+// rustfmt-fn_return_indent: WithArgs
+// Function return type indent
+
+fn lorem(ipsum: Ipsum,
+         dolor: Dolor,
+         sit: Sit,
+         amet: Amet,
+         consectetur: Consectetur,
+         adipiscing: Adipiscing)
+         -> Elit
+    where Ipsum: Eq
+{
+    // body
+}

--- a/tests/target/configs-fn_return_indent-with_where_clause.rs
+++ b/tests/target/configs-fn_return_indent-with_where_clause.rs
@@ -1,0 +1,14 @@
+// rustfmt-fn_return_indent: WithWhereClause
+// Function return type indent
+
+fn lorem(ipsum: Ipsum,
+         dolor: Dolor,
+         sit: Sit,
+         amet: Amet,
+         consectetur: Consectetur,
+         adipiscing: Adipiscing)
+    -> Elit
+    where Ipsum: Eq
+{
+    // body
+}

--- a/tests/target/configs-fn_single_line-false.rs
+++ b/tests/target/configs-fn_single_line-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-fn_single_line: false
+// Single-expression function on single line
+
+fn lorem() -> usize {
+    42
+}
+
+fn lorem() -> usize {
+    let ipsum = 42;
+    ipsum
+}

--- a/tests/target/configs-fn_single_line-true.rs
+++ b/tests/target/configs-fn_single_line-true.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_single_line: true
+// Single-expression function on single line
+
+fn lorem() -> usize { 42 }
+
+fn lorem() -> usize {
+    let ipsum = 42;
+    ipsum
+}

--- a/tests/target/configs-force_explicit_abi-false.rs
+++ b/tests/target/configs-force_explicit_abi-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-force_explicit_abi: false
+// Force explicit abi
+
+extern {
+    pub static lorem: c_int;
+}

--- a/tests/target/configs-force_explicit_abi-true.rs
+++ b/tests/target/configs-force_explicit_abi-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-force_explicit_abi: true
+// Force explicit abi
+
+extern "C" {
+    pub static lorem: c_int;
+}

--- a/tests/target/configs-force_format_strings-false.rs
+++ b/tests/target/configs-force_format_strings-false.rs
@@ -1,0 +1,9 @@
+// rustfmt-force_format_strings: false
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/target/configs-force_format_strings-true.rs
+++ b/tests/target/configs-force_format_strings-true.rs
@@ -1,0 +1,10 @@
+// rustfmt-force_format_strings: true
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// Force format strings
+
+fn main() {
+    let lorem =
+        "ipsum dolor sit amet consectetur \
+         adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/target/configs-format_strings-false.rs
+++ b/tests/target/configs-format_strings-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-format_strings: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Force format strings
+
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/target/configs-format_strings-true.rs
+++ b/tests/target/configs-format_strings-true.rs
@@ -1,0 +1,9 @@
+// rustfmt-format_strings: true
+// rustfmt-max_width: 50
+// Force format strings
+
+fn main() {
+    let lorem =
+        "ipsum dolor sit amet consectetur \
+         adipiscing elit lorem ipsum dolor sit";
+}

--- a/tests/target/configs-generics_indent-block.rs
+++ b/tests/target/configs-generics_indent-block.rs
@@ -1,0 +1,21 @@
+// rustfmt-generics_indent: Block
+// Generics indent
+
+fn lorem<
+    Ipsum: Eq = usize,
+    Dolor: Eq = usize,
+    Sit: Eq = usize,
+    Amet: Eq = usize,
+    Adipiscing: Eq = usize,
+    Consectetur: Eq = usize,
+    Elit: Eq = usize
+>(ipsum: Ipsum,
+    dolor: Dolor,
+    sit: Sit,
+    amet: Amet,
+    adipiscing: Adipiscing,
+    consectetur: Consectetur,
+    elit: Elit)
+    -> T {
+    // body
+}

--- a/tests/target/configs-generics_indent-visual.rs
+++ b/tests/target/configs-generics_indent-visual.rs
@@ -1,0 +1,20 @@
+// rustfmt-generics_indent: Visual
+// Generics indent
+
+fn lorem<Ipsum: Eq = usize,
+         Dolor: Eq = usize,
+         Sit: Eq = usize,
+         Amet: Eq = usize,
+         Adipiscing: Eq = usize,
+         Consectetur: Eq = usize,
+         Elit: Eq = usize>
+    (ipsum: Ipsum,
+     dolor: Dolor,
+     sit: Sit,
+     amet: Amet,
+     adipiscing: Adipiscing,
+     consectetur: Consectetur,
+     elit: Elit)
+     -> T {
+    // body
+}

--- a/tests/target/configs-hard_tabs-false.rs
+++ b/tests/target/configs-hard_tabs-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-hard_tabs: false
+// Hard tabs
+
+fn lorem() -> usize {
+    42 // spaces before 42
+}

--- a/tests/target/configs-hard_tabs-true.rs
+++ b/tests/target/configs-hard_tabs-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-hard_tabs: true
+// Hard tabs
+
+fn lorem() -> usize {
+	42 // spaces before 42
+}

--- a/tests/target/configs-impl_empty_single_line-false.rs
+++ b/tests/target/configs-impl_empty_single_line-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-impl_empty_single_line: false
+// Empty impl on single line
+
+impl Lorem {
+}
+
+impl Ipsum {
+}

--- a/tests/target/configs-impl_empty_single_line-true.rs
+++ b/tests/target/configs-impl_empty_single_line-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-impl_empty_single_line: true
+// Empty impl on single line
+
+impl Lorem {}
+
+impl Ipsum {}

--- a/tests/target/configs-indent_match_arms-false.rs
+++ b/tests/target/configs-indent_match_arms-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-indent_match_arms: false
+// Indent match arms
+
+fn main() {
+    match lorem {
+    Lorem::Ipsum => (),
+    Lorem::Dolor => (),
+    Lorem::Sit => (),
+    Lorem::Amet => (),
+    }
+}

--- a/tests/target/configs-indent_match_arms-true.rs
+++ b/tests/target/configs-indent_match_arms-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-indent_match_arms: true
+// Indent match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => (),
+        Lorem::Dolor => (),
+        Lorem::Sit => (),
+        Lorem::Amet => (),
+    }
+}

--- a/tests/target/configs-item_brace_style-always_next_line.rs
+++ b/tests/target/configs-item_brace_style-always_next_line.rs
@@ -1,0 +1,13 @@
+// rustfmt-item_brace_style: AlwaysNextLine
+// Item brace style
+
+struct Lorem
+{
+    ipsum: bool,
+}
+
+struct Dolor<T>
+    where T: Eq
+{
+    sit: T,
+}

--- a/tests/target/configs-item_brace_style-prefer_same_line.rs
+++ b/tests/target/configs-item_brace_style-prefer_same_line.rs
@@ -1,0 +1,11 @@
+// rustfmt-item_brace_style: PreferSameLine
+// Item brace style
+
+struct Lorem {
+    ipsum: bool,
+}
+
+struct Dolor<T>
+    where T: Eq {
+    sit: T,
+}

--- a/tests/target/configs-item_brace_style-same_line_where.rs
+++ b/tests/target/configs-item_brace_style-same_line_where.rs
@@ -1,0 +1,12 @@
+// rustfmt-item_brace_style: SameLineWhere
+// Item brace style
+
+struct Lorem {
+    ipsum: bool,
+}
+
+struct Dolor<T>
+    where T: Eq
+{
+    sit: T,
+}

--- a/tests/target/configs-match_block_trailing_comma-false.rs
+++ b/tests/target/configs-match_block_trailing_comma-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-match_block_trailing_comma: false
+// Match block trailing comma
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        }
+        Lorem::Dolor => println!("dolor"),
+    }
+}

--- a/tests/target/configs-match_block_trailing_comma-true.rs
+++ b/tests/target/configs-match_block_trailing_comma-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-match_block_trailing_comma: true
+// Match block trailing comma
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        },
+        Lorem::Dolor => println!("dolor"),
+    }
+}

--- a/tests/target/configs-normalize_comments-false.rs
+++ b/tests/target/configs-normalize_comments-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-normalize_comments: false
+// Normalize comments
+
+// Lorem ipsum:
+fn dolor() -> usize {}
+
+/* sit amet: */
+fn adipiscing() -> usize {}

--- a/tests/target/configs-normalize_comments-true.rs
+++ b/tests/target/configs-normalize_comments-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-normalize_comments: true
+// Normalize comments
+
+// Lorem ipsum:
+fn dolor() -> usize {}
+
+// sit amet:
+fn adipiscing() -> usize {}

--- a/tests/target/configs-reorder_imported_names-false.rs
+++ b/tests/target/configs-reorder_imported_names-false.rs
@@ -1,0 +1,4 @@
+// rustfmt-reorder_imported_names: false
+// Reorder imported names
+
+use super::{lorem, ipsum, dolor, sit};

--- a/tests/target/configs-reorder_imported_names-true.rs
+++ b/tests/target/configs-reorder_imported_names-true.rs
@@ -1,0 +1,4 @@
+// rustfmt-reorder_imported_names: true
+// Reorder imported names
+
+use super::{dolor, ipsum, lorem, sit};

--- a/tests/target/configs-reorder_imports-false.rs
+++ b/tests/target/configs-reorder_imports-false.rs
@@ -1,0 +1,7 @@
+// rustfmt-reorder_imports: false
+// Reorder imports
+
+use lorem;
+use ipsum;
+use dolor;
+use sit;

--- a/tests/target/configs-reorder_imports-true.rs
+++ b/tests/target/configs-reorder_imports-true.rs
@@ -1,0 +1,7 @@
+// rustfmt-reorder_imports: true
+// Reorder imports
+
+use dolor;
+use ipsum;
+use lorem;
+use sit;

--- a/tests/target/configs-single_line_if_else_max_width-above.rs
+++ b/tests/target/configs-single_line_if_else_max_width-above.rs
@@ -1,0 +1,10 @@
+// rustfmt-single_line_if_else_max_width: 10
+// Single line if-else max width
+
+fn main() {
+    let lorem = if ipsum {
+        dolor
+    } else {
+        sit
+    };
+}

--- a/tests/target/configs-single_line_if_else_max_width-below.rs
+++ b/tests/target/configs-single_line_if_else_max_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-single_line_if_else_max_width: 100
+// Single line if-else max width
+
+fn main() {
+    let lorem = if ipsum { dolor } else { sit };
+}

--- a/tests/target/configs-space_after_bound_colon-false.rs
+++ b/tests/target/configs-space_after_bound_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_bound_colon: false
+// Space after bound colon
+
+fn lorem<T:Eq>(t: T) {
+    // body
+}

--- a/tests/target/configs-space_after_bound_colon-true.rs
+++ b/tests/target/configs-space_after_bound_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_bound_colon: true
+// Space after bound colon
+
+fn lorem<T: Eq>(t: T) {
+    // body
+}

--- a/tests/target/configs-space_after_type_annotation_colon-false.rs
+++ b/tests/target/configs-space_after_type_annotation_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_type_annotation_colon: false
+// Space after type annotation colon
+
+fn lorem<T: Eq>(t:T) {
+    let ipsum:Dolor = sit;
+}

--- a/tests/target/configs-space_after_type_annotation_colon-true.rs
+++ b/tests/target/configs-space_after_type_annotation_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_type_annotation_colon: true
+// Space after type annotation colon
+
+fn lorem<T: Eq>(t: T) {
+    let ipsum: Dolor = sit;
+}

--- a/tests/target/configs-space_before_bound-false.rs
+++ b/tests/target/configs-space_before_bound-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_bound: false
+// Space before bound
+
+fn lorem<T: Eq>(t: T) {
+    let ipsum: Dolor = sit;
+}

--- a/tests/target/configs-space_before_bound-true.rs
+++ b/tests/target/configs-space_before_bound-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_bound: true
+// Space before bound
+
+fn lorem<T : Eq>(t: T) {
+    let ipsum: Dolor = sit;
+}

--- a/tests/target/configs-space_before_type_annotation-false.rs
+++ b/tests/target/configs-space_before_type_annotation-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_type_annotation: false
+// Space before type-annotation
+
+fn lorem<T: Eq>(t: T) {
+    let ipsum: Dolor = sit;
+}

--- a/tests/target/configs-space_before_type_annotation-true.rs
+++ b/tests/target/configs-space_before_type_annotation-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_type_annotation: true
+// Space before type-annotation
+
+fn lorem<T: Eq>(t : T) {
+    let ipsum : Dolor = sit;
+}

--- a/tests/target/configs-spaces_around_ranges-false.rs
+++ b/tests/target/configs-spaces_around_ranges-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_around_ranges: false
+// Spaces around ranges
+
+fn main() {
+    let lorem = 0..10;
+}

--- a/tests/target/configs-spaces_around_ranges-true.rs
+++ b/tests/target/configs-spaces_around_ranges-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_around_ranges: true
+// Spaces around ranges
+
+fn main() {
+    let lorem = 0 .. 10;
+}

--- a/tests/target/configs-spaces_within_angle_brackets-false.rs
+++ b/tests/target/configs-spaces_within_angle_brackets-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_angle_brackets: false
+// Spaces within angle-brackets
+
+fn lorem<T: Eq>(t: T) {
+    // body
+}

--- a/tests/target/configs-spaces_within_angle_brackets-true.rs
+++ b/tests/target/configs-spaces_within_angle_brackets-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_angle_brackets: true
+// Spaces within angle-brackets
+
+fn lorem< T: Eq >(t: T) {
+    // body
+}

--- a/tests/target/configs-spaces_within_parens-false.rs
+++ b/tests/target/configs-spaces_within_parens-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_parens: false
+// Spaces within parens
+
+fn lorem<T: Eq>(t: T) {
+    let lorem = (ipsum, dolor);
+}

--- a/tests/target/configs-spaces_within_parens-true.rs
+++ b/tests/target/configs-spaces_within_parens-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_parens: true
+// Spaces within parens
+
+fn lorem<T: Eq>( t: T ) {
+    let lorem = ( ipsum, dolor );
+}

--- a/tests/target/configs-spaces_within_square_brackets-false.rs
+++ b/tests/target/configs-spaces_within_square_brackets-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_square_brackets: false
+// Spaces within square-brackets
+
+fn main() {
+    let lorem: [usize; 2] = [ipsum, dolor];
+}

--- a/tests/target/configs-spaces_within_square_brackets-true.rs
+++ b/tests/target/configs-spaces_within_square_brackets-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-spaces_within_square_brackets: true
+// Spaces within square-brackets
+
+fn main() {
+    let lorem: [ usize; 2 ] = [ ipsum, dolor ];
+}

--- a/tests/target/configs-struct_lit_multiline_style-force_multi.rs
+++ b/tests/target/configs-struct_lit_multiline_style-force_multi.rs
@@ -1,0 +1,9 @@
+// rustfmt-struct_lit_multiline_style: ForceMulti
+// Struct literal multiline-style
+
+fn main() {
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+}

--- a/tests/target/configs-struct_lit_multiline_style-prefer_single.rs
+++ b/tests/target/configs-struct_lit_multiline_style-prefer_single.rs
@@ -1,0 +1,7 @@
+// rustfmt-struct_lit_multiline_style: PreferSingle
+// rustfmt-struct_lit_width: 100
+// Struct literal multiline-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/target/configs-struct_lit_style-block.rs
+++ b/tests/target/configs-struct_lit_style-block.rs
@@ -1,0 +1,9 @@
+// rustfmt-struct_lit_style: Block
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+}

--- a/tests/target/configs-struct_lit_style-visual.rs
+++ b/tests/target/configs-struct_lit_style-visual.rs
@@ -1,0 +1,7 @@
+// rustfmt-struct_lit_style: Visual
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor,
+            sit: amet, };
+}

--- a/tests/target/configs-struct_lit_width-above.rs
+++ b/tests/target/configs-struct_lit_width-above.rs
@@ -1,0 +1,9 @@
+// rustfmt-struct_lit_width: 10
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+}

--- a/tests/target/configs-struct_lit_width-below.rs
+++ b/tests/target/configs-struct_lit_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_width: 100
+// Struct literal-style
+
+fn main() {
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+}

--- a/tests/target/configs-struct_variant_width-above.rs
+++ b/tests/target/configs-struct_variant_width-above.rs
@@ -1,0 +1,11 @@
+// rustfmt-struct_variant_width: 10
+// Struct variant width
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit {
+        amet: Consectetur,
+        adipiscing: Elit,
+    },
+}

--- a/tests/target/configs-struct_variant_width-below.rs
+++ b/tests/target/configs-struct_variant_width-below.rs
@@ -1,0 +1,8 @@
+// rustfmt-struct_variant_width: 100
+// Struct variant width
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit { amet: Consectetur, adipiscing: Elit },
+}

--- a/tests/target/configs-tab_spaces-2.rs
+++ b/tests/target/configs-tab_spaces-2.rs
@@ -1,0 +1,14 @@
+// rustfmt-tab_spaces: 2
+// rustfmt-max_width: 30
+// rustfmt-array_layout: Block
+// Tab spaces
+
+fn lorem() {
+  let ipsum = dolor();
+  let sit = vec![
+    "amet",
+    "consectetur",
+    "adipiscing",
+    "elit.",
+  ];
+}

--- a/tests/target/configs-tab_spaces-4.rs
+++ b/tests/target/configs-tab_spaces-4.rs
@@ -1,0 +1,14 @@
+// rustfmt-tab_spaces: 4
+// rustfmt-max_width: 30
+// rustfmt-array_layout: Block
+// Tab spaces
+
+fn lorem() {
+    let ipsum = dolor();
+    let sit = vec![
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit.",
+    ];
+}

--- a/tests/target/configs-trailing_comma-always.rs
+++ b/tests/target/configs-trailing_comma-always.rs
@@ -1,0 +1,14 @@
+// rustfmt-trailing_comma: Always
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit, } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing,
+    } = elit;
+}

--- a/tests/target/configs-trailing_comma-never.rs
+++ b/tests/target/configs-trailing_comma-never.rs
@@ -1,0 +1,14 @@
+// rustfmt-trailing_comma: Never
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing
+    } = elit;
+}

--- a/tests/target/configs-trailing_comma-vertical.rs
+++ b/tests/target/configs-trailing_comma-vertical.rs
@@ -1,0 +1,14 @@
+// rustfmt-trailing_comma: Vertical
+// Trailing comma
+
+fn main() {
+    let Lorem { ipsum, dolor, sit } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing,
+    } = elit;
+}

--- a/tests/target/configs-type_punctuation_density-compressed.rs
+++ b/tests/target/configs-type_punctuation_density-compressed.rs
@@ -1,0 +1,7 @@
+// rustfmt-type_punctuation_density: Compressed
+// Type punctuation density
+
+// FIXME: remove whitespace around `+`:
+fn lorem<Ipsum: Dolor + Sit=Amet>() {
+    // body
+}

--- a/tests/target/configs-type_punctuation_density-wide.rs
+++ b/tests/target/configs-type_punctuation_density-wide.rs
@@ -1,0 +1,6 @@
+// rustfmt-type_punctuation_density: Wide
+// Type punctuation density
+
+fn lorem<Ipsum: Dolor + Sit = Amet>() {
+    // body
+}

--- a/tests/target/configs-use_try_shorthand-false.rs
+++ b/tests/target/configs-use_try_shorthand-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-use_try_shorthand: false
+// Use try! shorthand
+
+fn main() {
+    let lorem = try!(ipsum.map(|dolor| dolor.sit()));
+}

--- a/tests/target/configs-use_try_shorthand-true.rs
+++ b/tests/target/configs-use_try_shorthand-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-use_try_shorthand: true
+// Use try! shorthand
+
+fn main() {
+    let lorem = ipsum.map(|dolor| dolor.sit())?;
+}

--- a/tests/target/configs-where_density-compressed.rs
+++ b/tests/target/configs-where_density-compressed.rs
@@ -1,0 +1,10 @@
+// rustfmt-where_density: Compressed
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq {
+        // body
+    }
+}

--- a/tests/target/configs-where_density-compressed_if_empty.rs
+++ b/tests/target/configs-where_density-compressed_if_empty.rs
@@ -1,0 +1,12 @@
+// rustfmt-where_density: CompressedIfEmpty
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit
+        where Dolor: Eq
+    {
+        // body
+    }
+}

--- a/tests/target/configs-where_density-tall.rs
+++ b/tests/target/configs-where_density-tall.rs
@@ -1,0 +1,13 @@
+// rustfmt-where_density: Tall
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit
+        where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit
+        where Dolor: Eq
+    {
+        // body
+    }
+}

--- a/tests/target/configs-where_density-vertical.rs
+++ b/tests/target/configs-where_density-vertical.rs
@@ -1,0 +1,13 @@
+// rustfmt-where_density: Vertical
+// Where density
+
+trait Lorem {
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit
+        where Dolor: Eq;
+
+    fn ipsum<Dolor>(dolor: Dolor) -> Sit
+        where Dolor: Eq
+    {
+        // body
+    }
+}

--- a/tests/target/configs-where_layout-horizontal.rs
+++ b/tests/target/configs-where_layout-horizontal.rs
@@ -1,0 +1,15 @@
+// rustfmt-where_layout: Horizontal
+// rustfmt-error_on_line_overflow: false
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor)
+    where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur
+{
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet)
+    where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur, Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit
+{
+    // body
+}

--- a/tests/target/configs-where_layout-horizontal_vertical.rs
+++ b/tests/target/configs-where_layout-horizontal_vertical.rs
@@ -1,0 +1,17 @@
+// rustfmt-where_layout: HorizontalVertical
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor)
+    where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur
+{
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet)
+    where Ipsum: IpsumDolorSitAmet,
+          Dolor: DolorSitAmetConsectetur,
+          Sit: SitAmetConsecteturAdipiscing,
+          Amet: AmetConsecteturAdipiscingElit
+{
+    // body
+}

--- a/tests/target/configs-where_layout-mixed.rs
+++ b/tests/target/configs-where_layout-mixed.rs
@@ -1,0 +1,15 @@
+// rustfmt-where_layout: Mixed
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor)
+    where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur
+{
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet)
+    where Ipsum: IpsumDolorSitAmet, Dolor: DolorSitAmetConsectetur,
+          Sit: SitAmetConsecteturAdipiscing, Amet: AmetConsecteturAdipiscingElit
+{
+    // body
+}

--- a/tests/target/configs-where_layout-vertical.rs
+++ b/tests/target/configs-where_layout-vertical.rs
@@ -1,0 +1,18 @@
+// rustfmt-where_layout: Vertical
+// Where layout
+
+fn lorem<Ipsum, Dolor>(ipsum: Ipsum, dolor: Dolor)
+    where Ipsum: IpsumDolorSitAmet,
+          Dolor: DolorSitAmetConsectetur
+{
+    // body
+}
+
+fn lorem<Ipsum, Dolor, Sit, Amet>(ipsum: Ipsum, dolor: Dolor, sit: Sit, amet: Amet)
+    where Ipsum: IpsumDolorSitAmet,
+          Dolor: DolorSitAmetConsectetur,
+          Sit: SitAmetConsecteturAdipiscing,
+          Amet: AmetConsecteturAdipiscingElit
+{
+    // body
+}

--- a/tests/target/configs-where_pred_indent-block.rs
+++ b/tests/target/configs-where_pred_indent-block.rs
@@ -1,0 +1,11 @@
+// rustfmt-where_pred_indent: Block
+// Where predicate indent
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T
+    where Ipsum: Eq,
+        Dolor: Eq,
+        Sit: Eq,
+        Amet: Eq
+{
+    // body
+}

--- a/tests/target/configs-where_pred_indent-visual.rs
+++ b/tests/target/configs-where_pred_indent-visual.rs
@@ -1,0 +1,11 @@
+// rustfmt-where_pred_indent: Visual
+// Where predicate indent
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T
+    where Ipsum: Eq,
+          Dolor: Eq,
+          Sit: Eq,
+          Amet: Eq
+{
+    // body
+}

--- a/tests/target/configs-where_style-default.rs
+++ b/tests/target/configs-where_style-default.rs
@@ -1,0 +1,11 @@
+// rustfmt-where_style: Default
+// Where style
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T
+    where Ipsum: Eq,
+          Dolor: Eq,
+          Sit: Eq,
+          Amet: Eq
+{
+    // body
+}

--- a/tests/target/configs-where_style-rfc.rs
+++ b/tests/target/configs-where_style-rfc.rs
@@ -1,0 +1,12 @@
+// rustfmt-where_style: Rfc
+// Where style
+
+fn lorem<Ipsum, Dolor, Sit, Amet>() -> T
+where
+    Ipsum: Eq,
+    Dolor: Eq,
+    Sit: Eq,
+    Amet: Eq,
+{
+    // body
+}

--- a/tests/target/configs-wrap_comments-false.rs
+++ b/tests/target/configs-wrap_comments-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: false
+// rustfmt-max_width: 50
+// rustfmt-error_on_line_overflow: false
+// Wrap comments
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+}

--- a/tests/target/configs-wrap_comments-true.rs
+++ b/tests/target/configs-wrap_comments-true.rs
@@ -1,0 +1,12 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 50
+// Wrap comments
+
+fn main() {
+    // Lorem ipsum dolor sit amet, consectetur
+    // adipiscing elit, sed do eiusmod tempor
+    // incididunt ut labore et dolore magna
+    // aliqua. Ut enim ad minim veniam, quis
+    // nostrud exercitation ullamco laboris nisi
+    // ut aliquip ex ea commodo consequat.
+}

--- a/tests/target/configs-wrap_match_arms-false.rs
+++ b/tests/target/configs-wrap_match_arms-false.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_match_arms: false
+// Wrap match-arms
+
+fn main() {
+    match lorem {
+        true => {
+            let ipsum = dolor;
+            println!("{:?}", ipsum);
+        }
+        false => {
+            println!("{}", sit)
+        }
+    }
+}

--- a/tests/target/configs-wrap_match_arms-true.rs
+++ b/tests/target/configs-wrap_match_arms-true.rs
@@ -1,0 +1,12 @@
+// rustfmt-wrap_match_arms: true
+// Wrap match-arms
+
+fn main() {
+    match lorem {
+        true => {
+            let ipsum = dolor;
+            println!("{}", ipsum);
+        }
+        false => println!("{}", sit),
+    }
+}


### PR DESCRIPTION
Based on PR https://github.com/rust-lang-nursery/rustfmt/pull/1474 I created isolated source/target test files for each config option.

120 tests in total.

Search for `FIXME:` for possible malformatting related to:

1. [`fn_args_density = "CompressedIfEmpty"` appears to be broken in rustfmt](https://github.com/rust-lang-nursery/rustfmt/issues/1483)
2. [`where_indent` appears to be ignored completely by rustfmt](https://github.com/rust-lang-nursery/rustfmt/issues/1484)
3. [`where_density = "Vertical"` behaves like `where_density = "Tall"`](https://github.com/rust-lang-nursery/rustfmt/issues/1485)

I wasn't sure where to put the tests (if they should go into a subdir), so please feel free to recommend a different location, or just move then yourself. 🙂 