### PR TITLE
Put closing paren on the next line when the last arg contains comment

### DIFF
--- a/tests/target/issue-1587.rs
+++ b/tests/target/issue-1587.rs
@@ -1,0 +1,8 @@
+pub trait X {
+    fn a(&self) -> &'static str;
+    fn bcd(&self,
+           c: &str, // comment on this arg
+           d: u16, // comment on this arg
+           e: &Vec<String> // comment on this arg
+           ) -> Box<Q>;
+}


### PR DESCRIPTION
This PR closes #1587.
TBH I am not sure whether the position of closing paren is ideal.