### PR TITLE
Allow macro to be nested like function call

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -168,10 +168,9 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
             .into_iter()
             .chain(::std::iter::repeat(other_child_shape).take(subexpr_list.len() - 1));
     let iter = subexpr_list.iter().rev().zip(child_shape_iter);
-    let mut rewrites = try_opt!(iter.map(|(e, shape)| {
-                                             rewrite_chain_subexpr(e, total_span, context, shape)
-                                         })
-                                    .collect::<Option<Vec<_>>>());
+    let mut rewrites =
+        try_opt!(iter.map(|(e, shape)| rewrite_chain_subexpr(e, total_span, context, shape))
+                     .collect::<Option<Vec<_>>>());
 
     // Total of all items excluding the last.
     let last_non_try_index = rewrites.len() - (1 + trailing_try_num);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1678,12 +1678,14 @@ fn rewrite_call_args(context: &RewriteContext,
                      one_line_width: usize,
                      force_trailing_comma: bool)
                      -> Option<(bool, String)> {
+    let mut item_context = context.clone();
+    item_context.inside_macro = false;
     let items = itemize_list(context.codemap,
                              args.iter(),
                              ")",
                              |item| item.span.lo,
                              |item| item.span.hi,
-                             |item| item.rewrite(context, shape),
+                             |item| item.rewrite(&item_context, shape),
                              span.lo,
                              span.hi);
     let mut item_vec: Vec<_> = items.collect();
@@ -1691,7 +1693,7 @@ fn rewrite_call_args(context: &RewriteContext,
     // Try letting the last argument overflow to the next line with block
     // indentation. If its first line fits on one line with the other arguments,
     // we format the function arguments horizontally.
-    let overflow_last = can_be_overflowed(context, args);
+    let overflow_last = can_be_overflowed(&item_context, args);
 
     let mut orig_last = None;
     let mut placeholder = None;
@@ -1709,7 +1711,7 @@ fn rewrite_call_args(context: &RewriteContext,
         } else {
             shape.block()
         };
-        let rewrite = args.last().unwrap().rewrite(context, arg_shape);
+        let rewrite = args.last().unwrap().rewrite(&item_context, arg_shape);
         swap(&mut item_vec[args.len() - 1].item, &mut orig_last);
 
         if let Some(rewrite) = rewrite {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1782,7 +1782,7 @@ fn rewrite_call_args(context: &RewriteContext,
         // and not rewriting macro.
         Some(ref s) if context.config.fn_call_style() == IndentStyle::Block &&
                        !context.inside_macro &&
-                       ((!can_be_overflowed(&context, args) && last_char_is_not_comma &&
+                       ((!can_be_overflowed(context, args) && last_char_is_not_comma &&
                          s.contains('\n')) ||
                         first_line_width(s) > one_line_budget) => {
             fmt.trailing_separator = SeparatorTactic::Vertical;

--- a/src/items.rs
+++ b/src/items.rs
@@ -1783,9 +1783,7 @@ fn rewrite_args(context: &RewriteContext,
                 -> Option<String> {
     let mut arg_item_strs =
         try_opt!(args.iter()
-                     .map(|arg| {
-                              arg.rewrite(&context, Shape::legacy(multi_line_budget, arg_indent))
-                          })
+                     .map(|arg| arg.rewrite(&context, Shape::legacy(multi_line_budget, arg_indent)))
                      .collect::<Option<Vec<_>>>());
 
     // Account for sugary self.

--- a/tests/source/configs-fn_call_style-block.rs
+++ b/tests/source/configs-fn_call_style-block.rs
@@ -16,6 +16,10 @@ fn main() {
                 .client_credentials(&self.config.auth.oauth2.id, &self.config.auth.oauth2.secret)?;
         }
     }
+
+    // nesting macro and function call
+    try!(foo(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx));
+    try!(foo(try!(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)));
 }
 
 // #1521

--- a/tests/target/closure-block-inside-macro.rs
+++ b/tests/target/closure-block-inside-macro.rs
@@ -1,13 +1,11 @@
 // rustfmt-fn_call_style: Block
 
 // #1547
-fuzz_target!(|data: &[u8]| {
-    if let Some(first) = data.first() {
-        let index = *first as usize;
-        if index >= ENCODINGS.len() {
-            return;
-        }
-        let encoding = ENCODINGS[index];
-        dispatch_test(encoding, &data[1..]);
+fuzz_target!(|data: &[u8]| if let Some(first) = data.first() {
+    let index = *first as usize;
+    if index >= ENCODINGS.len() {
+        return;
     }
+    let encoding = ENCODINGS[index];
+    dispatch_test(encoding, &data[1..]);
 });

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -32,6 +32,16 @@ fn main() {
             )?;
         }
     }
+
+    // nesting macro and function call
+    try!(foo(
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    ));
+    try!(foo(try!(
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    )));
 }
 
 // #1521


### PR DESCRIPTION
This PR allows macro to be nested like function call:
```rust
foo(try!(
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
))
```
Also, currently rustfmt forgets to add a trailing comma for multiline args when the function call is inside macro:
```rust
try!(foo(
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
));
```
This PR fixed this.