### PR TITLE
Expose methods to locate and load config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,11 @@
 extern crate toml;
 
 use std::cell::Cell;
+use std::fs;
+use std::fs::File;
+use std::env;
+use std::io::{Error, ErrorKind, Read};
+use std::path::{Path, PathBuf};
 
 use file_lines::FileLines;
 use lists::{SeparatorTactic, ListTactic};
@@ -347,6 +352,64 @@ macro_rules! create_config {
                 }
             }
 
+            /// Construct a `Config` from the toml file specified at `file_path`.
+            ///
+            /// This method only looks at the provided path, for a method that
+            /// searches parents for an `rls.toml` see `resolve_config`.
+            ///
+            /// Return a `Config` if the config could be read and parsed from
+            /// the file, Error otherwise.
+            pub fn from_toml_path(file_path: &Path) -> Result<Config, Error> {
+                let mut file = File::open(&file_path)?;
+                let mut toml = String::new();
+                file.read_to_string(&mut toml)?;
+                Config::from_toml(&toml).map_err(|err| Error::new(ErrorKind::InvalidData, err))
+            }
+
+            /// Resolve the config for input in `dir`.
+            ///
+            /// Searches for `rustfmt.toml` beginning with `dir`, and
+            /// recursively checking parents of `dir` if no config file is found.
+            /// If no config file exists in `dir` or in any parent, a
+            /// default `Config` will be returned (and the returned path will be empty).
+            ///
+            /// Returns the `Config` to use, and the path of the project file if there was
+            /// one.
+            pub fn from_resolved_toml_path(dir: &Path) -> Result<(Config, Option<PathBuf>), Error> {
+
+                /// Try to find a project file in the given directory and its parents.
+                /// Returns the path of a the nearest project file if one exists,
+                /// or `None` if no project file was found.
+                fn resolve_project_file(dir: &Path) -> Result<Option<PathBuf>, Error> {
+                    let mut current = if dir.is_relative() {
+                        env::current_dir()?.join(dir)
+                    } else {
+                        dir.to_path_buf()
+                    };
+
+                    current = fs::canonicalize(current)?;
+
+                    loop {
+                        match get_toml_path(&current) {
+                            Ok(Some(path)) => return Ok(Some(path)),
+                            Err(e) => return Err(e),
+                            _ => ()
+                        }
+
+                        // If the current directory has no parent, we're done searching.
+                        if !current.pop() {
+                            return Ok(None);
+                        }
+                    }
+                }
+
+                match resolve_project_file(dir)? {
+                    None => Ok((Config::default(), None)),
+                    Some(path) => Config::from_toml_path(&path).map(|config| (config, Some(path))),
+                }
+            }
+
+
             pub fn print_docs() {
                 use std::cmp;
                 let max = 0;
@@ -388,6 +451,32 @@ macro_rules! create_config {
         }
     )
 }
+
+/// Check for the presence of known config file names (`rustfmt.toml, `.rustfmt.toml`) in `dir`
+///
+/// Return the path if a config file exists, empty if no file exists, and Error for IO errors
+pub fn get_toml_path(dir: &Path) -> Result<Option<PathBuf>, Error> {
+    const CONFIG_FILE_NAMES: [&'static str; 2] = [".rustfmt.toml", "rustfmt.toml"];
+    for config_file_name in &CONFIG_FILE_NAMES {
+        let config_file = dir.join(config_file_name);
+        match fs::metadata(&config_file) {
+            // Only return if it's a file to handle the unlikely situation of a directory named
+            // `rustfmt.toml`.
+            Ok(ref md) if md.is_file() => return Ok(Some(config_file)),
+            // Return the error if it's something other than `NotFound`; otherwise we didn't
+            // find the project file yet, and continue searching.
+            Err(e) => {
+                if e.kind() != ErrorKind::NotFound {
+                    return Err(e);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(None)
+}
+
+
 
 create_config! {
     verbose: bool, false, "Use verbose output";

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,7 +355,7 @@ macro_rules! create_config {
             /// Construct a `Config` from the toml file specified at `file_path`.
             ///
             /// This method only looks at the provided path, for a method that
-            /// searches parents for an `rls.toml` see `resolve_config`.
+            /// searches parents for a `rustfmt.toml` see `from_resolved_toml_path`.
             ///
             /// Return a `Config` if the config could be read and parsed from
             /// the file, Error otherwise.


### PR DESCRIPTION
* Make method for searching parents for toml file public
* Make method for loading config from path directly public, tweak the
  API since it was never returning None

Would allow RLS to reuse the rustfmt.toml searching/loading code (https://github.com/rust-lang-nursery/rls/pull/331)