### PR TITLE
Add 'fn_args_paren_newline = false' to rfc-rustfmt.toml

### DIFF
--- a/rfc-rustfmt.toml
+++ b/rfc-rustfmt.toml
@@ -5,3 +5,4 @@ where_style = "Rfc"
 generics_indent = "Block"
 fn_call_style = "Block"
 combine_control_expr = true
+fn_args_paren_newline = false


### PR DESCRIPTION
Following https://github.com/rust-lang-nursery/fmt-rfcs/issues/39.
```rust
fn extract_one(
    &mut self,
    m: FxHashMap<PathBuf, PathKind>,
    flavor: CrateFlavor,
    slot: &mut Option<(Svh, MetadataBlob)>,
) -> Option<(PathBuf, PathKind)> {
    // ...
}
```