### PR TITLE
Add config options for spaces around the colon in struct literal fields

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1123,6 +1123,33 @@ fn lorem<T: Eq>(t: T) {
 
 See also: [`space_before_bound`](#space_before_bound).
 
+## `space_after_struct_lit_field_colon`
+
+Leave a space after the colon in a struct literal field
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `false`:
+
+```rust
+let lorem = Lorem {
+    ipsum:dolor,
+    sit:amet,
+};
+```
+
+#### `true`:
+
+```rust
+let lorem = Lorem {
+    ipsum: dolor,
+    sit: amet,
+};
+```
+
+See also: [`space_before_struct_lit_field_colon`](#space_before_struct_lit_field_colon).
+
 ## `space_after_type_annotation_colon`
 
 Leave a space after the colon in a type annotation
@@ -1172,6 +1199,33 @@ fn lorem<T : Eq>(t: T) {
 ```
 
 See also: [`space_after_bound_colon`](#space_after_bound_colon).
+
+## `space_before_struct_lit_field_colon`
+
+Leave a space before the colon in a struct literal field
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `false`:
+
+```rust
+let lorem = Lorem {
+    ipsum: dolor,
+    sit: amet,
+};
+```
+
+#### `true`:
+
+```rust
+let lorem = Lorem {
+    ipsum : dolor,
+    sit : amet,
+};
+```
+
+See also: [`space_after_struct_lit_field_colon`](#space_after_struct_lit_field_colon).
 
 ## `space_before_type_annotation`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -564,6 +564,10 @@ create_config! {
         "Leave a space before the colon in a type annotation";
     space_after_type_annotation_colon: bool, true,
         "Leave a space after the colon in a type annotation";
+    space_before_struct_lit_field_colon: bool, false,
+        "Leave a space before the colon in a struct literal field";
+    space_after_struct_lit_field_colon: bool, true,
+        "Leave a space after the colon in a struct literal field";
     space_before_bound: bool, false, "Leave a space before the colon in a trait or lifetime bound";
     space_after_bound_colon: bool, true,
         "Leave a space after the colon in a trait or lifetime bound";

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2050,18 +2050,18 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     // FIXME if context.config.struct_lit_style() == Visual, but we run out
     // of space, we should fall back to BlockIndent.
 }
-
-pub fn type_annotation_separator(config: &Config) -> &str {
-    colon_spaces(config.space_before_type_annotation(),
-                 config.space_after_type_annotation_colon())
+pub fn struct_lit_field_separator(config: &Config) -> &str {
+    colon_spaces(config.space_before_struct_lit_field_colon(),
+                 config.space_after_struct_lit_field_colon())
 }
+
 
 fn rewrite_field(context: &RewriteContext, field: &ast::Field, shape: Shape) -> Option<String> {
     let name = &field.ident.node.to_string();
     if field.is_shorthand {
         Some(name.to_string())
     } else {
-        let separator = type_annotation_separator(context.config);
+        let separator = struct_lit_field_separator(context.config);
         let overhead = name.len() + separator.len();
         let mut expr_shape = try_opt!(shape.sub_width(overhead));
         expr_shape.offset += overhead;

--- a/src/items.rs
+++ b/src/items.rs
@@ -14,10 +14,10 @@ use {Indent, Shape};
 use codemap::SpanUtils;
 use utils::{format_mutability, format_visibility, contains_skip, end_typaram, wrap_str,
             last_line_width, format_unsafety, trim_newlines, stmt_expr, semicolon_for_expr,
-            trimmed_last_line_width};
+            trimmed_last_line_width, colon_spaces};
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, list_helper,
             DefinitiveListTactic, ListTactic, definitive_tactic, format_item_list};
-use expr::{is_empty_block, is_simple_block_stmt, rewrite_assign_rhs, type_annotation_separator};
+use expr::{is_empty_block, is_simple_block_stmt, rewrite_assign_rhs};
 use comment::{FindUncommented, contains_comment, rewrite_comment, recover_comment_removed};
 use visitor::FmtVisitor;
 use rewrite::{Rewrite, RewriteContext};
@@ -26,6 +26,12 @@ use config::{Config, IndentStyle, Density, ReturnIndent, BraceStyle, Style, Type
 use syntax::{ast, abi, codemap, ptr, symbol};
 use syntax::codemap::{Span, BytePos, mk_sp};
 use syntax::ast::ImplItem;
+
+fn type_annotation_separator(config: &Config) -> &str {
+    colon_spaces(config.space_before_type_annotation(),
+                 config.space_after_type_annotation_colon())
+}
+
 
 // Statements of the form
 // let pat: ty = init;

--- a/tests/source/configs-space_after_struct_lit_field_colon-false.rs
+++ b/tests/source/configs-space_after_struct_lit_field_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_struct_lit_field_colon: false
+
+const LOREM: Lorem = Lorem {
+    ipsum:dolor,
+    sit :  amet,
+};

--- a/tests/source/configs-space_after_struct_lit_field_colon-true.rs
+++ b/tests/source/configs-space_after_struct_lit_field_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_struct_lit_field_colon: true
+
+const LOREM: Lorem = Lorem {
+    ipsum:dolor,
+    sit :  amet,
+};

--- a/tests/source/configs-space_before_struct_lit_field_colon-false.rs
+++ b/tests/source/configs-space_before_struct_lit_field_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_struct_lit_field_colon: false
+
+const LOREM: Lorem = Lorem {
+    ipsum:dolor,
+    sit  : amet,
+};

--- a/tests/source/configs-space_before_struct_lit_field_colon-true.rs
+++ b/tests/source/configs-space_before_struct_lit_field_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_struct_lit_field_colon: true
+
+const LOREM: Lorem = Lorem {
+    ipsum:dolor,
+    sit  : amet,
+};

--- a/tests/target/configs-space_after_struct_lit_field_colon-false.rs
+++ b/tests/target/configs-space_after_struct_lit_field_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_struct_lit_field_colon: false
+
+const LOREM: Lorem = Lorem {
+    ipsum:dolor,
+    sit:amet,
+};

--- a/tests/target/configs-space_after_struct_lit_field_colon-true.rs
+++ b/tests/target/configs-space_after_struct_lit_field_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_after_struct_lit_field_colon: true
+
+const LOREM: Lorem = Lorem {
+    ipsum: dolor,
+    sit: amet,
+};

--- a/tests/target/configs-space_before_struct_lit_field_colon-false.rs
+++ b/tests/target/configs-space_before_struct_lit_field_colon-false.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_struct_lit_field_colon: false
+
+const LOREM: Lorem = Lorem {
+    ipsum: dolor,
+    sit: amet,
+};

--- a/tests/target/configs-space_before_struct_lit_field_colon-true.rs
+++ b/tests/target/configs-space_before_struct_lit_field_colon-true.rs
@@ -1,0 +1,6 @@
+// rustfmt-space_before_struct_lit_field_colon: true
+
+const LOREM: Lorem = Lorem {
+    ipsum : dolor,
+    sit : amet,
+};

--- a/tests/target/space-before-type-annotation.rs
+++ b/tests/target/space-before-type-annotation.rs
@@ -9,5 +9,5 @@ struct S {
     fieldVar : i32,
 }
 fn f() {
-    S { fieldVar : 42 }
+    S { fieldVar: 42 }
 }

--- a/tests/target/space-not-after-type-annotation-colon.rs
+++ b/tests/target/space-not-after-type-annotation-colon.rs
@@ -10,5 +10,5 @@ struct S {
     fieldVar :i32,
 }
 fn f() {
-    S { fieldVar :42 }
+    S { fieldVar: 42 }
 }


### PR DESCRIPTION
In Rust, colons are used for three purposes:

* Type annotations, including type ascription
* Trait bounds
* Struct literal fields

This commit adds options for the last missing of the three purposes,
struct literal fields.