### PR TITLE
Change the link of Visual Studio Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can run `rustfmt --help` for more information.
 * [Emacs](https://github.com/rust-lang/rust-mode)
 * [Sublime Text 3](https://packagecontrol.io/packages/BeautifyRust)
 * [Atom](atom.md)
-* Visual Studio Code using [vscode-rust](https://github.com/editor-rs/vscode-rust) or [vsc-rustfmt](https://github.com/Connorcpu/vsc-rustfmt)
+* Visual Studio Code using [vscode-rust](https://github.com/editor-rs/vscode-rust), [vsc-rustfmt](https://github.com/Connorcpu/vsc-rustfmt) or [rls_vscode](https://github.com/jonathandturner/rls_vscode) through RLS.
 
 ## Checking style on a CI server
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can run `rustfmt --help` for more information.
 * [Emacs](https://github.com/rust-lang/rust-mode)
 * [Sublime Text 3](https://packagecontrol.io/packages/BeautifyRust)
 * [Atom](atom.md)
-* Visual Studio Code using [RustyCode](https://github.com/saviorisdead/RustyCode) or [vsc-rustfmt](https://github.com/Connorcpu/vsc-rustfmt)
+* Visual Studio Code using [vscode-rust](https://github.com/editor-rs/vscode-rust) or [vsc-rustfmt](https://github.com/Connorcpu/vsc-rustfmt)
 
 ## Checking style on a CI server
 


### PR DESCRIPTION
This PR changes the link of Visual Studio Code extension in README.md, from [RustyCode](https://github.com/saviorisdead/RustyCode) to [vscode-rust](https://github.com/editor-rs/vscode-rust).

Although the README introduced RustyCode as the extension of rustfmt in Visual Studio Code, RustyCode is no longer maintained according to vscode-rust's README.