### PR TITLE
Block indent tuple type when fn_call_style is Block

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -23,7 +23,7 @@ use items::{format_generics_item_list, generics_shape_from_config};
 use lists::{itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{extra_offset, format_mutability, colon_spaces, wrap_str, mk_sp, last_line_width};
-use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple_type};
+use expr::{rewrite_unary_prefix, rewrite_pair, rewrite_tuple};
 use config::{Style, TypeDensity};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -689,9 +689,7 @@ impl Rewrite for ast::Ty {
                         format!("[{}]", ty_str)
                     })
             }
-            ast::TyKind::Tup(ref items) => {
-                rewrite_tuple_type(context, items.iter().map(|x| &**x), self.span, shape)
-            }
+            ast::TyKind::Tup(ref items) => rewrite_tuple(context, items, self.span, shape),
             ast::TyKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Type, q_self.as_ref(), path, shape)
             }

--- a/tests/target/configs-fn_args_layout-block.rs
+++ b/tests/target/configs-fn_args_layout-block.rs
@@ -36,10 +36,12 @@ extern "C" {
 // #1652
 fn deconstruct(
     foo: Bar,
-) -> (SocketAddr,
-      Header,
-      Method,
-      RequestUri,
-      HttpVersion,
-      AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) {
+) -> (
+    SocketAddr,
+    Header,
+    Method,
+    RequestUri,
+    HttpVersion,
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+) {
 }

--- a/tests/target/fn_args_layout-block.rs
+++ b/tests/target/fn_args_layout-block.rs
@@ -87,7 +87,12 @@ where
 }
 
 fn foo()
-    -> (Loooooooooooooooooooooong, Reeeeeeeeeeeeeeeeeeeeeeeeturn, iiiiiiiiis, Looooooooooooooooong)
+    -> (
+    Loooooooooooooooooooooong,
+    Reeeeeeeeeeeeeeeeeeeeeeeeturn,
+    iiiiiiiiis,
+    Looooooooooooooooong,
+)
 {
     foo();
 }
@@ -127,10 +132,12 @@ fn foo<L: Loooooooooooooooooooong, G: Geeeeeeeeeeneric, I: iiiiiiiiis, L: Looooo
 }
 
 fn foo()
-    -> (Looooooooooooooooooooooooooong,
-        Reeeeeeeeeeeeeeeeeeeeeeeeeeeeeturn,
-        iiiiiiiiiiiiiis,
-        Loooooooooooooooooooooong)
+    -> (
+    Looooooooooooooooooooooooooong,
+    Reeeeeeeeeeeeeeeeeeeeeeeeeeeeeturn,
+    iiiiiiiiiiiiiis,
+    Loooooooooooooooooooooong,
+)
 {
     foo();
 }

--- a/tests/target/multiple.rs
+++ b/tests/target/multiple.rs
@@ -152,23 +152,27 @@ fn main() {
 }
 
 fn deconstruct()
-    -> (SocketAddr,
-        Method,
-        Headers,
-        RequestUri,
-        HttpVersion,
-        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)
+    -> (
+    SocketAddr,
+    Method,
+    Headers,
+    RequestUri,
+    HttpVersion,
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+)
 {
 }
 
 fn deconstruct(
     foo: Bar,
-) -> (SocketAddr,
-      Method,
-      Headers,
-      RequestUri,
-      HttpVersion,
-      AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) {
+) -> (
+    SocketAddr,
+    Method,
+    Headers,
+    RequestUri,
+    HttpVersion,
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+) {
 }
 
 #[rustfmt_skip]

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -2,10 +2,12 @@
 fn types() {
     let x: [Vec<_>] = [];
     let y: *mut [SomeType; konst_funk()] = expr();
-    let z: (// #digits
-            usize,
-            // exp
-            i16) = funk();
+    let z: (
+        // #digits
+        usize,
+        // exp
+        i16,
+    ) = funk();
     let z: (usize /* #digits */, i16 /* exp */) = funk();
 }
 

--- a/tests/target/type_alias.rs
+++ b/tests/target/type_alias.rs
@@ -1,7 +1,9 @@
 // rustfmt-normalize_comments: true
 
-type PrivateTest<'a, I> = (Box<Parser<Input = I, Output = char> + 'a>,
-                           Box<Parser<Input = I, Output = char> + 'a>);
+type PrivateTest<'a, I> = (
+    Box<Parser<Input = I, Output = char> + 'a>,
+    Box<Parser<Input = I, Output = char> + 'a>,
+);
 
 pub type PublicTest<'a, I, O> = Result<
     Vec<MyLongType>,


### PR DESCRIPTION
This PR closes #1662.

In order to reuse the code for rewriting tupe literals and tupe types, we need a way to distinguish `ast::Expr` and `ast::Ty`. This PR adds `ExprTypeIdentifier` trait to solve this, although I am not convinced that this is an ideal way, especially it requires reconstructing a vector of args.
```rust
         let args = args.iter().map(|e| e.to_expr()).collect::<Vec<_>>(); 
```