### PR TITLE
Allow attributes on expressions

### DIFF
--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -103,3 +103,11 @@ fn issue_1555() {
                          "65454654654654654654654655464",
                          "4");
 }
+
+fn issue1178() {
+    macro_rules! foo {
+        (#[$attr:meta] $name:ident) => {}
+    }
+
+    foo!(#[doc = "bar"] baz);
+}

--- a/tests/source/skip.rs
+++ b/tests/source/skip.rs
@@ -16,3 +16,16 @@ impl LateLintPass for UsedUnderscoreBinding {
     fn check_expr() { // comment
     }
 }
+
+fn issue1346() {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    Box::new(self.inner.call(req).then(move |result| {
+        match result {
+            Ok(resp) => Box::new(future::done(Ok(resp))),
+            Err(e) => {
+                try_error!(clo_stderr, "{}", e);
+                Box::new(future::err(e))
+            }
+        }
+    }))
+}

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -108,3 +108,11 @@ fn issue_1555() {
                          "65454654654654654654654655464",
                          "4");
 }
+
+fn issue1178() {
+    macro_rules! foo {
+        (#[$attr:meta] $name:ident) => {}
+    }
+
+    foo!(#[doc = "bar"] baz);
+}

--- a/tests/target/skip.rs
+++ b/tests/target/skip.rs
@@ -16,3 +16,16 @@ impl LateLintPass for UsedUnderscoreBinding {
     fn check_expr() { // comment
     }
 }
+
+fn issue1346() {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    Box::new(self.inner.call(req).then(move |result| {
+        match result {
+            Ok(resp) => Box::new(future::done(Ok(resp))),
+            Err(e) => {
+                try_error!(clo_stderr, "{}", e);
+                Box::new(future::err(e))
+            }
+        }
+    }))
+}


### PR DESCRIPTION
Closes #1178 and closes #1346.
If rustfmt should not support attributes on expressions, I am fine closing this without merging.