### PR TITLE
Use block indent for args of macro if single line args exceeds max width

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1721,6 +1721,20 @@ fn rewrite_call_inner(context: &RewriteContext,
                                                    nested_shape,
                                                    one_line_width,
                                                    force_trailing_comma)
+        .or_else(|| if context.use_block_indent() {
+                     rewrite_call_args(context,
+                                       args,
+                                       args_span,
+                                       Shape::indented(shape
+                                                           .block()
+                                                           .indent
+                                                           .block_indent(context.config),
+                                                       context.config),
+                                       0,
+                                       force_trailing_comma)
+                 } else {
+                     None
+                 })
         .ok_or(Ordering::Less)?;
 
     if !context.use_block_indent() && need_block_indent(&list_str, nested_shape) && !extendable {

--- a/tests/source/configs-fn_call_style-block.rs
+++ b/tests/source/configs-fn_call_style-block.rs
@@ -125,3 +125,9 @@ fn issue1581() {
         },
     );
 }
+
+fn issue1651() {
+    {
+        let type_list: Vec<_> = try_opt!(types.iter().map(|ty| ty.rewrite(context, shape)).collect());
+    }
+}

--- a/tests/target/configs-fn_call_style-block-trailing-comma.rs
+++ b/tests/target/configs-fn_call_style-block-trailing-comma.rs
@@ -3,7 +3,9 @@
 
 // rustfmt should not add trailing comma when rewriting macro. See #1528.
 fn a() {
-    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+    panic!(
+        "this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:"
+    );
     foo(
         oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt(),
     );

--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -145,3 +145,10 @@ fn issue1581() {
         }
     });
 }
+
+fn issue1651() {
+    {
+        let type_list: Vec<_> =
+            try_opt!(types.iter().map(|ty| ty.rewrite(context, shape)).collect());
+    }
+}


### PR DESCRIPTION
Previously when arguments of macro contained no newlines rustfmt put it in a single line without respecting max width. This PR fixed this.

Closes #1651.