### PR TITLE
Wrap closure in block with a single control flow expr with multi line condition

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -750,14 +750,14 @@ fn and_one_line(x: Option<String>) -> Option<String> {
 
 fn nop_block_collapse(block_str: Option<String>, budget: usize) -> Option<String> {
     debug!("nop_block_collapse {:?} {}", block_str, budget);
-    block_str.map(|block_str| if block_str.starts_with('{') && budget >= 2 &&
-        (block_str[1..]
-             .find(|c: char| !c.is_whitespace())
-             .unwrap() == block_str.len() - 2)
-    {
-        "{}".to_owned()
-    } else {
-        block_str.to_owned()
+    block_str.map(|block_str| {
+        if block_str.starts_with('{') && budget >= 2 &&
+            (block_str[1..].find(|c: char| !c.is_whitespace()).unwrap() == block_str.len() - 2)
+        {
+            "{}".to_owned()
+        } else {
+            block_str.to_owned()
+        }
     })
 }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -159,9 +159,9 @@ impl Rewrite for ast::ViewPath {
     // Returns an empty string when the ViewPath is empty (like foo::bar::{})
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         match self.node {
-            ast::ViewPath_::ViewPathList(_, ref path_list) if path_list.is_empty() => {
-                Some(String::new())
-            }
+            ast::ViewPath_::ViewPathList(_, ref path_list) if path_list.is_empty() => Some(
+                String::new(),
+            ),
             ast::ViewPath_::ViewPathList(ref path, ref path_list) => {
                 rewrite_use_list(shape, path, path_list, self.span, context)
             }

--- a/tests/target/issue-1681.rs
+++ b/tests/target/issue-1681.rs
@@ -1,0 +1,19 @@
+// rustfmt-max_width: 80
+
+fn foo() {
+    // This is where it gets good
+    refmut_map_result(self.cache.borrow_mut(), |cache| {
+        match cache.entry(cache_key) {
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(entry) => {
+                let statement = {
+                    let sql = try!(entry.key().sql(source));
+                    prepare_fn(&sql)
+                };
+
+                Ok(entry.insert(try!(statement)))
+            }
+            // and now, casually call a method on this
+        }
+    }).map(MaybeCached::Cached)
+}

--- a/tests/target/issue-1681.rs
+++ b/tests/target/issue-1681.rs
@@ -1,7 +1,9 @@
 // rustfmt-max_width: 80
 
+// We would like to surround closure body with block when overflowing the last
+// argument of function call if the last argument has condition and without
+// block it may go multi lines.
 fn foo() {
-    // This is where it gets good
     refmut_map_result(self.cache.borrow_mut(), |cache| {
         match cache.entry(cache_key) {
             Occupied(entry) => Ok(entry.into_mut()),
@@ -13,7 +15,6 @@ fn foo() {
 
                 Ok(entry.insert(try!(statement)))
             }
-            // and now, casually call a method on this
         }
     }).map(MaybeCached::Cached)
 }


### PR DESCRIPTION
This PR wraps closure with multi line condition in block if it is being 'overflowed' at the last arg position of function call (I hope the sentence makes sense).
Closes #1681.