### PR TITLE
Add format_if_else_cond_comment config option

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -666,6 +666,7 @@ impl Rewrite for ast::Block {
 
         let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config);
         visitor.block_indent = shape.indent;
+        visitor.is_if_else_block = context.is_if_else_block;
 
         let prefix = match self.rules {
             ast::BlockCheckMode::Unsafe(..) => {
@@ -965,7 +966,10 @@ impl<'a> Rewrite for ControlFlow<'a> {
             width: block_width,
             ..shape
         };
-        let block_str = try_opt!(self.block.rewrite(context, block_shape));
+        let mut block_context = context.clone();
+        block_context.is_if_else_block = self.else_block.is_some();
+
+        let block_str = try_opt!(self.block.rewrite(&block_context, block_shape));
 
         let cond_span = if let Some(cond) = self.cond {
             cond.span

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -27,7 +27,11 @@ pub struct RewriteContext<'a> {
     pub codemap: &'a CodeMap,
     pub config: &'a Config,
     pub inside_macro: bool,
+    // Force block indent style even if we are using visual indent style.
     pub use_block: bool,
+    // When `format_if_else_cond_comment` is true, unindent the comment on top
+    // of the `else` or `else if`.
+    pub is_if_else_block: bool,
 }
 
 impl<'a> RewriteContext<'a> {

--- a/tests/target/unindent_if_else_cond_comment.rs
+++ b/tests/target/unindent_if_else_cond_comment.rs
@@ -1,0 +1,27 @@
+// Comments on else block. See #1575.
+
+fn example() {
+    // `if` comment
+    if x {
+        foo();
+    // `else if` comment
+    } else if y {
+        foo();
+    // Comment on `else if`.
+    // Comment on `else if`.
+    } else if z {
+        bar();
+    /*
+     *  Multi line comment on `else if`
+     */
+    } else if xx {
+        bar();
+    /* Single line comment on `else if` */
+    } else if yy {
+        foo();
+    // `else` comment
+    } else {
+        foo();
+        // Comment at the end of `else` block
+    };
+}


### PR DESCRIPTION
Closes #1575.
The option only supports comment starting with `//` and is set to `false` by default.