### PR TITLE
Use vertical layout when args len is larger than fn_call_width

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1784,7 +1784,8 @@ fn rewrite_call_args(context: &RewriteContext,
         // and not rewriting macro.
         Some(ref s) if context.config.fn_call_style == IndentStyle::Block &&
                        !force_no_trailing_comma &&
-                       (!s.contains('\n') && s.len() > one_line_width) => {
+                       (!s.contains('\n') &&
+                        (s.len() > one_line_width || s.len() > context.config.fn_call_width)) => {
             fmt.trailing_separator = SeparatorTactic::Vertical;
             write_list(&item_vec, &fmt)
         }

--- a/tests/source/configs-fn_call_width-zero.rs
+++ b/tests/source/configs-fn_call_width-zero.rs
@@ -1,0 +1,7 @@
+// rustfmt-fn_call_width: 0
+// rustfmt-fn_call_style: block
+
+// #1508
+fn a() {
+    let x = f(y);
+}

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -13,7 +13,9 @@ fn main() {
         "elit",
     );
     // #1501
-    let hyper = Arc::new(Client::with_connector(HttpsConnector::new(TlsClient::new())));
+    let hyper = Arc::new(
+        Client::with_connector(HttpsConnector::new(TlsClient::new())),
+    );
 }
 
 // #1521

--- a/tests/target/configs-fn_call_width-zero.rs
+++ b/tests/target/configs-fn_call_width-zero.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_call_width: 0
+// rustfmt-fn_call_style: block
+
+// #1508
+fn a() {
+    let x = f(
+        y,
+    );
+}


### PR DESCRIPTION
Closes #1508.
A test in `configs-fn_call_style-block.rs` is changed because `Client::with_connector(HttpsConnector::new(TlsClient::new()))` has 61 chars, which is larger than the default `fn_call_width`.