### PR TITLE
Add a trailing comma if the last arg ends with comment

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1879,12 +1879,21 @@ fn rewrite_args(context: &RewriteContext,
         item.item = Some(arg);
     }
 
+    let last_line_ends_with_comment = arg_items
+        .iter()
+        .last()
+        .and_then(|item| item.post_comment.as_ref())
+        .map_or(false, |s| s.trim().starts_with("//"));
+
     let (indent, trailing_comma, end_with_newline) = match context.config.fn_args_layout() {
         IndentStyle::Block if fits_in_one_line => {
             (indent.block_indent(context.config), SeparatorTactic::Never, true)
         }
         IndentStyle::Block => {
             (indent.block_indent(context.config), SeparatorTactic::Vertical, true)
+        }
+        IndentStyle::Visual if last_line_ends_with_comment => {
+            (arg_indent, SeparatorTactic::Vertical, true)
         }
         IndentStyle::Visual => (arg_indent, SeparatorTactic::Never, false),
     };

--- a/tests/target/fn-args-with-last-line-comment.rs
+++ b/tests/target/fn-args-with-last-line-comment.rs
@@ -1,0 +1,22 @@
+// #1587
+pub trait X {
+    fn a(&self) -> &'static str;
+    fn bcd(&self,
+           c: &str, // comment on this arg
+           d: u16, // comment on this arg
+           e: &Vec<String>, // comment on this arg
+           ) -> Box<Q>;
+}
+
+// #1595
+fn foo(arg1: LongTypeName,
+       arg2: LongTypeName,
+       arg3: LongTypeName,
+       arg4: LongTypeName,
+       arg5: LongTypeName,
+       arg6: LongTypeName,
+       arg7: LongTypeName,
+       //arg8: LongTypeName,
+       ) {
+    // do stuff
+}

--- a/tests/target/issue-1587.rs
+++ b/tests/target/issue-1587.rs
@@ -1,8 +1,0 @@
-pub trait X {
-    fn a(&self) -> &'static str;
-    fn bcd(&self,
-           c: &str, // comment on this arg
-           d: u16, // comment on this arg
-           e: &Vec<String> // comment on this arg
-           ) -> Box<Q>;
-}


### PR DESCRIPTION
Closes #1595.
This PR adds a trailing comma to the last arg in order to avoid reformatting.