### PR TITLE
Use correct spans when rewrting attributes

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1684,7 +1684,7 @@ fn rewrite_explicit_self(
                 Some(ref l) => {
                     let lifetime_str = try_opt!(l.rewrite(
                         context,
-                        Shape::legacy(usize::max_value(), Indent::empty()),
+                        Shape::legacy(context.config.max_width(), Indent::empty()),
                     ));
                     Some(format!("&{} {}self", lifetime_str, mut_str))
                 }
@@ -1697,7 +1697,7 @@ fn rewrite_explicit_self(
             let mutability = explicit_self_mutability(&args[0]);
             let type_str = try_opt!(ty.rewrite(
                 context,
-                Shape::legacy(usize::max_value(), Indent::empty()),
+                Shape::legacy(context.config.max_width(), Indent::empty()),
             ));
 
             Some(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,12 @@ impl Indent {
     }
 
     pub fn block_unindent(mut self, config: &Config) -> Indent {
-        self.block_indent -= config.tab_spaces();
-        self
+        if self.block_indent < config.tab_spaces() {
+            Indent::new(self.block_indent, 0)
+        } else {
+            self.block_indent -= config.tab_spaces();
+            self
+        }
     }
 
     pub fn width(&self) -> usize {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -82,14 +82,25 @@ impl<'a> FmtVisitor<'a> {
             ast::StmtKind::Item(ref item) => {
                 self.visit_item(item);
             }
-            ast::StmtKind::Local(..) |
-            ast::StmtKind::Expr(..) |
-            ast::StmtKind::Semi(..) => {
+            ast::StmtKind::Local(..) => {
                 let rewrite = stmt.rewrite(
                     &self.get_context(),
                     Shape::indented(self.block_indent, self.config),
                 );
                 self.push_rewrite(stmt.span, rewrite);
+            }
+            ast::StmtKind::Expr(ref expr) |
+            ast::StmtKind::Semi(ref expr) => {
+                let rewrite = stmt.rewrite(
+                    &self.get_context(),
+                    Shape::indented(self.block_indent, self.config),
+                );
+                let span = if expr.attrs.is_empty() {
+                    stmt.span
+                } else {
+                    mk_sp(expr.attrs[0].span.lo, stmt.span.hi)
+                };
+                self.push_rewrite(span, rewrite)
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, _macro_style, _) = **mac;

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -52,3 +52,19 @@ struct Foo {
     # [ derive ( Clone , PartialEq , Debug , Deserialize , Serialize ) ]
     foo: usize,
 }
+
+// #1668
+
+/// Default path (*nix)
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+fn foo() {
+    #[cfg(target_os = "freertos")]
+    match port_id {
+        'a' | 'A' => GpioPort { port_address: GPIO_A },
+        'b' | 'B' => GpioPort { port_address: GPIO_B },
+        _ => panic!(),
+    }
+
+    #[cfg_attr(not(target_os = "freertos"), allow(unused_variables))]
+    let x = 3;
+}

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -48,3 +48,19 @@ struct Foo {
     #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
     foo: usize,
 }
+
+// #1668
+
+/// Default path (*nix)
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+fn foo() {
+    #[cfg(target_os = "freertos")]
+    match port_id {
+        'a' | 'A' => GpioPort { port_address: GPIO_A },
+        'b' | 'B' => GpioPort { port_address: GPIO_B },
+        _ => panic!(),
+    }
+
+    #[cfg_attr(not(target_os = "freertos"), allow(unused_variables))]
+    let x = 3;
+}


### PR DESCRIPTION
This PR

1. add changes to prevent rustfmf to overflow arithmetic when running tests.
2. try to use correct spans when rewriting attributes. The span of `ast::Expr` does not cover its attributes, and the span of `ast::MetaItem` is missing closing parens.