### PR TITLE
Refactor impl format

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2063,11 +2063,11 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     // FIXME if context.config.struct_lit_style() == Visual, but we run out
     // of space, we should fall back to BlockIndent.
 }
+
 pub fn struct_lit_field_separator(config: &Config) -> &str {
     colon_spaces(config.space_before_struct_lit_field_colon(),
                  config.space_after_struct_lit_field_colon())
 }
-
 
 fn rewrite_field(context: &RewriteContext, field: &ast::Field, shape: Shape) -> Option<String> {
     let name = &field.ident.node.to_string();

--- a/tests/source/big-impl-rfc.rs
+++ b/tests/source/big-impl-rfc.rs
@@ -1,0 +1,114 @@
+// rustfmt-fn_args_layout: Block
+// rustfmt-fn_call_style: Block
+// rustfmt-generics_indent: Block
+// rustfmt-where_style: Rfc
+
+// #1357
+impl<
+    'a,
+    Select,
+    From,
+    Distinct,
+    Where,
+    Order,
+    Limit,
+    Offset,
+    Groupby,
+    DB,
+> InternalBoxedDsl<'a, DB>
+    for SelectStatement<
+        Select,
+        From,
+        Distinct,
+        Where,
+        Order,
+        Limit,
+        Offset,
+        GroupBy,
+    > where
+        DB: Backend,
+        Select: QueryFragment<DB> + SelectableExpression<From> + 'a,
+        Distinct: QueryFragment<DB> + 'a,
+        Where: Into<Option<Box<QueryFragment<DB> + 'a>>>,
+        Order: QueryFragment<DB> + 'a,
+        Limit: QueryFragment<DB> + 'a,
+        Offset: QueryFragment<DB> + 'a,
+{
+    type Output = BoxedSelectStatement<'a, Select::SqlTypeForSelect, From, DB>;
+
+    fn internal_into_boxed(self) -> Self::Output {
+        BoxedSelectStatement::new(
+            Box::new(self.select),
+            self.from,
+            Box::new(self.distinct),
+            self.where_clause.into(),
+            Box::new(self.order),
+            Box::new(self.limit),
+            Box::new(self.offset),
+        )
+    }
+}
+
+// #1369
+impl<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo for Bar {
+    fn foo() {}
+}
+impl Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo for Bar<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> {
+    fn foo() {}
+}
+impl Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> {
+    fn foo() {}
+}

--- a/tests/source/big-impl.rs
+++ b/tests/source/big-impl.rs
@@ -1,0 +1,104 @@
+// #1357
+impl<
+    'a,
+    Select,
+    From,
+    Distinct,
+    Where,
+    Order,
+    Limit,
+    Offset,
+    Groupby,
+    DB,
+> InternalBoxedDsl<'a, DB>
+    for SelectStatement<
+        Select,
+        From,
+        Distinct,
+        Where,
+        Order,
+        Limit,
+        Offset,
+        GroupBy,
+    > where
+        DB: Backend,
+        Select: QueryFragment<DB> + SelectableExpression<From> + 'a,
+        Distinct: QueryFragment<DB> + 'a,
+        Where: Into<Option<Box<QueryFragment<DB> + 'a>>>,
+        Order: QueryFragment<DB> + 'a,
+        Limit: QueryFragment<DB> + 'a,
+        Offset: QueryFragment<DB> + 'a,
+{
+    type Output = BoxedSelectStatement<'a, Select::SqlTypeForSelect, From, DB>;
+
+    fn internal_into_boxed(self) -> Self::Output {
+        BoxedSelectStatement::new(
+            Box::new(self.select),
+            self.from,
+            Box::new(self.distinct),
+            self.where_clause.into(),
+            Box::new(self.order),
+            Box::new(self.limit),
+            Box::new(self.offset),
+        )
+    }
+}
+
+// #1369
+impl<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo for Bar {
+    fn foo() {}
+}
+impl Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo for Bar<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> {
+    fn foo() {}
+}
+impl Foo<
+    ExcessivelyLongGenericName,
+      ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> for Bar<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> {
+    fn foo() {}
+}
+impl<ExcessivelyLongGenericName,
+     ExcessivelyLongGenericName,
+     AnotherExcessivelyLongGenericName> Foo<ExcessivelyLongGenericName,
+                                            ExcessivelyLongGenericName,
+                                            AnotherExcessivelyLongGenericName>
+    for Bar<ExcessivelyLongGenericName,
+            ExcessivelyLongGenericName,
+            AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -122,3 +122,20 @@ impl<ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNodeFoo> Issue1249<ConcreteTh
 impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
     fn drop() {}
 }
