### PR TITLE
Use original code snippet for macro which contains invalid syntax

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -113,14 +113,14 @@ pub fn rewrite_macro(mac: &ast::Mac,
                 Ok(expr) => {
                     // Recovered errors.
                     if context.parse_session.span_diagnostic.has_errors() {
-                        return None;
+                        return Some(context.snippet(mac.span));
                     }
 
                     expr
                 }
                 Err(mut e) => {
                     e.cancel();
-                    return None;
+                    return Some(context.snippet(mac.span));
                 }
             };
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -78,6 +78,11 @@ fn main() {
         // comment
         not function like
     );
+
+    // #1577
+    let json = json!({
+        "foo": "bar",
+    });
 }
 
 impl X {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -83,6 +83,11 @@ fn main() {
         // comment
         not function like
     );
+
+    // #1577
+    let json = json!({
+        "foo": "bar",
+    });
 }
 
 impl X {


### PR DESCRIPTION
Closes #1577.
I recently added a commit that allows rewriting of macro to fail on the rhs of assignment,
so that rustfmt can try to put the macro on the next line.
This seems to  work reasonable, although when macro contains invalid syntax, the whole trial is meaningless since it will eventually fail.
This PR avoids it by returning the original code snippet from `rewrite_macro` when parsing failed.