### PR TITLE
 Allow first child to stay on the same line with block parent when rewriting chain

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -99,10 +99,14 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     }
 
     // Parent is the first item in the chain, e.g., `foo` in `foo.bar.baz()`.
-    let mut parent_shape = shape;
-    if is_block_expr(&parent, "\n") {
-        parent_shape = chain_indent(context, shape);
-    }
+    let parent_shape = if is_block_expr(context, &parent, "\n") {
+        match context.config.chain_indent() {
+            IndentStyle::Visual => shape.visual_indent(0),
+            IndentStyle::Block => shape.block(),
+        }
+    } else {
+        shape
+    };
     let parent_rewrite = try_opt!(parent.rewrite(context, parent_shape));
     let parent_rewrite_contains_newline = parent_rewrite.contains('\n');
 
@@ -121,10 +125,14 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         (nested_shape,
          context.config.chain_indent() == IndentStyle::Visual ||
          parent_rewrite.len() <= context.config.tab_spaces())
-    } else if is_block_expr(&parent, &parent_rewrite) {
-        // The parent is a block, so align the rest of the chain with the closing
-        // brace.
-        (parent_shape, false)
+    } else if is_block_expr(context, &parent, &parent_rewrite) {
+        match context.config.chain_indent() {
+            // Try to put the first child on the same line with parent's last line
+            IndentStyle::Block => (parent_shape.block_indent(context.config.tab_spaces()), true),
+            // The parent is a block, so align the rest of the chain with the closing
+            // brace.
+            IndentStyle::Visual => (parent_shape, false),
+        }
     } else if parent_rewrite_contains_newline {
         (chain_indent(context, parent_shape), false)
     } else {
@@ -140,11 +148,11 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         ..nested_shape
     };
     let first_child_shape = if extend {
-        let first_child_shape = try_opt!(parent_shape
-                                             .offset_left(last_line_width(&parent_rewrite)));
+        let overhead = last_line_width(&parent_rewrite);
+        let offset = parent_rewrite.lines().rev().next().unwrap().trim().len();
         match context.config.chain_indent() {
-            IndentStyle::Visual => first_child_shape,
-            IndentStyle::Block => first_child_shape.block(),
+            IndentStyle::Visual => try_opt!(parent_shape.offset_left(overhead)),
+            IndentStyle::Block => try_opt!(parent_shape.block().offset_left(offset)),
         }
     } else {
         other_child_shape
@@ -224,8 +232,16 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         format!("\n{}", nested_shape.indent.to_string(context.config))
     };
 
