### PR TITLE
Only add offset for unary op

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1961,14 +1961,14 @@ pub fn rewrite_tuple<'a, I>(context: &RewriteContext,
         // 3 = "(" + ",)"
         let nested_shape = try_opt!(shape.sub_width(3)).visual_indent(1);
         return items
-                   .next()
-                   .unwrap()
-                   .rewrite(context, nested_shape)
-                   .map(|s| if context.config.spaces_within_parens {
-                            format!("( {}, )", s)
-                        } else {
-                            format!("({},)", s)
-                        });
+            .next()
+            .unwrap()
+            .rewrite(context, nested_shape)
+            .map(|s| if context.config.spaces_within_parens {
+                     format!("( {}, )", s)
+                 } else {
+                     format!("({},)", s)
+                 });
     }
 
     let list_lo = context.codemap.span_after(span, "(");

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -131,16 +131,16 @@ impl BadIssueSeeker {
             todo_idx += 1;
             if todo_idx == TO_DO_CHARS.len() {
                 return Seeking::Number {
-                           issue: Issue {
-                               issue_type: IssueType::Todo,
-                               missing_number: if let ReportTactic::Unnumbered = self.report_todo {
-                                   true
-                               } else {
-                                   false
-                               },
-                           },
-                           part: NumberPart::OpenParen,
-                       };
+                    issue: Issue {
+                        issue_type: IssueType::Todo,
+                        missing_number: if let ReportTactic::Unnumbered = self.report_todo {
+                            true
+                        } else {
+                            false
+                        },
+                    },
+                    part: NumberPart::OpenParen,
+                };
             }
             fixme_idx = 0;
         } else if self.report_fixme.is_enabled() && c == FIX_ME_CHARS[fixme_idx] {
@@ -149,17 +149,16 @@ impl BadIssueSeeker {
             fixme_idx += 1;
             if fixme_idx == FIX_ME_CHARS.len() {
                 return Seeking::Number {
-                           issue: Issue {
-                               issue_type: IssueType::Fixme,
-                               missing_number: if let ReportTactic::Unnumbered =
-                    self.report_fixme {
-                                   true
-                               } else {
-                                   false
-                               },
-                           },
-                           part: NumberPart::OpenParen,
-                       };
+                    issue: Issue {
+                        issue_type: IssueType::Fixme,
+                        missing_number: if let ReportTactic::Unnumbered = self.report_fixme {
+                            true
+                        } else {
+                            false
+                        },
+                    },
+                    part: NumberPart::OpenParen,
+                };
             }
             todo_idx = 0;
         } else {
@@ -182,10 +181,10 @@ impl BadIssueSeeker {
             return IssueClassification::Bad(issue);
         } else if c == ')' {
             return if let NumberPart::CloseParen = part {
-                       IssueClassification::Good
-                   } else {
-                       IssueClassification::Bad(issue)
-                   };
+                IssueClassification::Good
+            } else {
+                IssueClassification::Bad(issue)
+            };
         }
 
         match part {

--- a/src/items.rs
+++ b/src/items.rs
@@ -1104,7 +1104,7 @@ fn format_tuple_struct(context: &RewriteContext,
         // know that earlier, so the where clause will not be indented properly.
         result.push('\n');
         result.push_str(&(offset.block_only() + (context.config.tab_spaces - 1))
-                             .to_string(context.config));
+                            .to_string(context.config));
     }
     result.push_str(&where_clause_str);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -94,13 +94,13 @@ pub fn rewrite_macro(mac: &ast::Mac,
 
     if mac.node.tts.is_empty() && !contains_comment(&context.snippet(mac.span)) {
         return match style {
-                   MacroStyle::Parens if position == MacroPosition::Item => {
-                       Some(format!("{}();", macro_name))
-                   }
-                   MacroStyle::Parens => Some(format!("{}()", macro_name)),
-                   MacroStyle::Brackets => Some(format!("{}[]", macro_name)),
-                   MacroStyle::Braces => Some(format!("{}{{}}", macro_name)),
-               };
+            MacroStyle::Parens if position == MacroPosition::Item => {
+                Some(format!("{}();", macro_name))
+            }
+            MacroStyle::Parens => Some(format!("{}()", macro_name)),
+            MacroStyle::Brackets => Some(format!("{}[]", macro_name)),
+            MacroStyle::Braces => Some(format!("{}{{}}", macro_name)),
+        };
     }
 
     let mut parser = tts_to_parser(context.parse_session, mac.node.tts.clone());

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -138,8 +138,8 @@ impl<'a> FmtVisitor<'a> {
 
                 if rewrite_next_comment &&
                    !self.config
-                        .file_lines
-                        .intersects_range(file_name, cur_line, cur_line + subslice_num_lines) {
+                       .file_lines
+                       .intersects_range(file_name, cur_line, cur_line + subslice_num_lines) {
                     rewrite_next_comment = false;
                 }
 
@@ -164,7 +164,7 @@ impl<'a> FmtVisitor<'a> {
                                                    Shape::legacy(comment_width,
                                                                  self.block_indent),
                                                    self.config)
-                                           .unwrap());
+                                          .unwrap());
 
                     last_wspace = None;
                     line_start = offset + subslice.len();
