### PR TITLE
Forbid trailing comma at the end of args of variadic functions

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1944,7 +1944,11 @@ fn rewrite_args(context: &RewriteContext,
     let fmt = ListFormatting {
         tactic: tactic,
         separator: ",",
-        trailing_separator: trailing_comma,
+        trailing_separator: if variadic {
+            SeparatorTactic::Never
+        } else {
+            trailing_comma
+        },
         shape: Shape::legacy(budget, indent),
         ends_with_newline: end_with_newline,
         config: context.config,

--- a/tests/source/configs-fn_args_layout-block.rs
+++ b/tests/source/configs-fn_args_layout-block.rs
@@ -14,3 +14,9 @@ extern "system" {
     pub fn GetConsoleHistoryInfo(console_history_info: *mut ConsoleHistoryInfo) -> Boooooooooooooool;
 }
 
+// rustfmt should not add trailing comma for variadic function. See #1623.
+extern "C" {
+    pub fn variadic_fn(first_parameter: FirstParameterType,
+                       second_parameter: SecondParameterType,
+                       ...);
+}

--- a/tests/target/configs-fn_args_layout-block.rs
+++ b/tests/target/configs-fn_args_layout-block.rs
@@ -23,3 +23,12 @@ extern "system" {
         console_history_info: *mut ConsoleHistoryInfo,
     ) -> Boooooooooooooool;
 }
+
+// rustfmt should not add trailing comma for variadic function. See #1623.
+extern "C" {
+    pub fn variadic_fn(
+        first_parameter: FirstParameterType,
+        second_parameter: SecondParameterType,
+        ...
+    );
+}


### PR DESCRIPTION
Closes #1623.