### PR TITLE
Combine more expressions

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -166,6 +166,62 @@ lorem_ipsum(|| {
 });
 ```
 
+## `combine_control_expr`
+
+Combine control expressions with function calls.
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `true`
+
+```rust
+fn example() {
+    // If
+    foo!(if x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // IfLet
+    foo!(if let Some(..) = x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // While
+    foo!(while x {
+        foo();
+        bar();
+    });
+
+    // WhileLet
+    foo!(while let Some(..) = x {
+        foo();
+        bar();
+    });
+
+    // ForLoop
+    foo!(for x in y {
+        foo();
+        bar();
+    });
+
+    // Loop
+    foo!(loop {
+        foo();
+        bar();
+    });
+}
+```
+
+#### `false`
+
+```rust
+```
+
 ## `comment_width`
 
 Maximum length of comments. No effect unless`wrap_comments = true`.

--- a/rfc-rustfmt.toml
+++ b/rfc-rustfmt.toml
@@ -4,3 +4,4 @@ control_style = "Rfc"
 where_style = "Rfc"
 generics_indent = "Block"
 fn_call_style = "Block"
+combine_control_expr = true

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -252,6 +252,9 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         String::new()
     } else {
         // Use new lines.
+        if context.force_one_line_chain {
+            return None;
+        }
         format!("\n{}", nested_shape.indent.to_string(context.config))
     };
 

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -164,9 +164,9 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
             .into_iter()
             .chain(::std::iter::repeat(other_child_shape).take(subexpr_list.len() - 1));
     let iter = subexpr_list.iter().rev().zip(child_shape_iter);
-    let mut rewrites =
-        try_opt!(iter.map(|(e, shape)| rewrite_chain_subexpr(e, total_span, context, shape))
-                     .collect::<Option<Vec<_>>>());
+    let mut rewrites = try_opt!(iter.map(|(e, shape)| {
+                                             rewrite_chain_subexpr(e, total_span, context, shape)
+                                         }).collect::<Option<Vec<_>>>());
 
     // Total of all items excluding the last.
     let last_non_try_index = rewrites.len() - (1 + trailing_try_num);

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -229,7 +229,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     }
 
     // Try overflowing the last element if we are using block indent.
-    if !fits_single_line && context.config.fn_call_style() == IndentStyle::Block {
+    if !fits_single_line && context.use_block_indent() {
         let (init, last) = rewrites.split_at_mut(last_non_try_index);
         let almost_single_line = init.iter().all(|s| !s.contains('\n'));
         if almost_single_line {
@@ -339,9 +339,7 @@ fn join_rewrites(rewrites: &[String], subexps: &[ast::Expr], connector: &str) ->
 // parens, braces, and brackets in its idiomatic formatting.
 fn is_block_expr(context: &RewriteContext, expr: &ast::Expr, repr: &str) -> bool {
     match expr.node {
-        ast::ExprKind::Call(..) => {
-            context.config.fn_call_style() == IndentStyle::Block && repr.contains('\n')
-        }
+        ast::ExprKind::Call(..) => context.use_block_indent() && repr.contains('\n'),
         ast::ExprKind::Struct(..) |
         ast::ExprKind::While(..) |
         ast::ExprKind::WhileLet(..) |

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -339,6 +339,7 @@ fn join_rewrites(rewrites: &[String], subexps: &[ast::Expr], connector: &str) ->
 // parens, braces, and brackets in its idiomatic formatting.
 fn is_block_expr(context: &RewriteContext, expr: &ast::Expr, repr: &str) -> bool {
     match expr.node {
+        ast::ExprKind::Mac(..) |
         ast::ExprKind::Call(..) => context.use_block_indent() && repr.contains('\n'),
         ast::ExprKind::Struct(..) |
         ast::ExprKind::While(..) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -575,7 +575,8 @@ create_config! {
     write_mode: WriteMode, WriteMode::Replace,
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";
     condense_wildcard_suffixes: bool, false, "Replace strings of _ wildcards by a single .. in \
-                                              tuple patterns"
+                                              tuple patterns";
+    combine_control_expr: bool, true, "Combine control expressions with funciton calls."
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,7 +576,7 @@ create_config! {
         "What Write Mode to use when none is supplied: Replace, Overwrite, Display, Diff, Coverage";
     condense_wildcard_suffixes: bool, false, "Replace strings of _ wildcards by a single .. in \
                                               tuple patterns";
-    combine_control_expr: bool, true, "Combine control expressions with funciton calls."
+    combine_control_expr: bool, false, "Combine control expressions with funciton calls."
 }
 
 #[cfg(test)]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -928,6 +928,7 @@ impl<'a> Rewrite for ControlFlow<'a> {
                                           cond,
                                           self.matcher,
                                           self.connector,
+                                          self.keyword,
                                           cond_shape))
             }
             None => String::new(),
@@ -1529,6 +1530,7 @@ fn rewrite_pat_expr(context: &RewriteContext,
                     // Connecting piece between pattern and expression,
                     // *without* trailing space.
                     connector: &str,
+                    keyword: &str,
                     shape: Shape)
                     -> Option<String> {
     debug!("rewrite_pat_expr {:?} {:?} {:?}", shape, pat, expr);
@@ -1565,6 +1567,10 @@ fn rewrite_pat_expr(context: &RewriteContext,
                 return Some(result);
             }
         }
+    }
+
+    if pat.is_none() && keyword == "if" {
+        return None;
     }
 
     let nested_indent = shape.indent.block_only().block_indent(context.config);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -980,12 +980,14 @@ impl<'a> Rewrite for ControlFlow<'a> {
         // for event in event
         let between_kwd_cond = mk_sp(
             context.codemap.span_after(self.span, self.keyword.trim()),
-            self.pat
-                .map_or(cond_span.lo, |p| if self.matcher.is_empty() {
+            self.pat.map_or(
+                cond_span.lo,
+                |p| if self.matcher.is_empty() {
                     p.span.lo
                 } else {
                     context.codemap.span_before(self.span, self.matcher.trim())
-                }),
+                },
+            ),
         );
 
         let between_kwd_cond_comment = extract_comment(between_kwd_cond, context, shape);
@@ -1863,7 +1865,7 @@ fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_len: 
         ast::ExprKind::Loop(..) |
         ast::ExprKind::While(..) |
         ast::ExprKind::WhileLet(..) => {
-            context.use_block_indent() && args_len == 1
+            context.config.combine_control_expr() && context.use_block_indent() && args_len == 1
         }
         ast::ExprKind::Block(..) |
         ast::ExprKind::Closure(..) => {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1784,6 +1784,11 @@ fn try_overflow_last_arg(context: &RewriteContext,
     // Replace the last item with its first line to see if it fits with
     // first arguments.
     let (orig_last, placeholder) = if overflow_last {
+        let mut context = context.clone();
+        match args[args.len() - 1].node {
+            ast::ExprKind::MethodCall(..) => context.force_one_line_chain = true,
+            _ => (),
+        }
         last_arg_shape(&context, &item_vec, shape).map_or((None, None), |arg_shape| {
             rewrite_last_arg_with_overflow(&context,
                                            &args[args.len() - 1],

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -143,8 +143,9 @@ pub fn write_file<T>(text: &StringBuffer,
             if let Ok((ori, fmt)) = source_and_formatted_text(text, filename, config) {
                 let mismatch = make_diff(&ori, &fmt, 3);
                 let has_diff = !mismatch.is_empty();
-                print_diff(mismatch,
-                           |line_num| format!("Diff in {} at line {}:", filename, line_num));
+                print_diff(mismatch, |line_num| {
+                    format!("Diff in {} at line {}:", filename, line_num)
+                });
                 return Ok(has_diff);
             }
         }

--- a/src/items.rs
+++ b/src/items.rs
@@ -1161,21 +1161,23 @@ pub fn rewrite_type_alias(context: &RewriteContext,
         .unwrap_or(0);
     let type_indent = indent + line_width;
     // Try to fit the type on the same line
-    let ty_str = try_opt!(ty.rewrite(context, Shape::legacy(budget, type_indent))
-        .or_else(|| {
-            // The line was too short, try to put the type on the next line
+    let ty_str = try_opt!(
+        ty.rewrite(context, Shape::legacy(budget, type_indent))
+            .or_else(|| {
+                // The line was too short, try to put the type on the next line
 
-            // Remove the space after '='
-            result.pop();
-            let type_indent = indent.block_indent(context.config);
-            result.push('\n');
-            result.push_str(&type_indent.to_string(context.config));
-            let budget = try_opt!(context
-                                      .config
-                                      .max_width()
-                                      .checked_sub(type_indent.width() + ";".len()));
-            ty.rewrite(context, Shape::legacy(budget, type_indent))
-        }));
+                // Remove the space after '='
+                result.pop();
+                let type_indent = indent.block_indent(context.config);
+                result.push('\n');
+                result.push_str(&type_indent.to_string(context.config));
+                let budget = try_opt!(context
+                                          .config
+                                          .max_width()
+                                          .checked_sub(type_indent.width() + ";".len()));
+                ty.rewrite(context, Shape::legacy(budget, type_indent))
+            })
+    );
     result.push_str(&ty_str);
     result.push_str(";");
     Some(result)

--- a/src/items.rs
+++ b/src/items.rs
@@ -1162,20 +1162,20 @@ pub fn rewrite_type_alias(context: &RewriteContext,
     let type_indent = indent + line_width;
     // Try to fit the type on the same line
     let ty_str = try_opt!(ty.rewrite(context, Shape::legacy(budget, type_indent))
-                              .or_else(|| {
-        // The line was too short, try to put the type on the next line
+        .or_else(|| {
+            // The line was too short, try to put the type on the next line
 
-        // Remove the space after '='
-        result.pop();
-        let type_indent = indent.block_indent(context.config);
-        result.push('\n');
-        result.push_str(&type_indent.to_string(context.config));
-        let budget = try_opt!(context
-                                  .config
-                                  .max_width()
-                                  .checked_sub(type_indent.width() + ";".len()));
-        ty.rewrite(context, Shape::legacy(budget, type_indent))
-    }));
+            // Remove the space after '='
+            result.pop();
+            let type_indent = indent.block_indent(context.config);
+            result.push('\n');
+            result.push_str(&type_indent.to_string(context.config));
+            let budget = try_opt!(context
+                                      .config
+                                      .max_width()
+                                      .checked_sub(type_indent.width() + ";".len()));
+            ty.rewrite(context, Shape::legacy(budget, type_indent))
+        }));
     result.push_str(&ty_str);
     result.push_str(";");
     Some(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,7 +626,7 @@ pub fn format_input<T: Write>(input: Input,
                 return filemap::write_file(file, file_name, out, config);
             }
             Ok(false)
-        }
+        },
     ) {
         Ok((file_map, has_diff)) => {
             if report.has_warnings() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -172,12 +172,12 @@ pub fn rewrite_macro(mac: &ast::Mac,
         MacroStyle::Parens => {
             // Format macro invocation as function call, forcing no trailing
             // comma because not all macros support them.
-            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape).map(|rw| {
-                match position {
+            rewrite_call(context, &macro_name, &expr_vec, mac.span, shape).map(
+                |rw| match position {
                     MacroPosition::Item => format!("{};", rw),
                     _ => rw,
-                }
-            })
+                },
+            )
         }
         MacroStyle::Brackets => {
             let mac_shape = try_opt!(shape.shrink_left(macro_name.len()));
@@ -199,17 +199,13 @@ pub fn rewrite_macro(mac: &ast::Mac,
             } else {
                 // Format macro invocation as array literal.
                 let rewrite =
-                    try_opt!(rewrite_array(
-                    expr_vec.iter().map(|x| &**x),
-                    mk_sp(
-                        context
-                            .codemap
-                            .span_after(mac.span, original_style.opener()),
-                        mac.span.hi - BytePos(1),
-                    ),
-                    context,
-                    mac_shape,
-                ));
+                    try_opt!(rewrite_array(expr_vec.iter().map(|x| &**x),
+                                           mk_sp(context
+                                                     .codemap
+                                                     .span_after(mac.span, original_style.opener()),
+                                               mac.span.hi - BytePos(1)),
+                                           context,
+                                           mac_shape));
 
                 Some(format!("{}{}", macro_name, rewrite))
             }

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -22,8 +22,9 @@ impl<'a> FmtVisitor<'a> {
     // TODO these format_missing methods are ugly. Refactor and add unit tests
     // for the central whitespace stripping loop.
     pub fn format_missing(&mut self, end: BytePos) {
-        self.format_missing_inner(end,
-                                  |this, last_snippet, _| this.buffer.push_str(last_snippet))
+        self.format_missing_inner(end, |this, last_snippet, _| {
+            this.buffer.push_str(last_snippet)
+        })
     }
 
     pub fn format_missing_with_indent(&mut self, end: BytePos) {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -14,7 +14,7 @@ use syntax::codemap::{CodeMap, Span};
 use syntax::parse::ParseSess;
 
 use Shape;
-use config::Config;
+use config::{Config, IndentStyle};
 
 pub trait Rewrite {
     /// Rewrite self into shape.
@@ -37,5 +37,10 @@ pub struct RewriteContext<'a> {
 impl<'a> RewriteContext<'a> {
     pub fn snippet(&self, span: Span) -> String {
         self.codemap.span_to_snippet(span).unwrap()
+    }
+
+    /// Return true if we should use block indent style for rewriting function call.
+    pub fn use_block_indent(&self) -> bool {
+        self.config.fn_call_style() == IndentStyle::Block || self.use_block
     }
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -32,6 +32,8 @@ pub struct RewriteContext<'a> {
     // When `format_if_else_cond_comment` is true, unindent the comment on top
     // of the `else` or `else if`.
     pub is_if_else_block: bool,
+    // When rewriting chain, veto going multi line except the last element
+    pub force_one_line_chain: bool,
 }
 
 impl<'a> RewriteContext<'a> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -376,13 +376,15 @@ impl Rewrite for ast::WherePredicate {
                     // 6 = "for<> ".len()
                     let used_width = lifetime_str.len() + type_str.len() + colon.len() + 6;
                     let budget = try_opt!(shape.width.checked_sub(used_width));
-                    let bounds_str: String = try_opt!(bounds
-                        .iter()
-                        .map(|ty_bound| {
-                            ty_bound
-                                .rewrite(context, Shape::legacy(budget, shape.indent + used_width))
-                        })
-                        .collect::<Option<Vec<_>>>())
+                    let bounds_str: String = try_opt!(
+                        bounds
+                            .iter()
+                            .map(|ty_bound| {
+                                ty_bound.rewrite(context,
+                                                 Shape::legacy(budget, shape.indent + used_width))
+                            })
+                            .collect::<Option<Vec<_>>>()
+                    )
                         .join(joiner);
 
                     if context.config.spaces_within_angle_brackets() && lifetime_str.len() > 0 {
@@ -401,13 +403,15 @@ impl Rewrite for ast::WherePredicate {
                     };
                     let used_width = type_str.len() + colon.len();
                     let budget = try_opt!(shape.width.checked_sub(used_width));
-                    let bounds_str: String = try_opt!(bounds
-                        .iter()
-                        .map(|ty_bound| {
-                            ty_bound
-                                .rewrite(context, Shape::legacy(budget, shape.indent + used_width))
-                        })
-                        .collect::<Option<Vec<_>>>())
+                    let bounds_str: String = try_opt!(
+                        bounds
+                            .iter()
+                            .map(|ty_bound| {
+                                ty_bound.rewrite(context,
+                                                 Shape::legacy(budget, shape.indent + used_width))
+                            })
+                            .collect::<Option<Vec<_>>>()
+                    )
                         .join(joiner);
 
                     format!("{}{}{}", type_str, colon, bounds_str)
@@ -701,15 +705,16 @@ fn rewrite_bare_fn(bare_fn: &ast::BareFnTy,
         // 6 = "for<> ".len(), 4 = "for<".
         // This doesn't work out so nicely for mutliline situation with lots of
         // rightward drift. If that is a problem, we could use the list stuff.
-        result.push_str(&try_opt!(bare_fn
-            .lifetimes
-            .iter()
-            .map(|l| {
-                l.rewrite(context,
-                          Shape::legacy(try_opt!(shape.width.checked_sub(6)), shape.indent + 4))
-            })
-            .collect::<Option<Vec<_>>>())
-            .join(", "));
+        result.push_str(&try_opt!(
+            bare_fn
+                .lifetimes
+                .iter()
+                .map(|l| {
+                    l.rewrite(context,
+                              Shape::legacy(try_opt!(shape.width.checked_sub(6)), shape.indent + 4))
+                })
+                .collect::<Option<Vec<_>>>()
+        ).join(", "));
         result.push_str("> ");
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -384,8 +384,7 @@ impl Rewrite for ast::WherePredicate {
                                                  Shape::legacy(budget, shape.indent + used_width))
                             })
                             .collect::<Option<Vec<_>>>()
-                    )
-                        .join(joiner);
+                    ).join(joiner);
 
                     if context.config.spaces_within_angle_brackets() && lifetime_str.len() > 0 {
                         format!("for< {} > {}{}{}",
@@ -411,8 +410,7 @@ impl Rewrite for ast::WherePredicate {
                                                  Shape::legacy(budget, shape.indent + used_width))
                             })
                             .collect::<Option<Vec<_>>>()
-                    )
-                        .join(joiner);
+                    ).join(joiner);
 
                     format!("{}{}{}", type_str, colon, bounds_str)
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -377,11 +377,12 @@ impl Rewrite for ast::WherePredicate {
                     let used_width = lifetime_str.len() + type_str.len() + colon.len() + 6;
                     let budget = try_opt!(shape.width.checked_sub(used_width));
                     let bounds_str: String = try_opt!(bounds
-                                                          .iter()
-                                                          .map(|ty_bound| {
-                        ty_bound.rewrite(context, Shape::legacy(budget, shape.indent + used_width))
-                    })
-                                                          .collect::<Option<Vec<_>>>())
+                        .iter()
+                        .map(|ty_bound| {
+                            ty_bound
+                                .rewrite(context, Shape::legacy(budget, shape.indent + used_width))
+                        })
+                        .collect::<Option<Vec<_>>>())
                         .join(joiner);
 
                     if context.config.spaces_within_angle_brackets() && lifetime_str.len() > 0 {
@@ -401,11 +402,12 @@ impl Rewrite for ast::WherePredicate {
                     let used_width = type_str.len() + colon.len();
                     let budget = try_opt!(shape.width.checked_sub(used_width));
                     let bounds_str: String = try_opt!(bounds
-                                                          .iter()
-                                                          .map(|ty_bound| {
-                        ty_bound.rewrite(context, Shape::legacy(budget, shape.indent + used_width))
-                    })
-                                                          .collect::<Option<Vec<_>>>())
+                        .iter()
+                        .map(|ty_bound| {
+                            ty_bound
+                                .rewrite(context, Shape::legacy(budget, shape.indent + used_width))
+                        })
+                        .collect::<Option<Vec<_>>>())
                         .join(joiner);
 
                     format!("{}{}{}", type_str, colon, bounds_str)
@@ -700,14 +702,14 @@ fn rewrite_bare_fn(bare_fn: &ast::BareFnTy,
         // This doesn't work out so nicely for mutliline situation with lots of
         // rightward drift. If that is a problem, we could use the list stuff.
         result.push_str(&try_opt!(bare_fn
-                                      .lifetimes
-                                      .iter()
-                                      .map(|l| {
-            l.rewrite(context,
-                      Shape::legacy(try_opt!(shape.width.checked_sub(6)), shape.indent + 4))
-        })
-                                      .collect::<Option<Vec<_>>>())
-                            .join(", "));
+            .lifetimes
+            .iter()
+            .map(|l| {
+                l.rewrite(context,
+                          Shape::legacy(try_opt!(shape.width.checked_sub(6)), shape.indent + 4))
+            })
+            .collect::<Option<Vec<_>>>())
+            .join(", "));
         result.push_str("> ");
     }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -629,6 +629,7 @@ impl<'a> FmtVisitor<'a> {
             inside_macro: false,
             use_block: false,
             is_if_else_block: false,
+            force_one_line_chain: false,
         }
     }
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -201,8 +201,9 @@ fn print_mismatches(result: HashMap<String, Vec<Mismatch>>) {
     let mut t = term::stdout().unwrap();
 
     for (file_name, diff) in result {
-        print_diff(diff,
-                   |line_num| format!("\nMismatch at {}:{}:", file_name, line_num));
+        print_diff(diff, |line_num| {
+            format!("\nMismatch at {}:{}:", file_name, line_num)
+        });
     }
 
     t.reset().unwrap();

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -147,12 +147,9 @@ fn try_shorthand() {
         .0
         .x;
 
-    parameterized(f,
-                  substs,
-                  def_id,
-                  Ns::Value,
-                  &[],
-                  |tcx| tcx.lookup_item_type(def_id).generics)?;
+    parameterized(f, substs, def_id, Ns::Value, &[], |tcx| {
+        tcx.lookup_item_type(def_id).generics
+    })?;
     fooooooooooooooooooooooooooo()?
         .bar()?
         .baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz()?;

--- a/tests/target/combining.rs
+++ b/tests/target/combining.rs
@@ -1,0 +1,120 @@
+// rustfmt-fn_call_style: Block
+// Combining openings and closings. See https://github.com/rust-lang-nursery/fmt-rfcs/issues/61.
+
+fn main() {
+    // Call
+    foo(bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Mac
+    foo(foo!(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // MethodCall
+    foo(x.foo::<Bar, Baz>(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Block
+    foo!({
+        foo();
+        bar();
+    });
+
+    // Closure
+    foo(|x| {
+        let y = x + 1;
+        y
+    });
+
+    // Match
+    foo(match opt {
+        Some(x) => x,
+        None => y,
+    });
+
+    // Struct
+    foo(Bar {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    });
+
+    // If
+    foo!(if x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // IfLet
+    foo!(if let Some(..) = x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // While
+    foo!(while x {
+        foo();
+        bar();
+    });
+
+    // WhileLet
+    foo!(while let Some(..) = x {
+        foo();
+        bar();
+    });
+
+    // ForLoop
+    foo!(for x in y {
+        foo();
+        bar();
+    });
+
+    // Loop
+    foo!(loop {
+        foo();
+        bar();
+    });
+
+    // Tuple
+    foo((
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // AddrOf
+    foo(&bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Box
+    foo(box Bar {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    });
+
+    // Unary
+    foo(!bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Try
+    foo(bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    )?);
+
+    // Cast
+    foo(Bar {
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    } as i64);
+}

--- a/tests/target/configs-combine_control_expr-false.rs
+++ b/tests/target/configs-combine_control_expr-false.rs
@@ -1,4 +1,5 @@
 // rustfmt-fn_call_style: Block
+// rustfmt-combine_control_expr: false
 // Combining openings and closings. See https://github.com/rust-lang-nursery/fmt-rfcs/issues/61.
 
 fn main() {
@@ -45,42 +46,54 @@ fn main() {
     });
 
     // If
-    foo!(if x {
-        foo();
-    } else {
-        bar();
-    });
+    foo!(
+        if x {
+            foo();
+        } else {
+            bar();
+        }
+    );
 
     // IfLet
-    foo!(if let Some(..) = x {
-        foo();
-    } else {
-        bar();
-    });
+    foo!(
+        if let Some(..) = x {
+            foo();
+        } else {
+            bar();
+        }
+    );
 
     // While
-    foo!(while x {
-        foo();
-        bar();
-    });
+    foo!(
+        while x {
+            foo();
+            bar();
+        }
+    );
 
     // WhileLet
-    foo!(while let Some(..) = x {
-        foo();
-        bar();
-    });
+    foo!(
+        while let Some(..) = x {
+            foo();
+            bar();
+        }
+    );
 
     // ForLoop
-    foo!(for x in y {
-        foo();
-        bar();
-    });
+    foo!(
+        for x in y {
+            foo();
+            bar();
+        }
+    );
 
     // Loop
-    foo!(loop {
-        foo();
-        bar();
-    });
+    foo!(
+        loop {
+            foo();
+            bar();
+        }
+    );
 
     // Tuple
     foo((

--- a/tests/target/configs-combine_control_expr-true.rs
+++ b/tests/target/configs-combine_control_expr-true.rs
@@ -1,0 +1,121 @@
+// rustfmt-fn_call_style: Block
+// rustfmt-combine_control_expr: true
+// Combining openings and closings. See https://github.com/rust-lang-nursery/fmt-rfcs/issues/61.
+
+fn main() {
+    // Call
+    foo(bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Mac
+    foo(foo!(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // MethodCall
+    foo(x.foo::<Bar, Baz>(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Block
+    foo!({
+        foo();
+        bar();
+    });
+
+    // Closure
+    foo(|x| {
+        let y = x + 1;
+        y
+    });
+
+    // Match
+    foo(match opt {
+        Some(x) => x,
+        None => y,
+    });
+
+    // Struct
+    foo(Bar {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    });
+
+    // If
+    foo!(if x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // IfLet
+    foo!(if let Some(..) = x {
+        foo();
+    } else {
+        bar();
+    });
+
+    // While
+    foo!(while x {
+        foo();
+        bar();
+    });
+
+    // WhileLet
+    foo!(while let Some(..) = x {
+        foo();
+        bar();
+    });
+
+    // ForLoop
+    foo!(for x in y {
+        foo();
+        bar();
+    });
+
+    // Loop
+    foo!(loop {
+        foo();
+        bar();
+    });
+
+    // Tuple
+    foo((
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // AddrOf
+    foo(&bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Box
+    foo(box Bar {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    });
+
+    // Unary
+    foo(!bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ));
+
+    // Try
+    foo(bar(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    )?);
+
+    // Cast
+    foo(Bar {
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    } as i64);
+}

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -134,15 +134,14 @@ impl Cursor {
 }
 
 fn issue1581() {
-    bootstrap.checks.register(
-        "PERSISTED_LOCATIONS",
-        move || if locations2.0.inner_mut.lock().poisoned {
+    bootstrap.checks.register("PERSISTED_LOCATIONS", move || {
+        if locations2.0.inner_mut.lock().poisoned {
             Check::new(
                 State::Error,
                 "Persisted location storage is poisoned due to a write failure",
             )
         } else {
             Check::new(State::Healthy, "Persisted location storage is healthy")
-        },
-    );
+        }
+    });
 }

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -67,10 +67,10 @@ fn main() {
 	}
 
 	loong_func().quux(move || if true {
-		                  1
-		                 } else {
-		                  2
-		                 });
+		1
+	} else {
+		2
+	});
 
 	fffffffffffffffffffffffffffffffffff(a, {
 		SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
@@ -78,7 +78,7 @@ fn main() {
 	a.b.c.d();
 
 	x().y(|| match cond() {
-	          true => (),
-	          false => (),
-	      });
+		true => (),
+		false => (),
+	});
 }

--- a/tests/target/nested-visual-block.rs
+++ b/tests/target/nested-visual-block.rs
@@ -45,13 +45,16 @@ fn main() {
     });
 
     // #1581
-    bootstrap.checks.register(
-        "PERSISTED_LOCATIONS",
-        move || if locations2.0.inner_mut.lock().poisoned {
+    bootstrap
+        .checks
+        .register("PERSISTED_LOCATIONS", move || if locations2
+               .0
+               .inner_mut
+               .lock()
+               .poisoned {
             Check::new(State::Error,
                        "Persisted location storage is poisoned due to a write failure")
         } else {
             Check::new(State::Healthy, "Persisted location storage is healthy")
-        }
-    );
+        });
 }


### PR DESCRIPTION
This PR allows more expressions to be combined with function calls, but not with match arms because I am not sure how combining interacts with `wrap_match_arms` option.

If it is prefered to wait before implementing, I am happy to close this without merging.
