### PR TITLE
Better file_lines

### DIFF
--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -144,6 +144,20 @@ impl FileLines {
             Err(_) => false,
         }
     }
+
+    pub fn contains_line(&self, file_name: &str, line: usize) -> bool {
+        let map = match self.0 {
+            // `None` means "all lines in all files".
+            None => return true,
+            Some(ref map) => map,
+        };
+
+        match canonicalize_path_string(file_name)
+                  .and_then(|canonical| map.get_vec(&canonical).ok_or(())) {
+            Ok(ranges) => ranges.iter().any(|r| r.lo <= line && r.hi >= line),
+            Err(_) => false,
+        }
+    }
 }
 
 /// FileLines files iterator.

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -158,6 +158,20 @@ impl FileLines {
             Err(_) => false,
         }
     }
+
+    pub fn intersects_range(&self, file_name: &str, lo: usize, hi: usize) -> bool {
+        let map = match self.0 {
+            // `None` means "all lines in all files".
+            None => return true,
+            Some(ref map) => map,
+        };
+
+        match canonicalize_path_string(file_name)
+                  .and_then(|canonical| map.get_vec(&canonical).ok_or(())) {
+            Ok(ranges) => ranges.iter().any(|r| r.intersects(Range::new(lo, hi))),
+            Err(_) => false,
+        }
+    }
 }
 
 /// FileLines files iterator.

--- a/tests/source/file-lines-4.rs
+++ b/tests/source/file-lines-4.rs
@@ -11,10 +11,10 @@ fn floaters() {
     let y = if cond {
                 val1
             } else {
-                val2
+                val2	
             }
                 .method_call();
-
+                                                                                              // aaaaaaaaaaaaa
     {
         match x {
             PushParam => {
@@ -24,6 +24,6 @@ fn floaters() {
                                         }]
                                .clone());
             }
-        }
+        }    
     }
 }

--- a/tests/source/file-lines-5.rs
+++ b/tests/source/file-lines-5.rs
@@ -1,0 +1,17 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[3,5]}]
+
+struct A {
+t: i64,     
+}
+
+mod foo {
+    fn bar() {
+                         // test
+                             let i = 12;
+                                 // test
+    }
+    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    fn baz() {
+        let j = 15;     
+    }
+}

--- a/tests/source/file-lines-6.rs
+++ b/tests/source/file-lines-6.rs
@@ -1,0 +1,18 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-6.rs","range":[9,10]}]
+
+struct A {
+    t: i64,
+}
+
+mod foo {
+    fn bar() {
+                         // test	
+                             let i = 12;
+                                 // test
+    }
+
+    fn baz() {
+///
+        let j = 15;     
+    }
+}

--- a/tests/target/file-lines-4.rs
+++ b/tests/target/file-lines-4.rs
@@ -11,10 +11,10 @@ fn floaters() {
     let y = if cond {
                 val1
             } else {
-                val2
+                val2	
             }
                 .method_call();
-
+                                                                                              // aaaaaaaaaaaaa
     {
         match x {
             PushParam => {
@@ -24,6 +24,6 @@ fn floaters() {
                                         }]
                                .clone());
             }
-        }
+        }    
     }
 }

--- a/tests/target/file-lines-5.rs
+++ b/tests/target/file-lines-5.rs
@@ -1,0 +1,17 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-5.rs","range":[3,5]}]
+
+struct A {
+    t: i64,
+}
+
+mod foo {
+    fn bar() {
+                         // test
+                             let i = 12;
+                                 // test
+    }
+    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    fn baz() {
+        let j = 15;     
+    }
+}

--- a/tests/target/file-lines-6.rs
+++ b/tests/target/file-lines-6.rs
@@ -1,0 +1,18 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-6.rs","range":[9,10]}]
+
+struct A {
+    t: i64,
+}
+
+mod foo {
+    fn bar() {
+        // test
+        let i = 12;
+                                 // test
+    }
+
+    fn baz() {
+///
+        let j = 15;     
+    }
+}


### PR DESCRIPTION
This patch makes rustfmt respect the file_lines argument in more places.

For example, trying to format the first three lines of example.rs:
```rust
struct A {
t: i64,     
}

mod foo {
    fn bar() {
                         // test
                             let i = 12;
                                 // test
    }
    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    fn baz() {
        let j = 15;     
    }
}
```

with this command:
```
rustfmt  --write-mode=diff --file-lines '[{"file": "example.rs", "range": [0, 2]}]' example.rs
```
used to produce this output:
```diff
Diff in example.rs at line 1:
 struct A {⏎
-t: i64,     ⏎
+    t: i64,⏎
 }⏎
 ⏎
 mod foo {⏎
Diff in example.rs at line 6:
     fn bar() {⏎
-                         // test⏎
+        // test⏎
                              let i = 12;⏎
-                                 // test⏎
+        // test⏎
     }⏎
     // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa⏎
     fn baz() {⏎
Diff in example.rs at line 13:
-        let j = 15;     ⏎
+        let j = 15;⏎
     }⏎
 }⏎
Rustfmt failed at example.rs:11: line exceeded maximum length (maximum: 100, found: 128) (sorry)
```

but now only this:
```diff
Diff in example.rs at line 1:
 struct A {⏎
-t: i64,     ⏎
+    t: i64,⏎
 }⏎
 ⏎
 mod foo {⏎
```