+
+// #1168
+pub trait Number: Copy + Eq +      Not<Output = Self> + Shl<u8, Output = Self> +
+    Shr<u8, Output = Self>       +
+    BitAnd<Self, Output=Self> +    BitOr<Self, Output=Self>  + BitAndAssign + BitOrAssign
+
+
+
+{
+    // test
+    fn zero() -> Self;
+}
+
+// #1642
+pub trait SomeTrait : Clone + Eq + PartialEq + Ord + PartialOrd + Default + Hash + Debug + Display + Write + Read + FromStr {
+    // comment
+}

--- a/tests/target/big-impl-rfc.rs
+++ b/tests/target/big-impl-rfc.rs
@@ -5,7 +5,7 @@
 
 // #1357
 impl<'a, Select, From, Distinct, Where, Order, Limit, Offset, Groupby, DB> InternalBoxedDsl<'a, DB>
-for SelectStatement<Select, From, Distinct, Where, Order, Limit, Offset, GroupBy>
+    for SelectStatement<Select, From, Distinct, Where, Order, Limit, Offset, GroupBy>
 where
     DB: Backend,
     Select: QueryFragment<DB> + SelectableExpression<From> + 'a,
@@ -32,11 +32,11 @@ where
 
 // #1369
 impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
-for Bar {
+    for Bar {
     fn foo() {}
 }
 impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
-for Bar {
+    for Bar {
     fn foo() {}
 }
 impl<
@@ -44,15 +44,23 @@ impl<
     ExcessivelyLongGenericName,
     AnotherExcessivelyLongGenericName,
 > Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
-for Bar {
+    for Bar {
     fn foo() {}
 }
 impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
-for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    for Bar<
+        ExcessivelyLongGenericName,
+        ExcessivelyLongGenericName,
+        AnotherExcessivelyLongGenericName,
+    > {
     fn foo() {}
 }
 impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
-for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    for Bar<
+        ExcessivelyLongGenericName,
+        ExcessivelyLongGenericName,
+        AnotherExcessivelyLongGenericName,
+    > {
     fn foo() {}
 }
 impl<
@@ -60,6 +68,10 @@ impl<
     ExcessivelyLongGenericName,
     AnotherExcessivelyLongGenericName,
 > Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
-for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    for Bar<
+        ExcessivelyLongGenericName,
+        ExcessivelyLongGenericName,
+        AnotherExcessivelyLongGenericName,
+    > {
     fn foo() {}
 }

--- a/tests/target/big-impl-rfc.rs
+++ b/tests/target/big-impl-rfc.rs
@@ -1,0 +1,65 @@
+// rustfmt-fn_args_layout: Block
+// rustfmt-fn_call_style: Block
+// rustfmt-generics_indent: Block
+// rustfmt-where_style: Rfc
+
+// #1357
+impl<'a, Select, From, Distinct, Where, Order, Limit, Offset, Groupby, DB> InternalBoxedDsl<'a, DB>
+for SelectStatement<Select, From, Distinct, Where, Order, Limit, Offset, GroupBy>
+where
+    DB: Backend,
+    Select: QueryFragment<DB> + SelectableExpression<From> + 'a,
+    Distinct: QueryFragment<DB> + 'a,
+    Where: Into<Option<Box<QueryFragment<DB> + 'a>>>,
+    Order: QueryFragment<DB> + 'a,
+    Limit: QueryFragment<DB> + 'a,
+    Offset: QueryFragment<DB> + 'a,
+{
+    type Output = BoxedSelectStatement<'a, Select::SqlTypeForSelect, From, DB>;
+
+    fn internal_into_boxed(self) -> Self::Output {
+        BoxedSelectStatement::new(
+            Box::new(self.select),
+            self.from,
+            Box::new(self.distinct),
+            self.where_clause.into(),
+            Box::new(self.order),
+            Box::new(self.limit),
+            Box::new(self.offset),
+        )
+    }
+}
+
+// #1369
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
+for Bar {
+    fn foo() {}
+}
+impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+for Bar {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+for Bar {
+    fn foo() {}
+}
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
+for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}
+impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}
+impl<
+    ExcessivelyLongGenericName,
+    ExcessivelyLongGenericName,
+    AnotherExcessivelyLongGenericName,
+> Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+for Bar<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}

--- a/tests/target/big-impl.rs
+++ b/tests/target/big-impl.rs
@@ -1,0 +1,62 @@
+// #1357
+impl<'a, Select, From, Distinct, Where, Order, Limit, Offset, Groupby, DB> InternalBoxedDsl<'a, DB>
+    for SelectStatement<Select, From, Distinct, Where, Order, Limit, Offset, GroupBy>
+    where DB: Backend,
+          Select: QueryFragment<DB> + SelectableExpression<From> + 'a,
+          Distinct: QueryFragment<DB> + 'a,
+          Where: Into<Option<Box<QueryFragment<DB> + 'a>>>,
+          Order: QueryFragment<DB> + 'a,
+          Limit: QueryFragment<DB> + 'a,
+          Offset: QueryFragment<DB> + 'a
+{
+    type Output = BoxedSelectStatement<'a, Select::SqlTypeForSelect, From, DB>;
+
+    fn internal_into_boxed(self) -> Self::Output {
+        BoxedSelectStatement::new(Box::new(self.select),
+                                  self.from,
+                                  Box::new(self.distinct),
+                                  self.where_clause.into(),
+                                  Box::new(self.order),
+                                  Box::new(self.limit),
+                                  Box::new(self.offset))
+    }
+}
+
+// #1369
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
+    for Bar {
+    fn foo() {}
+}
+impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    for Bar {
+    fn foo() {}
+}
+impl<ExcessivelyLongGenericName,
+     ExcessivelyLongGenericName,
+     AnotherExcessivelyLongGenericName> Foo<ExcessivelyLongGenericName,
+                                            ExcessivelyLongGenericName,
+                                            AnotherExcessivelyLongGenericName> for Bar {
+    fn foo() {}
+}
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
+    for Bar<ExcessivelyLongGenericName,
+            ExcessivelyLongGenericName,
+            AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}
+impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    for Bar<ExcessivelyLongGenericName,
+            ExcessivelyLongGenericName,
+            AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}
+impl<ExcessivelyLongGenericName,
+     ExcessivelyLongGenericName,
+     AnotherExcessivelyLongGenericName> Foo<ExcessivelyLongGenericName,
+                                            ExcessivelyLongGenericName,
+                                            AnotherExcessivelyLongGenericName>
+    for Bar<ExcessivelyLongGenericName,
+            ExcessivelyLongGenericName,
+            AnotherExcessivelyLongGenericName> {
+    fn foo() {}
+}

