### PR TITLE
Implement Rewrite trait for syntax::ast::Attribute 

### DIFF
--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -41,4 +41,14 @@ impl Bar {
     /// Blah blah bing.
     fn f4(self) -> Cat {
     }
+
+    // We want spaces around `=`
+    #[cfg(feature="nightly")]
+    fn f5(self) -> Monkey {}
+}
+
+// #984
+struct Foo {
+    # [ derive ( Clone , PartialEq , Debug , Deserialize , Serialize ) ]
+    foo: usize,
 }

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -109,3 +109,14 @@ pub enum Bencoding<'i> {
     // TODO make Dict "structlike" AKA name the two values.
     Dict(&'i [u8], BTreeMap<&'i [u8], Bencoding<'i>>),
 }
+
+// #1261
+pub enum CoreResourceMsg {
+    SetCookieForUrl(
+        ServoUrl,
+        #[serde(deserialize_with = "::hyper_serde::deserialize",
+                serialize_with = "::hyper_serde::serialize")]
+        Cookie,
+        CookieSource
+    ),
+}

--- a/tests/source/struct-field-attributes.rs
+++ b/tests/source/struct-field-attributes.rs
@@ -20,3 +20,18 @@ fn do_something() -> Foo {
 fn main() {
     do_something();
 }
+
+// #1462
+struct Foo {
+    foo: usize,
+    #[cfg(feature="include-bar")]
+    bar: usize,
+}
+
+fn new_foo() -> Foo {
+    Foo {
+        foo: 0,
+        #[cfg(feature="include-bar")]
+        bar: 0,
+    }
+}

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -37,4 +37,14 @@ impl Bar {
     // tooooooooooooooooooooooooooooooo loooooooooooong.
     /// Blah blah bing.
     fn f4(self) -> Cat {}
+
+    // We want spaces around `=`
+    #[cfg(feature = "nightly")]
+    fn f5(self) -> Monkey {}
+}
+
+// #984
+struct Foo {
+    #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+    foo: usize,
 }

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -139,3 +139,12 @@ pub enum Bencoding<'i> {
     // TODO make Dict "structlike" AKA name the two values.
     Dict(&'i [u8], BTreeMap<&'i [u8], Bencoding<'i>>),
 }
+
+// #1261
+pub enum CoreResourceMsg {
+    SetCookieForUrl(ServoUrl,
+                    #[serde(deserialize_with = "::hyper_serde::deserialize",
+                            serialize_with = "::hyper_serde::serialize")]
+                    Cookie,
+                    CookieSource),
+}

--- a/tests/target/nestedmod/mod.rs
+++ b/tests/target/nestedmod/mod.rs
@@ -7,7 +7,7 @@ mod mymod1 {
     mod mod3a;
 }
 
-#[path="mod2c.rs"]
+#[path = "mod2c.rs"]
 mod mymod2;
 
 mod submod2;

--- a/tests/target/nestedmod/mod2b.rs
+++ b/tests/target/nestedmod/mod2b.rs
@@ -1,3 +1,3 @@
 
-#[path="mod2a.rs"]
+#[path = "mod2a.rs"]
 mod c;

--- a/tests/target/struct-field-attributes.rs
+++ b/tests/target/struct-field-attributes.rs
@@ -20,3 +20,18 @@ fn do_something() -> Foo {
 fn main() {
     do_something();
 }
+
+// #1462
+struct Foo {
+    foo: usize,
+    #[cfg(feature = "include-bar")]
+    bar: usize,
+}
+
+fn new_foo() -> Foo {
+    Foo {
+        foo: 0,
+        #[cfg(feature = "include-bar")]
+        bar: 0,
+    }
+}


### PR DESCRIPTION
This PR implements basic formatting against `syntax::ast::Attribute`.

Possible TODOs:
* Add an option to change indent style or list layout when list (e.g. `[derive(..)]`) goes multi line
* Implement https://github.com/rust-lang-nursery/fmt-rfcs/issues/72

Closes #984, closes #1261, and closes #1462.

