### PR TITLE
Allow config-path to point to a file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -237,16 +237,24 @@ macro_rules! create_config {
             }
 
             pub fn from_toml(toml: &str) -> Result<Config, String> {
-                let parsed: toml::Value = toml.parse().expect("Could not parse TOML");
+                let parsed: toml::Value =
+                    toml.parse().map_err(|e| format!("Could not parse TOML: {}", e))?;
                 let mut err: String = String::new();
-                for (key, _) in parsed.as_table().expect("Parsed config was not table") {
-                    match &**key {
-                        $(
-                            stringify!($i) => (),
-                        )+
-                        _ => {
-                            let msg = &format!("Warning: Unknown configuration option `{}`\n", key);
-                            err.push_str(msg)
+                {
+                    let table = parsed
+                        .as_table()
+                        .ok_or(String::from("Parsed config was not table"))?;
+                    for (key, _) in table {
+                        match &**key {
+                            $(
+                                stringify!($i) => (),
+                            )+
+                                _ => {
+                                    let msg =
+                                        &format!("Warning: Unknown configuration option `{}`\n",
+                                                 key);
+                                    err.push_str(msg)
+                                }
                         }
                     }
                 }


### PR DESCRIPTION
This PR allow `config-path` to point to a file. Closes #1429.

e.g.
```
rustfmt --config-path rfc-rustfmt.toml src/lib.rs
```
Also, this PR

1. prevents rustfmt from using default config when `config-path` is specified.
2. adds newline between an error messge and an usage message to improve readability.
3. prevents panicking when reading invalid config file (closes #1082).