### PR TITLE
Prevent rewriting closure block to expr inside macro

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -440,5 +440,5 @@ fn rewrite_method_call(method_name: ast::Ident,
     let callee_str = format!(".{}{}", method_name, type_str);
     let span = mk_sp(lo, span.hi);
 
-    rewrite_call(context, &callee_str, &args[1..], span, shape, false)
+    rewrite_call(context, &callee_str, &args[1..], span, shape)
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -65,6 +65,8 @@ pub fn rewrite_macro(mac: &ast::Mac,
                      shape: Shape,
                      position: MacroPosition)
                      -> Option<String> {
+    let mut context = &mut context.clone();
+    context.inside_macro = true;
     if context.config.use_try_shorthand {
         if let Some(expr) = convert_try_mac(mac, context) {
             return expr.rewrite(context, shape);
@@ -146,11 +148,12 @@ pub fn rewrite_macro(mac: &ast::Mac,
         MacroStyle::Parens => {
             // Format macro invocation as function call, forcing no trailing
             // comma because not all macros support them.
-            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape, true)
-                .map(|rw| match position {
-                         MacroPosition::Item => format!("{};", rw),
-                         _ => rw,
-                     })
+            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape).map(|rw| {
+                match position {
+                    MacroPosition::Item => format!("{};", rw),
+                    _ => rw,
+                }
+            })
         }
         MacroStyle::Brackets => {
             // Format macro invocation as array literal.

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -26,6 +26,7 @@ pub struct RewriteContext<'a> {
     pub parse_session: &'a ParseSess,
     pub codemap: &'a CodeMap,
     pub config: &'a Config,
+    pub inside_macro: bool,
 }
 
 impl<'a> RewriteContext<'a> {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -574,6 +574,7 @@ impl<'a> FmtVisitor<'a> {
             parse_session: self.parse_session,
             codemap: self.codemap,
             config: self.config,
+            inside_macro: false,
         }
     }
 }

--- a/tests/target/closure-block-inside-macro.rs
+++ b/tests/target/closure-block-inside-macro.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_style: Block
+
+// #1547
+fuzz_target!(
+    |data: &[u8]| {
+        if let Some(first) = data.first() {
+            let index = *first as usize;
+            if index >= ENCODINGS.len() {
+                return;
+            }
+            let encoding = ENCODINGS[index];
+            dispatch_test(encoding, &data[1..]);
+        }
+    }
+);


### PR DESCRIPTION
Closes #1547, although I am not sure whether `RewriteContext` is a good place to add additional information.