### PR TITLE
Use correct line budget when using Rfc control style

### DIFF
--- a/tests/target/configs-control_style-rfc.rs
+++ b/tests/target/configs-control_style-rfc.rs
@@ -1,0 +1,23 @@
+// rustfmt-control_style: Rfc
+
+// #1618
+fn main() {
+    loop {
+        if foo {
+            if ((right_paddle_speed < 0.) &&
+                 (right_paddle.position().y - paddle_size.y / 2. > 5.)) ||
+                ((right_paddle_speed > 0.) &&
+                     (right_paddle.position().y + paddle_size.y / 2. < game_height as f32 - 5.))
+            {
+                foo
+            }
+            if ai_timer.elapsed_time().as_microseconds() > ai_time.as_microseconds() {
+                if ball.position().y + ball_radius >
+                    right_paddle.position().y + paddle_size.y / 2.
+                {
+                    foo
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #1618, although it only fixes the issue related to exceeding the max width.
I am not confident that output is correctly indented.
```rust
fn main() {
    loop {
        if foo {
            if ((right_paddle_speed < 0.) &&
                 (right_paddle.position().y - paddle_size.y / 2. > 5.)) ||
                ((right_paddle_speed > 0.) &&
                     (right_paddle.position().y + paddle_size.y / 2. < game_height as f32 - 5.))
            {
                foo
            }
            if ai_timer.elapsed_time().as_microseconds() > ai_time.as_microseconds() {
                if ball.position().y + ball_radius >
                    right_paddle.position().y + paddle_size.y / 2.
                {
                    foo
                }
            }
        }
    }
}
```