### PR TITLE
Add methods to Shape

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -592,10 +592,7 @@ fn rewrite_closure(capture: ast::CaptureBy,
 
         // The body of the closure is big enough to be block indented, that
         // means we must re-format.
-        let block_shape = Shape {
-            width: context.config.max_width - shape.block().indent.width(),
-            ..shape.block()
-        };
+        let block_shape = shape.block().with_max_width(context.config);
         let block_str = try_opt!(block.rewrite(&context, block_shape));
         Some(format!("{} {}",
                      prefix,
@@ -1212,11 +1209,7 @@ fn rewrite_match(context: &RewriteContext,
         result.push('\n');
         result.push_str(&arm_indent_str);
 
-        let arm_str = arm.rewrite(&context,
-                                  Shape {
-                                      width: context.config.max_width - arm_shape.indent.width(),
-                                      ..arm_shape
-                                  });
+        let arm_str = arm.rewrite(&context, arm_shape.with_max_width(context.config));
         if let Some(ref arm_str) = arm_str {
             result.push_str(arm_str);
         } else {
@@ -1323,10 +1316,7 @@ impl Rewrite for ast::Arm {
         let pats_str = try_opt!(write_list(items, &fmt));
 
         let guard_shape = if pats_str.contains('\n') {
-            Shape {
-                width: context.config.max_width - shape.indent.width(),
-                ..shape
-            }
+            shape.with_max_width(context.config)
         } else {
             shape
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,34 +298,27 @@ impl Shape {
     }
 
     pub fn block_left(&self, width: usize) -> Option<Shape> {
-        let block_shape = self.block_indent(width);
-        Some(Shape {
-                 width: try_opt!(block_shape.width.checked_sub(width)),
-                 ..block_shape
-             })
+        self.block_indent(width).sub_width(width)
     }
 
     pub fn add_offset(&self, extra_width: usize) -> Shape {
         Shape {
-            width: self.width,
-            indent: self.indent,
             offset: self.offset + extra_width,
+            ..*self
         }
     }
 
     pub fn block(&self) -> Shape {
         Shape {
-            width: self.width,
             indent: self.indent.block_only(),
-            offset: self.offset,
+            ..*self
         }
     }
 
     pub fn sub_width(&self, width: usize) -> Option<Shape> {
         Some(Shape {
                  width: try_opt!(self.width.checked_sub(width)),
-                 indent: self.indent,
-                 offset: self.offset,
+                 ..*self
              })
     }
 
@@ -338,11 +331,7 @@ impl Shape {
     }
 
     pub fn offset_left(&self, width: usize) -> Option<Shape> {
-        Some(Shape {
-                 width: try_opt!(self.width.checked_sub(width)),
-                 indent: self.indent,
-                 offset: self.offset + width,
-             })
+        self.add_offset(width).sub_width(width)
     }
 
     pub fn used_width(&self) -> usize {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -62,10 +62,9 @@ impl<'a> FmtVisitor<'a> {
             ast::StmtKind::Local(..) |
             ast::StmtKind::Expr(..) |
             ast::StmtKind::Semi(..) => {
-                let rewrite = stmt.rewrite(&self.get_context(),
-                                           Shape::legacy(self.config.max_width -
-                                                         self.block_indent.width(),
-                                                         self.block_indent));
+                let rewrite =
+                    stmt.rewrite(&self.get_context(),
+                                 Shape::indented(self.block_indent, self.config));
                 if rewrite.is_none() {
                     self.failed = true;
                 }
@@ -497,8 +496,7 @@ impl<'a> FmtVisitor<'a> {
 
         let rewrite = outers
             .rewrite(&self.get_context(),
-                     Shape::legacy(self.config.max_width - self.block_indent.width(),
-                                   self.block_indent))
+                     Shape::indented(self.block_indent, self.config))
             .unwrap();
         self.buffer.push_str(&rewrite);
         let last = outers.last().unwrap();

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -455,10 +455,7 @@ impl<'a> FmtVisitor<'a> {
             codemap: parse_session.codemap(),
             buffer: StringBuffer::new(),
             last_pos: BytePos(0),
-            block_indent: Indent {
-                block_indent: 0,
-                alignment: 0,
-            },
+            block_indent: Indent::empty(),
             config: config,
             failed: false,
         }


### PR DESCRIPTION
While reading the code, I found following two patterns to be pervasive.

```rust
// 1
let max_width = context.config.max_width - indent.width();
let shape = Shape::legacy(max_width, indent);
```
```rust
// 2
let new_shape = Shape {
    width: context.config.max_width - shape.indent.width(),
    **shape
}
```

This PR adds above two methods and does minor refactorings.