### PR TITLE
Use multi line for trait bounds when they don't fit in a single line

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2182,11 +2182,21 @@ fn rewrite_trait_bounds(context: &RewriteContext,
                                  .map(|ty_bound| ty_bound.rewrite(&context, shape))
                                  .collect::<Option<Vec<_>>>())
         .join(joiner);
-
-    let mut result = String::new();
-    result.push_str(": ");
-    result.push_str(&bound_str);
-    Some(result)
+    // 2 = `: `
+    if bound_str.len() + 2 <= shape.width {
+        Some(format!(": {}", bound_str))
+    } else {
+        let bound_str = try_opt!(bounds
+                                     .iter()
+                                     .map(|ty_bound| ty_bound.rewrite(&context, shape))
+                                     .collect::<Option<Vec<_>>>())
+            .join(&format!("\n{}+ ",
+                           shape
+                               .indent
+                               .block_indent(context.config)
+                               .to_string(context.config)));
+        Some(format!(": {}", bound_str))
+    }
 }
 
 fn rewrite_where_clause_rfc_style(context: &RewriteContext,

--- a/tests/source/trait.rs
+++ b/tests/source/trait.rs
@@ -53,3 +53,19 @@ trait FooBar<T> : Tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt
 
 trait WhereList<T, J> where T: Foo, J: Bar {}
 
+// #1168
+pub trait Number: Copy + Eq +      Not<Output = Self> + Shl<u8, Output = Self> +
+    Shr<u8, Output = Self>       +
+    BitAnd<Self, Output=Self> +    BitOr<Self, Output=Self>  + BitAndAssign + BitOrAssign
+
+
+
+{
+    // test
+    fn zero() -> Self;
+}
+
+// #1642
+pub trait SomeTrait : Clone + Eq + PartialEq + Ord + PartialOrd + Default + Hash + Debug + Display + Write + Read + FromStr {
+    // comment
+}

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -66,3 +66,35 @@ trait WhereList<T, J>
           J: Bar
 {
 }
+
+// #1168
+pub trait Number
+    : Copy
+    + Eq
+    + Not<Output = Self>
+    + Shl<u8, Output = Self>
+    + Shr<u8, Output = Self>
+    + BitAnd<Self, Output = Self>
+    + BitOr<Self, Output = Self>
+    + BitAndAssign
+    + BitOrAssign {
+    // test
+    fn zero() -> Self;
+}
+
+// #1642
+pub trait SomeTrait
+    : Clone
+    + Eq
+    + PartialEq
+    + Ord
+    + PartialOrd
+    + Default
+    + Hash
+    + Debug
+    + Display
+    + Write
+    + Read
+    + FromStr {
+    // comment
+}


### PR DESCRIPTION
Closes #1168 and closes #1642.
This PR is a simple workaround for the time being. After the discussion in https://github.com/rust-lang-nursery/fmt-rfcs/issues/80 settled, we should be able to add options and whatnot to `rewrite_trait_bounds`.