--- a/tests/target/configs-generics_indent-block.rs
+++ b/tests/target/configs-generics_indent-block.rs
@@ -8,7 +8,7 @@ fn lorem<
     Amet: Eq = usize,
     Adipiscing: Eq = usize,
     Consectetur: Eq = usize,
-    Elit: Eq = usize
+    Elit: Eq = usize,
 >(ipsum: Ipsum,
     dolor: Dolor,
     sit: Sit,

--- a/tests/target/fn-custom-2.rs
+++ b/tests/target/fn-custom-2.rs
@@ -16,7 +16,7 @@ fn foo(
 fn bar<
     'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
     TTTTTTTTTTTTT,
-    UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
+    UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW,
 >(
     a: Aaaaaaaaaaaaaaa,
 ) {
@@ -51,7 +51,7 @@ impl Foo {
     fn bar<
         'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
         TTTTTTTTTTTTT,
-        UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
+        UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW,
     >(
         a: Aaaaaaaaaaaaaaa,
     ) {
@@ -69,7 +69,7 @@ struct Foo<
     TTTTTTTTTTTTTTTTTTTTTTTTTTTT,
     UUUUUUUUUUUUUUUUUUUUUU,
     VVVVVVVVVVVVVVVVVVVVVVVVVVV,
-    WWWWWWWWWWWWWWWWWWWWWWWW
+    WWWWWWWWWWWWWWWWWWWWWWWW,
 > {
     foo: Foo,
 }

--- a/tests/target/fn-custom-3.rs
+++ b/tests/target/fn-custom-3.rs
@@ -16,7 +16,7 @@ fn foo(
 fn bar<
     'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
     TTTTTTTTTTTTT,
-    UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
+    UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW,
 >(
     a: Aaaaaaaaaaaaaaa,
 ) {
@@ -53,7 +53,7 @@ impl Foo {
     fn bar<
         'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb,
         TTTTTTTTTTTTT,
-        UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW
+        UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW,
     >(
         a: Aaaaaaaaaaaaaaa,
     ) {
@@ -65,7 +65,7 @@ struct Foo<
     TTTTTTTTTTTTTTTTTTTTTTTTTTTT,
     UUUUUUUUUUUUUUUUUUUUUU,
     VVVVVVVVVVVVVVVVVVVVVVVVVVV,
-    WWWWWWWWWWWWWWWWWWWWWWWW
+    WWWWWWWWWWWWWWWWWWWWWWWW,
 > {
     foo: Foo,
 }

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -126,8 +126,8 @@ mod m {
     impl<T> PartialEq for S<T> where T: PartialEq {}
 }
 
-impl<BorrowType, K, V, NodeType, HandleType> Handle<NodeRef<BorrowType, K, V, NodeType>,
-                                                    HandleType> {
+impl<BorrowType, K, V, NodeType, HandleType>
+    Handle<NodeRef<BorrowType, K, V, NodeType>, HandleType> {
 }
 
 impl<BorrowType, K, V, NodeType, HandleType> PartialEq
@@ -153,4 +153,36 @@ impl<ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNodeFoo>
 // #1600
 impl<#[may_dangle] K, #[may_dangle] V> Drop for RawTable<K, V> {
     fn drop() {}
+}
+
+// #1168
+pub trait Number
+    : Copy
+    + Eq
+    + Not<Output = Self>
+    + Shl<u8, Output = Self>
+    + Shr<u8, Output = Self>
+    + BitAnd<Self, Output = Self>
+    + BitOr<Self, Output = Self>
+    + BitAndAssign
+    + BitOrAssign {
+    // test
+    fn zero() -> Self;
+}
+
+// #1642
+pub trait SomeTrait
+    : Clone
+    + Eq
+    + PartialEq
+    + Ord
+    + PartialOrd
+    + Default
+    + Hash
+    + Debug
+    + Display
+    + Write
+    + Read
+    + FromStr {
+    // comment
 }


### PR DESCRIPTION
This PR updates formatting against long impls.
Passes all stress tests from #1357 and #1369. ~~when using `rfc-rustfmt.toml`, but fails on some tests when using the current default configutation.~~
~~I am creating this PR anyway since we will be switching the default to Rfc style and this PR does cause no regression.~~