### PR TITLE
Replace 'try!' with '?'

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -105,7 +105,7 @@ pub enum Verbosity {
 fn format_crate(verbosity: Verbosity,
                 workspace_hitlist: WorkspaceHitlist)
                 -> Result<ExitStatus, std::io::Error> {
-    let targets = try!(get_targets(workspace_hitlist));
+    let targets = get_targets(workspace_hitlist)?;
 
     // Currently only bin and lib files get formatted
     let files: Vec<_> = targets
@@ -181,7 +181,7 @@ impl WorkspaceHitlist {
 fn get_targets(workspace_hitlist: WorkspaceHitlist) -> Result<Vec<Target>, std::io::Error> {
     let mut targets: Vec<Target> = vec![];
     if workspace_hitlist == WorkspaceHitlist::None {
-        let output = try!(Command::new("cargo").arg("read-manifest").output());
+        let output = Command::new("cargo").arg("read-manifest").output()?;
         if output.status.success() {
             // None of the unwraps should fail if output of `cargo read-manifest` is correct
             let data = &String::from_utf8(output.stdout).unwrap();
@@ -287,7 +287,7 @@ fn format_files(files: &[PathBuf],
         }
         println!("");
     }
-    let mut command = try!(Command::new("rustfmt")
+    let mut command = Command::new("rustfmt")
         .stdout(stdout)
         .args(files)
         .args(fmt_args)
@@ -298,6 +298,6 @@ fn format_files(files: &[PathBuf],
                                     "Could not run rustfmt, please make sure it is in your PATH.")
             }
             _ => e,
-        }));
+        })?;
     command.wait()
 }

--- a/src/checkstyle.rs
+++ b/src/checkstyle.rs
@@ -20,7 +20,7 @@ pub fn output_header<T>(out: &mut T, mode: WriteMode) -> Result<(), io::Error>
         xml_heading.push_str("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
         xml_heading.push_str("\n");
         xml_heading.push_str("<checkstyle version=\"4.3\">");
-        try!(write!(out, "{}", xml_heading));
+        write!(out, "{}", xml_heading)?;
     }
     Ok(())
 }
@@ -31,7 +31,7 @@ pub fn output_footer<T>(out: &mut T, mode: WriteMode) -> Result<(), io::Error>
     if mode == WriteMode::Checkstyle {
         let mut xml_tail = String::new();
         xml_tail.push_str("</checkstyle>");
-        try!(write!(out, "{}", xml_tail));
+        write!(out, "{}", xml_tail)?;
     }
     Ok(())
 }
@@ -42,21 +42,21 @@ pub fn output_checkstyle_file<T>(mut writer: T,
                                  -> Result<(), io::Error>
     where T: Write
 {
-    try!(write!(writer, "<file name=\"{}\">", filename));
+    write!(writer, "<file name=\"{}\">", filename)?;
     for mismatch in diff {
         for line in mismatch.lines {
             // Do nothing with `DiffLine::Context` and `DiffLine::Resulting`.
             if let DiffLine::Expected(ref str) = line {
                 let message = xml_escape_str(str);
-                try!(write!(writer,
-                            "<error line=\"{}\" severity=\"warning\" message=\"Should be `{}`\" \
+                write!(writer,
+                       "<error line=\"{}\" severity=\"warning\" message=\"Should be `{}`\" \
                              />",
-                            mismatch.line_number,
-                            message));
+                       mismatch.line_number,
+                       message)?;
             }
         }
     }
-    try!(write!(writer, "</file>"));
+    write!(writer, "</file>")?;
     Ok(())
 }
 

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -173,8 +173,10 @@ impl str::FromStr for FileLines {
     type Err = String;
 
     fn from_str(s: &str) -> Result<FileLines, String> {
-        let v: Vec<JsonSpan> = try!(json::from_str(s).map_err(|e| e.to_string()));
-        let m = try!(v.into_iter().map(JsonSpan::into_tuple).collect());
+        let v: Vec<JsonSpan> = json::from_str(s).map_err(|e| e.to_string())?;
+        let m = v.into_iter()
+            .map(JsonSpan::into_tuple)
+            .collect::<Result<_, _>>()?;
         Ok(FileLines::from_multimap(m))
     }
 }
@@ -190,8 +192,8 @@ impl JsonSpan {
     // To allow `collect()`ing into a `MultiMap`.
     fn into_tuple(self) -> Result<(String, Range), String> {
         let (lo, hi) = self.range;
-        let canonical = try!(canonicalize_path_string(&self.file)
-                                 .map_err(|_| format!("Can't canonicalize {}", &self.file)));
+        let canonical = canonicalize_path_string(&self.file)
+            .map_err(|_| format!("Can't canonicalize {}", &self.file))?;
         Ok((canonical, Range::new(lo, hi)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,13 +414,13 @@ impl fmt::Display for FormatReport {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for (file, errors) in &self.file_error_map {
             for error in errors {
-                try!(write!(fmt,
-                            "{} {}:{}: {} {}\n",
-                            error.msg_prefix(),
-                            file,
-                            error.line,
-                            error.kind,
-                            error.msg_suffix()));
+                write!(fmt,
+                       "{} {}:{}: {} {}\n",
+                       error.msg_prefix(),
+                       file,
+                       error.line,
+                       error.kind,
+                       error.msg_suffix())?;
             }
         }
         Ok(())
@@ -454,7 +454,7 @@ fn format_ast<F>(krate: &ast::Crate,
         let mut visitor = FmtVisitor::from_codemap(parse_session, config);
         visitor.format_separate_mod(module);
 
-        has_diff |= try!(after_file(path, &mut visitor.buffer));
+        has_diff |= after_file(path, &mut visitor.buffer)?;
 
         result.push((path.to_owned(), visitor.buffer));
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -211,7 +211,7 @@ macro_rules! impl_enum_decodable {
                         Ok(String::from(value))
                     }
                 }
-                let s = try!(d.deserialize_string(StringOnly::<D>(PhantomData)));
+                let s = d.deserialize_string(StringOnly::<D>(PhantomData))?;
                 $(
                     if stringify!($x).eq_ignore_ascii_case(&s) {
                       return Ok($e::$x);


### PR DESCRIPTION
Closes #1515.
Running rustfmt with `use_try_shorthand = true` worked for most part, except [these two](https://github.com/topecongiro/rustfmt/blob/2776615dc95715d197c2e757ae18b3285f06d80e/src/file_lines.rs#L176-L179) in file_lines.rs. It required type annotation.