### PR TITLE
Refactor vertical layout of function definition with options

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1587,7 +1587,10 @@ fn rewrite_fn_base(context: &RewriteContext,
     let generics_str = try_opt!(rewrite_generics(context, generics, shape, generics_span));
     result.push_str(&generics_str);
 
-    let snuggle_angle_bracket = last_line_width(&generics_str) == 1;
+    let snuggle_angle_bracket = generics_str
+        .lines()
+        .last()
+        .map_or(false, |l| l.trim_left().len() == 1);
 
     // Note that the width and indent don't really matter, we'll re-layout the
     // return type later anyway.

--- a/src/items.rs
+++ b/src/items.rs
@@ -1622,24 +1622,28 @@ fn rewrite_fn_base(context: &RewriteContext,
     // Check if vertical layout was forced.
     if one_line_budget == 0 {
         if snuggle_angle_bracket {
-            result.push_str("(");
-        } else if context.config.fn_args_paren_newline() {
-            result.push('\n');
-            result.push_str(&arg_indent.to_string(context.config));
-            arg_indent = arg_indent + 1; // extra space for `(`
             result.push('(');
-            if context.config.spaces_within_parens() && fd.inputs.len() > 0 {
-                result.push(' ')
-            }
         } else {
-            result.push_str("(\n");
-            result.push_str(&arg_indent.to_string(context.config));
+            if context.config.fn_args_paren_newline() {
+                result.push('\n');
+                result.push_str(&arg_indent.to_string(context.config));
+                if context.config.fn_args_layout() == IndentStyle::Visual {
+                    arg_indent = arg_indent + 1; // extra space for `(`
+                }
+                result.push('(');
+            } else {
+                result.push_str("(");
+                if context.config.fn_args_layout() == IndentStyle::Visual {
+                    result.push('\n');
+                    result.push_str(&arg_indent.to_string(context.config));
+                }
+            }
         }
     } else {
         result.push('(');
-        if context.config.spaces_within_parens() && fd.inputs.len() > 0 {
-            result.push(' ')
-        }
+    }
+    if context.config.spaces_within_parens() && fd.inputs.len() > 0 && result.ends_with('(') {
+        result.push(' ')
     }
 
     if multi_line_ret_str {

--- a/tests/target/fn-custom-2.rs
+++ b/tests/target/fn-custom-2.rs
@@ -52,8 +52,7 @@ impl Foo {
         'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
         TTTTTTTTTTTTT,
         UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
-    >
-        (
+    >(
         a: Aaaaaaaaaaaaaaa,
     ) {
         bar();

--- a/tests/target/fn-custom-3.rs
+++ b/tests/target/fn-custom-3.rs
@@ -54,8 +54,7 @@ impl Foo {
         'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
         TTTTTTTTTTTTT,
         UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
-    >
-        (
+    >(
         a: Aaaaaaaaaaaaaaa,
     ) {
         bar();

--- a/tests/target/issue-1624.rs
+++ b/tests/target/issue-1624.rs
@@ -1,0 +1,9 @@
+// rustfmt-fn_args_layout: Block
+// rustfmt-fn_args_paren_newline: false
+
+// #1624
+pub unsafe fn some_long_function_name(
+    arg1: Type1,
+    arg2: Type2,
+) -> (SomeLongTypeName, AnotherLongTypeName, AnotherLongTypeName) {
+}


### PR DESCRIPTION
This PR
* removes an extra blank line from function definition when `fn_args_layout = "Block"` and `fn_args_paren_newline = false` are used (Please take a look at #1624 and https://github.com/rust-lang-nursery/fmt-rfcs/issues/39).
* allows the opening `(` of args to stay after the closing `>` of multi line generic.