### PR TITLE
Force brace on new line if the signature ends with comment

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1871,6 +1871,7 @@ fn rewrite_fn_base(context: &RewriteContext,
 
                 result.push_str(&where_clause_str);
 
+                force_new_line_for_brace |= last_line_contains_single_line_comment(&result);
                 return Some((result, force_new_line_for_brace));
             }
         }
@@ -1888,7 +1889,12 @@ fn rewrite_fn_base(context: &RewriteContext,
 
     result.push_str(&where_clause_str);
 
-    Some((result, force_new_line_for_brace))
+    force_new_line_for_brace |= last_line_contains_single_line_comment(&result);
+    return Some((result, force_new_line_for_brace));
+}
+
+fn last_line_contains_single_line_comment(s: &str) -> bool {
+    s.lines().last().map_or(false, |l| l.contains("//"))
 }
 
 fn rewrite_args(context: &RewriteContext,

--- a/tests/target/comments-fn.rs
+++ b/tests/target/comments-fn.rs
@@ -19,3 +19,7 @@ fn foo<F, G>(a: aaaaaaaaaaaaa, // A comment
 fn bar<F /* comment on F */, G /* comment on G */>() {}
 
 fn baz() -> Baz /* Comment after return type */ {}
+
+fn some_fn<T>() where T: Eq // some comment
+{
+}


### PR DESCRIPTION
Fixes the second issue of #1643.