### PR TITLE
Add fallback path inside rewrite_closure

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -530,13 +530,11 @@ fn rewrite_closure(capture: ast::CaptureBy,
             // We need braces, but we might still prefer a one-liner.
             let stmt = &block.stmts[0];
             // 4 = braces and spaces.
-            let mut rewrite = stmt.rewrite(context, try_opt!(body_shape.sub_width(4)));
-
-            // Checks if rewrite succeeded and fits on a single line.
-            rewrite = and_one_line(rewrite);
-
-            if let Some(rewrite) = rewrite {
-                return Some(format!("{} {{ {} }}", prefix, rewrite));
+            if let Some(body_shape) = body_shape.sub_width(4) {
+                // Checks if rewrite succeeded and fits on a single line.
+                if let Some(rewrite) = and_one_line(stmt.rewrite(context, body_shape)) {
+                    return Some(format!("{} {{ {} }}", prefix, rewrite));
+                }
             }
         }
 

--- a/tests/source/closure.rs
+++ b/tests/source/closure.rs
@@ -120,3 +120,14 @@ fn issue470() {
             });
     }}}
 }
+
+// #1509
+impl Foo {
+    pub fn bar(&self) {
+        Some(SomeType {
+            push_closure_out_to_100_chars: iter(otherwise_it_works_ok.into_iter().map(|f| {
+                Ok(f)
+            })),
+        })
+    }
+}

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -139,3 +139,14 @@ fn issue470() {
         }
     }
 }
+
+// #1509
+impl Foo {
+    pub fn bar(&self) {
+        Some(SomeType {
+                 push_closure_out_to_100_chars: iter(otherwise_it_works_ok.into_iter().map(|f| {
+                                                                                               Ok(f)
+                                                                                           })),
+             })
+    }
+}


### PR DESCRIPTION
This PR closes #1509.
Now we have a fixpoint:
```rust
impl Foo {
    pub fn bar(&self) {
        Some(SomeType {
                 push_closure_out_to_100_chars: iter(otherwise_it_works_ok.into_iter().map(|f| {
                                                                                               Ok(f)
                                                                                           })),
             })
    }
}
```