-    let first_connector = if extend || subexpr_list.is_empty() || first_subexpr_is_try {
+    let first_connector = if subexpr_list.is_empty() {
         ""
+    } else if extend || first_subexpr_is_try {
+        // 1 = ";", being conservative here.
+        if last_line_width(&parent_rewrite) + first_line_width(&rewrites[0]) + 1 <=
+           context.config.max_width() {
+            ""
+        } else {
+            &*connector
+        }
     } else {
         &*connector
     };
@@ -277,8 +293,11 @@ fn join_rewrites(rewrites: &[String], subexps: &[ast::Expr], connector: &str) ->
 
 // States whether an expression's last line exclusively consists of closing
 // parens, braces, and brackets in its idiomatic formatting.
-fn is_block_expr(expr: &ast::Expr, repr: &str) -> bool {
+fn is_block_expr(context: &RewriteContext, expr: &ast::Expr, repr: &str) -> bool {
     match expr.node {
+        ast::ExprKind::Call(..) => {
+            context.config.fn_call_style() == IndentStyle::Block && repr.contains('\n')
+        }
         ast::ExprKind::Struct(..) |
         ast::ExprKind::While(..) |
         ast::ExprKind::WhileLet(..) |
@@ -291,7 +310,7 @@ fn is_block_expr(expr: &ast::Expr, repr: &str) -> bool {
         ast::ExprKind::Paren(ref expr) |
         ast::ExprKind::Binary(_, _, ref expr) |
         ast::ExprKind::Index(_, ref expr) |
-        ast::ExprKind::Unary(_, ref expr) => is_block_expr(expr, repr),
+        ast::ExprKind::Unary(_, ref expr) => is_block_expr(context, expr, repr),
         _ => false,
     }
 }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -139,14 +139,8 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         (shape.block_indent(context.config.tab_spaces()), false)
     };
 
-    let max_width = try_opt!((shape.width + shape.indent.width() + shape.offset)
-                                 .checked_sub(nested_shape.indent.width() +
-                                              nested_shape.offset));
+    let other_child_shape = nested_shape.with_max_width(context.config);
 
-    let other_child_shape = Shape {
-        width: max_width,
-        ..nested_shape
-    };
     let first_child_shape = if extend {
         let overhead = last_line_width(&parent_rewrite);
         let offset = parent_rewrite.lines().rev().next().unwrap().trim().len();

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -155,10 +155,10 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
            first_child_shape,
            other_child_shape);
 
-    let child_shape_iter =
-        Some(first_child_shape)
-            .into_iter()
-            .chain(::std::iter::repeat(other_child_shape).take(subexpr_list.len() - 1));
+    let child_shape_iter = Some(first_child_shape)
+        .into_iter()
+        .chain(::std::iter::repeat(other_child_shape)
+                   .take(subexpr_list.len() - 1));
     let iter = subexpr_list.iter().rev().zip(child_shape_iter);
     let mut rewrites =
         try_opt!(iter.map(|(e, shape)| rewrite_chain_subexpr(e, total_span, context, shape))
@@ -175,7 +175,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         if rewrites.len() > 1 {
             true
         } else if rewrites.len() == 1 {
-            one_line_len > shape.width
+            parent_rewrite.len() > context.config.chain_one_line_max() / 2
         } else {
             false
         }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -158,15 +158,14 @@ fn light_rewrite_comment(orig: &str, offset: Indent, config: &Config) -> Option<
             // `*` in `/*`.
             let first_non_whitespace = l.find(|c| !char::is_whitespace(c));
             if let Some(fnw) = first_non_whitespace {
-                    if l.as_bytes()[fnw] == '*' as u8 && fnw > 0 {
-                        &l[fnw - 1..]
-                    } else {
-                        &l[fnw..]
-                    }
+                if l.as_bytes()[fnw] == '*' as u8 && fnw > 0 {
+                    &l[fnw - 1..]
                 } else {
-                    ""
+                    &l[fnw..]
                 }
-                .trim_right()
+            } else {
+                ""
+            }.trim_right()
         })
         .collect();
     Some(lines.join(&format!("\n{}", offset.to_string(config))))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -316,8 +316,7 @@ pub fn rewrite_pair<LHS, RHS>(lhs: &LHS,
     let lhs_budget = try_opt!(context
                                   .config
                                   .max_width()
-                                  .checked_sub(shape.used_width() + prefix.len() +
-                                               infix.len()));
+                                  .checked_sub(shape.used_width() + prefix.len() + infix.len()));
     let rhs_shape = match context.config.control_style() {
         Style::Default => {
             try_opt!(shape.sub_width(suffix.len() + prefix.len())).visual_indent(prefix.len())
@@ -853,8 +852,8 @@ impl<'a> ControlFlow<'a> {
 
             let new_width = try_opt!(new_width.checked_sub(if_str.len()));
             let else_expr = &else_node.stmts[0];
-            let else_str = try_opt!(else_expr.rewrite(context,
-                                                      Shape::legacy(new_width, Indent::empty())));
+            let else_str =
+                try_opt!(else_expr.rewrite(context, Shape::legacy(new_width, Indent::empty())));
 
             if if_str.contains('\n') || else_str.contains('\n') {
                 return None;
@@ -953,14 +952,13 @@ impl<'a> Rewrite for ControlFlow<'a> {
         };
 
         // for event in event
-        let between_kwd_cond =
-            mk_sp(context.codemap.span_after(self.span, self.keyword.trim()),
-                  self.pat
-                      .map_or(cond_span.lo, |p| if self.matcher.is_empty() {
-                p.span.lo
-            } else {
-                context.codemap.span_before(self.span, self.matcher.trim())
-            }));
+        let between_kwd_cond = mk_sp(context.codemap.span_after(self.span, self.keyword.trim()),
+                                     self.pat
+                                         .map_or(cond_span.lo, |p| if self.matcher.is_empty() {
+            p.span.lo
+        } else {
+            context.codemap.span_before(self.span, self.matcher.trim())
+        }));
 
         let between_kwd_cond_comment = extract_comment(between_kwd_cond, context, shape);
 
@@ -1042,9 +1040,10 @@ impl<'a> Rewrite for ControlFlow<'a> {
             let between_kwd_else_block_comment =
                 extract_comment(between_kwd_else_block, context, shape);
 
-            let after_else = mk_sp(context.codemap.span_after(mk_sp(self.block.span.hi,
-                                                                    else_block.span.lo),
-                                                              "else"),
+            let after_else = mk_sp(context
+                                       .codemap
+                                       .span_after(mk_sp(self.block.span.hi, else_block.span.lo),
+                                                   "else"),
                                    else_block.span.lo);
             let after_else_comment = extract_comment(after_else, context, shape);
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -98,16 +98,20 @@ fn format_expr(expr: &ast::Expr,
         }
         ast::ExprKind::Tup(ref items) => rewrite_tuple(context, items, expr.span, shape),
         ast::ExprKind::While(ref cond, ref block, label) => {
-            ControlFlow::new_while(None, cond, block, label, expr.span).rewrite(context, shape)
+            ControlFlow::new_while(None, cond, block, label, expr.span)
+                .rewrite(context, shape)
         }
         ast::ExprKind::WhileLet(ref pat, ref cond, ref block, label) => {
-            ControlFlow::new_while(Some(pat), cond, block, label, expr.span).rewrite(context, shape)
+            ControlFlow::new_while(Some(pat), cond, block, label, expr.span)
+                .rewrite(context, shape)
         }
         ast::ExprKind::ForLoop(ref pat, ref cond, ref block, label) => {
-            ControlFlow::new_for(pat, cond, block, label, expr.span).rewrite(context, shape)
+            ControlFlow::new_for(pat, cond, block, label, expr.span)
+                .rewrite(context, shape)
         }
         ast::ExprKind::Loop(ref block, label) => {
-            ControlFlow::new_loop(block, label, expr.span).rewrite(context, shape)
+            ControlFlow::new_loop(block, label, expr.span)
+                .rewrite(context, shape)
         }
         ast::ExprKind::Block(ref block) => block.rewrite(context, shape),
         ast::ExprKind::If(ref cond, ref if_block, ref else_block) => {
@@ -175,11 +179,12 @@ fn format_expr(expr: &ast::Expr,
         ast::ExprKind::Mac(ref mac) => {
             // Failure to rewrite a marco should not imply failure to
             // rewrite the expression.
-            rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|| {
-                wrap_str(context.snippet(expr.span),
-                         context.config.max_width(),
-                         shape)
-            })
+            rewrite_macro(mac, None, context, shape, MacroPosition::Expression)
+                .or_else(|| {
+                             wrap_str(context.snippet(expr.span),
+                                      context.config.max_width(),
+                                      shape)
+                         })
         }
         ast::ExprKind::Ret(None) => {
             wrap_str("return".to_owned(), context.config.max_width(), shape)
@@ -319,7 +324,8 @@ pub fn rewrite_pair<LHS, RHS>(lhs: &LHS,
                                   .checked_sub(shape.used_width() + prefix.len() + infix.len()));
     let rhs_shape = match context.config.control_style() {
         Style::Default => {
-            try_opt!(shape.sub_width(suffix.len() + prefix.len())).visual_indent(prefix.len())
+            try_opt!(shape.sub_width(suffix.len() + prefix.len()))
+                .visual_indent(prefix.len())
         }
         Style::Rfc => try_opt!(shape.block_left(context.config.tab_spaces())),
     };
@@ -510,7 +516,8 @@ fn rewrite_closure(capture: ast::CaptureBy,
 
     // 1 = space between `|...|` and body.
     let extra_offset = extra_offset(&prefix, shape) + 1;
-    let body_shape = try_opt!(shape.sub_width(extra_offset)).add_offset(extra_offset);
+    let body_shape = try_opt!(shape.sub_width(extra_offset))
+        .add_offset(extra_offset);
 
     if let ast::ExprKind::Block(ref block) = body.node {
         // The body of the closure is an empty block.
@@ -852,8 +859,8 @@ impl<'a> ControlFlow<'a> {
 
             let new_width = try_opt!(new_width.checked_sub(if_str.len()));
             let else_expr = &else_node.stmts[0];
-            let else_str =
-                try_opt!(else_expr.rewrite(context, Shape::legacy(new_width, Indent::empty())));
+            let else_str = try_opt!(else_expr.rewrite(context,
+                                                      Shape::legacy(new_width, Indent::empty())));
 
             if if_str.contains('\n') || else_str.contains('\n') {
                 return None;
@@ -1790,11 +1797,11 @@ fn rewrite_call_args(context: &RewriteContext,
 
 fn can_be_overflowed(context: &RewriteContext, args: &[ptr::P<ast::Expr>]) -> bool {
     match args.last().map(|x| &x.node) {
-        Some(&ast::ExprKind::Block(..)) |
         Some(&ast::ExprKind::Match(..)) => {
             (context.config.fn_call_style() == IndentStyle::Block && args.len() == 1) ||
             (context.config.fn_call_style() == IndentStyle::Visual && args.len() > 1)
         }
+        Some(&ast::ExprKind::Block(..)) |
         Some(&ast::ExprKind::Closure(..)) => {
             context.config.fn_call_style() == IndentStyle::Block ||
             context.config.fn_call_style() == IndentStyle::Visual && args.len() > 1
@@ -1821,6 +1828,7 @@ fn is_extendable(args: &[ptr::P<ast::Expr>]) -> bool {
         }
     } else if args.len() > 1 {
         match args[args.len() - 1].node {
+            ast::ExprKind::Block(..) |
             ast::ExprKind::Closure(..) |
             ast::ExprKind::Tup(..) => true,
             _ => false,

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -126,7 +126,8 @@ impl FileLines {
             Some(ref map) => map,
         };
 
-        match canonicalize_path_string(file_name).and_then(|file| map.get_vec(&file).ok_or(())) {
+        match canonicalize_path_string(file_name)
+                  .and_then(|file| map.get_vec(&file).ok_or(())) {
             Ok(ranges) => ranges.iter().any(f),
             Err(_) => false,
         }

--- a/src/items.rs
+++ b/src/items.rs
@@ -1062,11 +1062,11 @@ fn format_tuple_struct(context: &RewriteContext,
                          |field| field.rewrite(context, Shape::legacy(item_budget, item_indent)),
                          context.codemap.span_after(span, "("),
                          span.hi);
-        let body_budget = try_opt!(context
-                                       .config
-                                       .max_width()
-                                       .checked_sub(offset.block_only().width() + result.len() +
-                                                    3));
+        let body_budget =
+            try_opt!(context
+                         .config
+                         .max_width()
+                         .checked_sub(offset.block_only().width() + result.len() + 3));
         let body = try_opt!(list_helper(items,
                                         // TODO budget is wrong in block case
                                         Shape::legacy(body_budget, item_indent),
@@ -1126,8 +1126,7 @@ pub fn rewrite_type_alias(context: &RewriteContext,
 
     let generics_indent = indent + result.len();
     let generics_span = mk_sp(context.codemap.span_after(span, "type"), ty.span.lo);
-    let shape = try_opt!(Shape::indented(generics_indent, context.config)
-                             .sub_width(" =".len()));
+    let shape = try_opt!(Shape::indented(generics_indent, context.config).sub_width(" =".len()));
     let generics_str = try_opt!(rewrite_generics(context, generics, shape, generics_span));
 
     result.push_str(&generics_str);
@@ -1310,28 +1309,30 @@ pub fn rewrite_associated_type(ident: ast::Ident,
                                -> Option<String> {
     let prefix = format!("type {}", ident);
 
-    let type_bounds_str =
-        if let Some(ty_param_bounds) = ty_param_bounds_opt {
-            let joiner = match context.config.type_punctuation_density() {
-                TypeDensity::Compressed => "+",
-                TypeDensity::Wide => " + ",
-            };
-            let bounds: &[_] = ty_param_bounds;
-            let bound_str = try_opt!(bounds
-                                         .iter()
-                                         .map(|ty_bound| {
-                ty_bound.rewrite(context, Shape::legacy(context.config.max_width(), indent))
-            })
-                                         .intersperse(Some(joiner.to_string()))
-                                         .collect::<Option<String>>());
-            if bounds.len() > 0 {
-                format!(": {}", bound_str)
-            } else {
-                String::new()
-            }
+    let type_bounds_str = if let Some(ty_param_bounds) = ty_param_bounds_opt {
+        let joiner = match context.config.type_punctuation_density() {
+            TypeDensity::Compressed => "+",
+            TypeDensity::Wide => " + ",
+        };
+        let bounds: &[_] = ty_param_bounds;
+        let bound_str =
+            try_opt!(bounds
+                         .iter()
+                         .map(|ty_bound| {
+                                  ty_bound.rewrite(context,
+                                                   Shape::legacy(context.config.max_width(),
+                                                                 indent))
+                              })
+                         .intersperse(Some(joiner.to_string()))
+                         .collect::<Option<String>>());
+        if bounds.len() > 0 {
+            format!(": {}", bound_str)
         } else {
             String::new()
-        };
+        }
+    } else {
+        String::new()
+    };
 
     if let Some(ty) = ty_opt {
         let ty_str = try_opt!(ty.rewrite(context,
@@ -1931,8 +1932,7 @@ fn compute_budgets_for_args(context: &RewriteContext,
             let multi_line_budget = try_opt!(context
                                                  .config
                                                  .max_width()
-                                                 .checked_sub(indent.width() + result.len() +
-                                                              4));
+                                                 .checked_sub(indent.width() + result.len() + 4));
 
             return Some((one_line_budget, multi_line_budget, indent + result.len() + 1));
         }

--- a/src/items.rs
+++ b/src/items.rs
@@ -1126,7 +1126,8 @@ pub fn rewrite_type_alias(context: &RewriteContext,
 
     let generics_indent = indent + result.len();
     let generics_span = mk_sp(context.codemap.span_after(span, "type"), ty.span.lo);
-    let shape = try_opt!(Shape::indented(generics_indent, context.config).sub_width(" =".len()));
+    let shape = try_opt!(Shape::indented(generics_indent, context.config)
+                             .sub_width(" =".len()));
     let generics_str = try_opt!(rewrite_generics(context, generics, shape, generics_span));
 
     result.push_str(&generics_str);

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -430,7 +430,8 @@ impl<'a, T, I, F1, F2, F3> Iterator for ListItems<'a, I, F1, F2, F3>
             let post_snippet_trimmed = if post_snippet.starts_with(',') {
                 post_snippet[1..].trim_matches(white_space)
             } else if post_snippet.ends_with(',') {
-                post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
+                post_snippet[..(post_snippet.len() - 1)]
+                    .trim_matches(white_space)
             } else {
                 post_snippet
             };
@@ -528,7 +529,8 @@ pub fn struct_lit_shape(shape: Shape,
                         -> Option<(Option<Shape>, Shape)> {
     let v_shape = match context.config.struct_lit_style() {
         IndentStyle::Visual => {
-            try_opt!(try_opt!(shape.shrink_left(prefix_width)).sub_width(suffix_width))
+            try_opt!(try_opt!(shape.shrink_left(prefix_width))
+                         .sub_width(suffix_width))
         }
         IndentStyle::Block => {
             let shape = shape.block_indent(context.config.tab_spaces());

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -172,12 +172,11 @@ pub fn rewrite_macro(mac: &ast::Mac,
         MacroStyle::Parens => {
             // Format macro invocation as function call, forcing no trailing
             // comma because not all macros support them.
-            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape).map(|rw| {
-                match position {
-                    MacroPosition::Item => format!("{};", rw),
-                    _ => rw,
-                }
-            })
+            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape)
+                .map(|rw| match position {
+                         MacroPosition::Item => format!("{};", rw),
+                         _ => rw,
+                     })
         }
         MacroStyle::Brackets => {
             let mac_shape = try_opt!(shape.shrink_left(macro_name.len()));

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -68,7 +68,8 @@ fn module_file(id: ast::Ident,
         return path;
     }
 
-    match parser::Parser::default_submod_path(id, dir_path, codemap).result {
+    match parser::Parser::default_submod_path(id, dir_path, codemap)
+              .result {
         Ok(parser::ModulePathSuccess { path, .. }) => path,
         Err(_) => panic!("Couldn't find module {}", id),
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -35,7 +35,8 @@ pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> 
     let re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][[:space:]]*").unwrap();
     let stripped_str = re.replace_all(orig, "$1");
 
-    let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
+    let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false)
+        .collect::<Vec<&str>>();
     let shape = fmt.shape.visual_indent(0);
     let indent = shape.indent.to_string(fmt.config);
     let punctuation = ":,;.";

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,12 +364,11 @@ impl Rewrite for ast::WherePredicate {
                 let colon = type_bound_colon(context);
 
                 if !bound_lifetimes.is_empty() {
-                    let lifetime_str: String =
-                        try_opt!(bound_lifetimes
-                                     .iter()
-                                     .map(|lt| lt.rewrite(context, shape))
-                                     .intersperse(Some(", ".to_string()))
-                                     .collect());
+                    let lifetime_str: String = try_opt!(bound_lifetimes
+                                                            .iter()
+                                                            .map(|lt| lt.rewrite(context, shape))
+                                                            .intersperse(Some(", ".to_string()))
+                                                            .collect());
 
                     let joiner = match context.config.type_punctuation_density() {
                         TypeDensity::Compressed => "+",
@@ -378,17 +377,13 @@ impl Rewrite for ast::WherePredicate {
                     // 6 = "for<> ".len()
                     let used_width = lifetime_str.len() + type_str.len() + colon.len() + 6;
                     let budget = try_opt!(shape.width.checked_sub(used_width));
-                    let bounds_str: String =
-                        try_opt!(bounds
-                                     .iter()
-                                     .map(|ty_bound| {
-                                              ty_bound.rewrite(context,
-                                                               Shape::legacy(budget,
-                                                                             shape.indent +
-                                                                             used_width))
-                                          })
-                                     .intersperse(Some(joiner.to_string()))
-                                     .collect());
+                    let bounds_str: String = try_opt!(bounds
+                                                          .iter()
+                                                          .map(|ty_bound| {
+                        ty_bound.rewrite(context, Shape::legacy(budget, shape.indent + used_width))
+                    })
+                                                          .intersperse(Some(joiner.to_string()))
+                                                          .collect());
 
                     if context.config.spaces_within_angle_brackets() && lifetime_str.len() > 0 {
                         format!("for< {} > {}{}{}",
@@ -406,17 +401,13 @@ impl Rewrite for ast::WherePredicate {
                     };
                     let used_width = type_str.len() + colon.len();
                     let budget = try_opt!(shape.width.checked_sub(used_width));
-                    let bounds_str: String =
-                        try_opt!(bounds
-                                     .iter()
-                                     .map(|ty_bound| {
-                                              ty_bound.rewrite(context,
-                                                               Shape::legacy(budget,
-                                                                             shape.indent +
-                                                                             used_width))
-                                          })
-                                     .intersperse(Some(joiner.to_string()))
-                                     .collect());
+                    let bounds_str: String = try_opt!(bounds
+                                                          .iter()
+                                                          .map(|ty_bound| {
+                        ty_bound.rewrite(context, Shape::legacy(budget, shape.indent + used_width))
+                    })
+                                                          .intersperse(Some(joiner.to_string()))
+                                                          .collect());
 
                     format!("{}{}{}", type_str, colon, bounds_str)
                 }
@@ -532,12 +523,11 @@ impl Rewrite for ast::TyParam {
                 TypeDensity::Compressed => "+",
                 TypeDensity::Wide => " + ",
             };
-            let bounds: String =
-                try_opt!(self.bounds
-                             .iter()
-                             .map(|ty_bound| ty_bound.rewrite(context, shape))
-                             .intersperse(Some(joiner.to_string()))
-                             .collect());
+            let bounds: String = try_opt!(self.bounds
+                                              .iter()
+                                              .map(|ty_bound| ty_bound.rewrite(context, shape))
+                                              .intersperse(Some(joiner.to_string()))
+                                              .collect());
 
             result.push_str(&bounds);
         }
@@ -612,8 +602,7 @@ impl Rewrite for ast::Ty {
                              let lt_budget = try_opt!(shape.width.checked_sub(2 + mut_len));
                              let lt_str = try_opt!(lifetime.rewrite(context,
                                                                     Shape::legacy(lt_budget,
-                                                                                  shape.indent +
-                                                                                  2 +
+                                                                                  shape.indent + 2 +
                                                                                   mut_len)));
                              let lt_len = lt_str.len();
                              let budget = try_opt!(shape.width.checked_sub(2 + mut_len + lt_len));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -334,7 +334,8 @@ pub fn wrap_str<S: AsRef<str>>(s: S, max_width: usize, shape: Shape) -> Option<S
 
 impl Rewrite for String {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        wrap_str(self, context.config.max_width(), shape).map(ToOwned::to_owned)
+        wrap_str(self, context.config.max_width(), shape)
+            .map(ToOwned::to_owned)
     }
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -55,7 +55,8 @@ fn system_tests() {
 // the only difference is the coverage mode
 #[test]
 fn coverage_tests() {
-    let files = fs::read_dir("tests/coverage/source").expect("Couldn't read source dir");
+    let files = fs::read_dir("tests/coverage/source")
+        .expect("Couldn't read source dir");
     let files = files.map(get_path_string);
     let (_reports, count, fails) = check_files(files);
 
@@ -82,7 +83,8 @@ fn assert_output(source: &str, expected_filename: &str) {
     let _ = filemap::write_all_files(&file_map, &mut out, &config);
     let output = String::from_utf8(out).unwrap();
 
-    let mut expected_file = fs::File::open(&expected_filename).expect("Couldn't open target");
+    let mut expected_file = fs::File::open(&expected_filename)
+        .expect("Couldn't open target");
     let mut expected_text = String::new();
     expected_file
         .read_to_string(&mut expected_text)
@@ -277,7 +279,8 @@ fn get_config(config_file: Option<&str>) -> Config {
         }
     };
 
-    let mut def_config_file = fs::File::open(config_file_name).expect("Couldn't open config");
+    let mut def_config_file = fs::File::open(config_file_name)
+        .expect("Couldn't open config");
     let mut def_config = String::new();
     def_config_file
         .read_to_string(&mut def_config)

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -66,38 +66,34 @@ fn floaters() {
     };
 
     let x = Foo {
-            field1: val1,
-            field2: val2,
-        }
-        .method_call()
+        field1: val1,
+        field2: val2,
+    }.method_call()
         .method_call();
 
     let y = if cond {
-            val1
-        } else {
-            val2
-        }
-        .method_call();
+        val1
+    } else {
+        val2
+    }.method_call();
 
     {
         match x {
             PushParam => {
                 // params are 1-indexed
                 stack.push(mparams[match cur.to_digit(10) {
-                                   Some(d) => d as usize - 1,
-                                   None => return Err("bad param number".to_owned()),
-                               }]
-                               .clone());
+                    Some(d) => d as usize - 1,
+                    None => return Err("bad param number".to_owned()),
+                }].clone());
             }
         }
     }
 
     if cond {
-            some();
-        } else {
-            none();
-        }
-        .bar()
+        some();
+    } else {
+        none();
+    }.bar()
         .baz();
 
     Foo { x: val }
@@ -108,21 +104,19 @@ fn floaters() {
         .quux();
 
     Foo {
-            y: i_am_multi_line,
-            z: ok,
-        }
-        .baz(|| {
-                 force();
-                 multiline();
-             })
+        y: i_am_multi_line,
+        z: ok,
+    }.baz(|| {
+              force();
+              multiline();
+          })
         .quux();
 
     a +
     match x {
-            true => "yay!",
-            false => "boo!",
-        }
-        .bar()
+        true => "yay!",
+        false => "boo!",
+    }.bar()
 }
 
 fn is_replaced_content() -> bool {

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -37,8 +37,7 @@ fn issue1420() {
         # Getting started
         ...
     "#,
-    )
-        .running(waltz)
+    ).running(waltz)
 }
 
 // #1563

--- a/tests/target/file-lines-1.rs
+++ b/tests/target/file-lines-1.rs
@@ -2,10 +2,9 @@
 
 fn floaters() {
     let x = Foo {
-            field1: val1,
-            field2: val2,
-        }
-        .method_call()
+        field1: val1,
+        field2: val2,
+    }.method_call()
         .method_call();
 
     let y = if cond {

--- a/tests/target/file-lines-3.rs
+++ b/tests/target/file-lines-3.rs
@@ -3,10 +3,9 @@
 
 fn floaters() {
     let x = Foo {
-            field1: val1,
-            field2: val2,
-        }
-        .method_call()
+        field1: val1,
+        field2: val2,
+    }.method_call()
         .method_call();
 
     let y = if cond { val1 } else { val2 }.method_call();


### PR DESCRIPTION
Please see https://github.com/rust-lang-nursery/fmt-rfcs/issues/66.