### PR TITLE
Fix excessive indentation in trait where clause when using Rfc style

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2306,7 +2306,7 @@ fn rewrite_where_clause_rfc_style(context: &RewriteContext,
                              terminator,
                              |pred| span_for_where_pred(pred).lo,
                              |pred| span_for_where_pred(pred).hi,
-                             |pred| pred.rewrite(context, clause_shape),
+                             |pred| pred.rewrite(context, shape),
                              span_start,
                              span_end);
     let comma_tactic = if suppress_comma {

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,7 +24,7 @@ use lists::{itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{extra_offset, format_mutability, colon_spaces, wrap_str, mk_sp, last_line_width};
 use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple_type};
-use config::TypeDensity;
+use config::{Style, TypeDensity};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PathContext {
@@ -383,7 +383,10 @@ impl Rewrite for ast::WherePredicate {
                     }
                 } else {
                     let used_width = type_str.len() + colon.len();
-                    let ty_shape = try_opt!(shape.block_left(used_width));
+                    let ty_shape = match context.config.where_style() {
+                        Style::Legacy => try_opt!(shape.block_left(used_width)),
+                        Style::Rfc => shape.block_indent(context.config.tab_spaces()),
+                    };
                     let bounds: Vec<_> =
                         try_opt!(bounds
                                      .iter()

--- a/tests/source/where-clause-rfc.rs
+++ b/tests/source/where-clause-rfc.rs
@@ -42,3 +42,9 @@ struct Exactly100CharsToSemicolon<A, B, C, D, E>
 struct AlwaysOnNextLine<LongLongTypename, LongTypename, A, B, C, D, E, F> where A: LongTrait {
     x: i32
 }
+
+pub trait SomeTrait<T>
+    where
+    T: Something + Sync + Send + Display     + Debug     + Copy + Hash + Debug + Display + Write + Read + FromStr
+{
+}

--- a/tests/target/where-clause-rfc.rs
+++ b/tests/target/where-clause-rfc.rs
@@ -96,3 +96,20 @@ where
 {
     x: i32,
 }
+
+pub trait SomeTrait<T>
+where
+    T: Something
+        + Sync
+        + Send
+        + Display
+        + Debug
+        + Copy
+        + Hash
+        + Debug
+        + Display
+        + Write
+        + Read
+        + FromStr
+{
+}


### PR DESCRIPTION
Currently we get
```rust
pub trait SomeTrait<T>
where
    T: Something
           + Sync
           + Send
           + Display
           + Debug
           + Copy
           + Hash
           + Debug
           + Display
           + Write
           + Read
           + FromStr
{
}
```
This PR fixed this by following https://github.com/rust-lang-nursery/fmt-rfcs/issues/75#issuecomment-307950340.