### PR TITLE
config: fix `suffices` -> `suffixes` typo

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -166,7 +166,7 @@ Maximum length of comments. No effect unless`wrap_comments = true`.
 
 See also [`wrap_comments`](#wrap_comments).
 
-## `condense_wildcard_suffices`
+## `condense_wildcard_suffixes`
 
 Replace strings of _ wildcards by a single .. in tuple patterns
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -421,6 +421,6 @@ create_config! {
     use_try_shorthand: bool, false, "Replace uses of the try! macro by the ? shorthand";
     write_mode: WriteMode, WriteMode::Replace,
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";
-    condense_wildcard_suffices: bool, false, "Replace strings of _ wildcards by a single .. in \
+    condense_wildcard_suffixes: bool, false, "Replace strings of _ wildcards by a single .. in \
                                               tuple patterns"
 }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -295,7 +295,7 @@ fn rewrite_tuple_pat(pats: &[ptr::P<ast::Pat>],
     // Condense wildcard string suffix into a single ..
     let wildcard_suffix_len = count_wildcard_suffix_len(&items);
 
-    let list = if context.config.condense_wildcard_suffices && wildcard_suffix_len >= 2 {
+    let list = if context.config.condense_wildcard_suffixes && wildcard_suffix_len >= 2 {
         let new_item_count = 1 + pats.len() - wildcard_suffix_len;
         items[new_item_count - 1].item = Some("..".to_owned());
 

--- a/tests/source/configs-condense_wildcard_suffices-false.rs
+++ b/tests/source/configs-condense_wildcard_suffices-false.rs
@@ -1,5 +1,5 @@
-// rustfmt-condense_wildcard_suffices: false
-// Condense wildcard suffices
+// rustfmt-condense_wildcard_suffixes: false
+// Condense wildcard suffixes
 
 fn main() {
     let (lorem, ipsum, _, _) = (1, 2, 3, 4);

--- a/tests/source/configs-condense_wildcard_suffices-true.rs
+++ b/tests/source/configs-condense_wildcard_suffices-true.rs
@@ -1,5 +1,5 @@
-// rustfmt-condense_wildcard_suffices: true
-// Condense wildcard suffices
+// rustfmt-condense_wildcard_suffixes: true
+// Condense wildcard suffixes
 
 fn main() {
     let (lorem, ipsum, _, _) = (1, 2, 3, 4);

--- a/tests/source/pattern-condense-wildcards.rs
+++ b/tests/source/pattern-condense-wildcards.rs
@@ -1,5 +1,5 @@
 // rustfmt-normalize_comments: true
-// rustfmt-condense_wildcard_suffices: true
+// rustfmt-condense_wildcard_suffixes: true
 
 fn main() {
     match x {

--- a/tests/target/configs-condense_wildcard_suffices-false.rs
+++ b/tests/target/configs-condense_wildcard_suffices-false.rs
@@ -1,5 +1,5 @@
-// rustfmt-condense_wildcard_suffices: false
-// Condense wildcard suffices
+// rustfmt-condense_wildcard_suffixes: false
+// Condense wildcard suffixes
 
 fn main() {
     let (lorem, ipsum, _, _) = (1, 2, 3, 4);

--- a/tests/target/configs-condense_wildcard_suffices-true.rs
+++ b/tests/target/configs-condense_wildcard_suffices-true.rs
@@ -1,5 +1,5 @@
-// rustfmt-condense_wildcard_suffices: true
-// Condense wildcard suffices
+// rustfmt-condense_wildcard_suffixes: true
+// Condense wildcard suffixes
 
 fn main() {
     let (lorem, ipsum, ..) = (1, 2, 3, 4);

--- a/tests/target/pattern-condense-wildcards.rs
+++ b/tests/target/pattern-condense-wildcards.rs
@@ -1,5 +1,5 @@
 // rustfmt-normalize_comments: true
-// rustfmt-condense_wildcard_suffices: true
+// rustfmt-condense_wildcard_suffixes: true
 
 fn main() {
     match x {


### PR DESCRIPTION
Fixes #1477.

---
Is backwards compat for the old name wanted to bridge over updates?