@@ -172,9 +172,9 @@ impl<'a> FmtVisitor<'a> {
                     if let Some('/') = subslice.chars().skip(1).next() {
                         // check that there are no contained block comments
                         if !subslice
-                                .split('\n')
-                                .map(|s| s.trim_left())
-                                .any(|s| s.len() > 2 && &s[0..2] == "/*") {
+                               .split('\n')
+                               .map(|s| s.trim_left())
+                               .any(|s| s.len() > 2 && &s[0..2] == "/*") {
                             // Add a newline after line comments
                             self.buffer.push_str("\n");
                         }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -28,9 +28,7 @@ use syntax::codemap::{self, BytePos, Span};
 impl Rewrite for Pat {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         match self.node {
-            PatKind::Box(ref pat) => {
-                rewrite_unary_prefix(context, "box ", &**pat, shape, self.span)
-            }
+            PatKind::Box(ref pat) => rewrite_unary_prefix(context, "box ", &**pat, shape),
             PatKind::Ident(binding_mode, ident, ref sub_pat) => {
                 let (prefix, mutability) = match binding_mode {
                     BindingMode::ByRef(mutability) => ("ref ", mutability),
@@ -74,7 +72,7 @@ impl Rewrite for Pat {
             }
             PatKind::Ref(ref pat, mutability) => {
                 let prefix = format!("&{}", format_mutability(mutability));
-                rewrite_unary_prefix(context, &prefix, &**pat, shape, self.span)
+                rewrite_unary_prefix(context, &prefix, &**pat, shape)
             }
             PatKind::Tuple(ref items, dotdot_pos) => {
                 rewrite_tuple_pat(items, dotdot_pos, None, self.span, context, shape)

--- a/src/types.rs
+++ b/src/types.rs
@@ -595,7 +595,7 @@ impl Rewrite for ast::Ty {
                     Mutability::Immutable => "*const ",
                 };
 
-                rewrite_unary_prefix(context, prefix, &*mt.ty, shape, self.span)
+                rewrite_unary_prefix(context, prefix, &*mt.ty, shape)
             }
             ast::TyKind::Rptr(ref lifetime, ref mt) => {
                 let mut_str = format_mutability(mt.mutbl);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -50,8 +50,8 @@ impl<'a> FmtVisitor<'a> {
 
         // FIXME(#434): Move this check to somewhere more central, eg Rewrite.
         if !self.config
-                .file_lines
-                .intersects(&self.codemap.lookup_line_range(stmt.span)) {
+               .file_lines
+               .intersects(&self.codemap.lookup_line_range(stmt.span)) {
             return;
         }
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -79,3 +79,9 @@ gfx_pipeline!(pipe {
 fn issue_1279() {
     println!("dsfs"); // a comment
 }
+
+fn issue_1555() {
+    let hello = &format!("HTTP/1.1 200 OK\r\nServer: {}\r\n\r\n{}",
+                         "65454654654654654654654655464",
+                         "4");
+}

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -80,3 +80,9 @@ gfx_pipeline!(pipe {
 fn issue_1279() {
     println!("dsfs"); // a comment
 }
+
+fn issue_1555() {
+    let hello = &format!("HTTP/1.1 200 OK\r\nServer: {}\r\n\r\n{}",
+                         "65454654654654654654654655464",
+                         "4");
+}


### PR DESCRIPTION
Closes #1555.
Looks good for most part (e.g. using block indent for `return`).
However, I am not sure whether the code like the following is fine:
```rust
!self.
    .file_lines
    .intersects_range(file_name, cur_line, cur_line + subslice_num_lines) {
```
Currently, the above code gets formatted as
```rust
!self.
     .file_lines
     .intersects_range(file_name, cur_line, cur_line + subslice_num_lines) {
```
Basically, since chain is block-indented, after the PR the width of `!` is not taken into account.