### PR TITLE
Decide whether args fit in a single line inside rewrite_call_args

### DIFF
--- a/tests/source/configs-fn_call_style-block.rs
+++ b/tests/source/configs-fn_call_style-block.rs
@@ -96,3 +96,17 @@ impl Cursor {
             });
     }
 }
+
+fn issue1581() {
+    bootstrap.checks.register(
+        "PERSISTED_LOCATIONS",
+        move || if locations2.0.inner_mut.lock().poisoned {
+            Check::new(
+                State::Error,
+                "Persisted location storage is poisoned due to a write failure",
+            )
+        } else {
+            Check::new(State::Healthy, "Persisted location storage is healthy")
+        },
+    );
+}

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -106,3 +106,17 @@ impl Cursor {
             });
     }
 }
+
+fn issue1581() {
+    bootstrap.checks.register(
+        "PERSISTED_LOCATIONS",
+        move || if locations2.0.inner_mut.lock().poisoned {
+            Check::new(
+                State::Error,
+                "Persisted location storage is poisoned due to a write failure",
+            )
+        } else {
+            Check::new(State::Healthy, "Persisted location storage is healthy")
+        },
+    );
+}


### PR DESCRIPTION
Currnely, when `fn_call_style = Block`, rustfmt puts the first argument when it shouldn't:
```rust
    bootstrap.checks.register("PERSISTED_LOCATIONS",
        move || if locations2.0.inner_mut.lock().poisoned {
            Check::new(
                State::Error,
                "Persisted location storage is poisoned due to a write failure",
            )
        } else {
            Check::new(State::Healthy, "Persisted location storage is healthy")
        },);
```
This PR fixes the above bug.