### PR TITLE
Use newline only when fn_call_style is Block

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1779,7 +1779,12 @@ fn rewrite_call_args(context: &RewriteContext,
     };
 
     match write_list(&item_vec, &fmt) {
-        Some(ref s) if !s.contains('\n') && s.len() > one_line_width => {
+        // If arguments do not fit in a single line and do not contain newline,
+        // try to put it on the next line. Try this only when we are in block mode
+        // and not rewriting macro.
+        Some(ref s) if context.config.fn_call_style == IndentStyle::Block &&
+                       !force_no_trailing_comma &&
+                       (!s.contains('\n') && s.len() > one_line_width) => {
             fmt.trailing_separator = SeparatorTactic::Vertical;
             write_list(&item_vec, &fmt)
         }

--- a/tests/source/configs-fn_call_style-block-trailing-comma.rs
+++ b/tests/source/configs-fn_call_style-block-trailing-comma.rs
@@ -1,0 +1,7 @@
+// rustfmt-error_on_line_overflow: false
+// rustfmt-fn_call_style: Block
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+}

--- a/tests/source/configs-fn_call_style-visual-trailing-comma.rs
+++ b/tests/source/configs-fn_call_style-visual-trailing-comma.rs
@@ -1,0 +1,7 @@
+// rustfmt-error_on_line_overflow: false
+// rustfmt-fn_call_style: Visual
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+}

--- a/tests/target/configs-fn_call_style-block-trailing-comma.rs
+++ b/tests/target/configs-fn_call_style-block-trailing-comma.rs
@@ -1,0 +1,7 @@
+// rustfmt-error_on_line_overflow: false
+// rustfmt-fn_call_style: Block
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+}

--- a/tests/target/configs-fn_call_style-visual-trailing-comma.rs
+++ b/tests/target/configs-fn_call_style-visual-trailing-comma.rs
@@ -1,0 +1,7 @@
+// rustfmt-error_on_line_overflow: false
+// rustfmt-fn_call_style: Visual
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+}


### PR DESCRIPTION
Closes #1528 (which I introduced, sorry).