### PR TITLE
Add back cargo-fmt binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ doctest = false
 [[bin]]
 name = "rustfmt"
 
+[[bin]]
+name = "cargo-fmt"
+
 [features]
 default = ["cargo-fmt"]
 cargo-fmt = []

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate rustfmt;
+extern crate rustfmt_nightly as rustfmt;
 extern crate diff;
 extern crate regex;
 extern crate term;


### PR DESCRIPTION
When there are no `[[bin]]` sections, all the binaries in `src/bin` are
automatically picked up. When a section is added, that is no longer the
case, so all the binaries need to be specified explicitly.

(Should fix #1670)