### PR TITLE
Forbid overflowing closure if its header goes multi lines

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -165,9 +165,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     );
 
     let child_shape_iter = Some(first_child_shape).into_iter().chain(
-        ::std::iter::repeat(
-            other_child_shape,
-        ).take(subexpr_list.len() - 1),
+        ::std::iter::repeat(other_child_shape).take(subexpr_list.len() - 1),
     );
     let iter = subexpr_list.iter().rev().zip(child_shape_iter);
     let mut rewrites = try_opt!(
@@ -178,9 +176,10 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
 
     // Total of all items excluding the last.
     let last_non_try_index = rewrites.len() - (1 + trailing_try_num);
-    let almost_total = rewrites[..last_non_try_index]
-        .iter()
-        .fold(0, |a, b| a + first_line_width(b)) + parent_rewrite.len();
+    let almost_total = rewrites[..last_non_try_index].iter().fold(
+        0,
+        |a, b| a + first_line_width(b),
+    ) + parent_rewrite.len();
     let one_line_len = rewrites.iter().fold(0, |a, r| a + first_line_width(r)) +
         parent_rewrite.len();
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -45,9 +45,10 @@ pub enum CommentStyle<'a> {
 
 fn custom_opener(s: &str) -> &str {
     s.lines().next().map_or("", |first_line| {
-        first_line
-            .find(' ')
-            .map_or(first_line, |space_index| &first_line[0..space_index + 1])
+        first_line.find(' ').map_or(
+            first_line,
+            |space_index| &first_line[0..space_index + 1],
+        )
     })
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -561,7 +561,7 @@ fn rewrite_closure_fn_decl(
         fn_decl.inputs.iter(),
         "|",
         |arg| span_lo_for_arg(arg),
-        |arg| span_hi_for_arg(arg),
+        |arg| span_hi_for_arg(context, arg),
         |arg| arg.rewrite(context, arg_shape),
         context.codemap.span_after(span, "|"),
         body.span.lo,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2558,7 +2558,12 @@ fn shape_from_fn_call_style(
     offset: usize,
 ) -> Option<Shape> {
     if context.use_block_indent() {
-        Some(shape.block().block_indent(context.config.tab_spaces()))
+        // 1 = ","
+        shape
+            .block()
+            .block_indent(context.config.tab_spaces())
+            .with_max_width(context.config)
+            .sub_width(1)
     } else {
         shape.visual_indent(offset).sub_width(overhead)
     }

--- a/src/items.rs
+++ b/src/items.rs
@@ -803,10 +803,9 @@ fn format_impl_ref_and_type(
             Style::Legacy => new_line_offset + trait_ref_overhead,
             Style::Rfc => new_line_offset,
         };
-        result.push_str(&*try_opt!(self_ty.rewrite(
-            context,
-            Shape::legacy(budget, type_offset),
-        )));
+        result.push_str(&*try_opt!(
+            self_ty.rewrite(context, Shape::legacy(budget, type_offset))
+        ));
         Some(result)
     } else {
         unreachable!();
@@ -967,8 +966,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
             where_density,
             "{",
             !has_body,
-            trait_bound_str.is_empty() &&
-                last_line_width(&generics_str) == 1,
+            trait_bound_str.is_empty() && last_line_width(&generics_str) == 1,
             None,
         ));
         // If the where clause cannot fit on the same line,
@@ -1260,10 +1258,12 @@ fn format_tuple_struct(
             context.codemap.span_after(span, "("),
             span.hi,
         );
-        let body_budget = try_opt!(context.config.max_width().checked_sub(
-            offset.block_only().width() +
-                result.len() + 3,
-        ));
+        let body_budget = try_opt!(
+            context
+                .config
+                .max_width()
+                .checked_sub(offset.block_only().width() + result.len() + 3)
+        );
         let body = try_opt!(list_helper(
             items,
             // TODO budget is wrong in block case
@@ -1548,8 +1548,7 @@ pub fn rewrite_static(
     let ty_str = try_opt!(ty.rewrite(
         context,
         Shape::legacy(
-            context.config.max_width() - offset.block_indent -
-                prefix.len() - 2,
+            context.config.max_width() - offset.block_indent - prefix.len() - 2,
             offset.block_only(),
         ),
     ));
@@ -1613,8 +1612,7 @@ pub fn rewrite_associated_type(
         let ty_str = try_opt!(ty.rewrite(
             context,
             Shape::legacy(
-                context.config.max_width() - indent.block_indent -
-                    prefix.len() - 2,
+                context.config.max_width() - indent.block_indent - prefix.len() - 2,
                 indent.block_only(),
             ),
         ));
@@ -1857,8 +1855,7 @@ fn rewrite_fn_base(
         2
     };
     let shape = try_opt!(
-        Shape::indented(indent + last_line_width(&result), context.config)
-            .sub_width(overhead)
+        Shape::indented(indent + last_line_width(&result), context.config).sub_width(overhead)
     );
     let g_span = mk_sp(span.lo, span_for_return(&fd.output).lo);
     let generics_str = try_opt!(rewrite_generics(context, generics, shape, g_span));
@@ -1979,10 +1976,10 @@ fn rewrite_fn_base(
         }
         // If the last line of args contains comment, we cannot put the closing paren
         // on the same line.
-        if arg_str
-            .lines()
-            .last()
-            .map_or(false, |last_line| last_line.contains("//"))
+        if arg_str.lines().last().map_or(
+            false,
+            |last_line| last_line.contains("//"),
+        )
         {
             args_last_line_contains_comment = true;
             result.push('\n');
@@ -2055,13 +2052,14 @@ fn rewrite_fn_base(
             let snippet_hi = span.hi;
             let snippet = context.snippet(mk_sp(snippet_lo, snippet_hi));
             // Try to preserve the layout of the original snippet.
-            let original_starts_with_newline =
-                snippet
-                    .find(|c| c != ' ')
-                    .map_or(false, |i| snippet[i..].starts_with('\n'));
-            let original_ends_with_newline = snippet
-                .rfind(|c| c != ' ')
-                .map_or(false, |i| snippet[i..].ends_with('\n'));
+            let original_starts_with_newline = snippet.find(|c| c != ' ').map_or(
+                false,
+                |i| snippet[i..].starts_with('\n'),
+            );
+            let original_ends_with_newline = snippet.rfind(|c| c != ' ').map_or(
+                false,
+                |i| snippet[i..].ends_with('\n'),
+            );
             let snippet = snippet.trim();
             if !snippet.is_empty() {
                 result.push(if original_starts_with_newline {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -132,9 +132,10 @@ impl ListItem {
     }
 
     pub fn has_line_pre_comment(&self) -> bool {
-        self.pre_comment
-            .as_ref()
-            .map_or(false, |comment| comment.starts_with("//"))
+        self.pre_comment.as_ref().map_or(
+            false,
+            |comment| comment.starts_with("//"),
+        )
     }
 
     pub fn from_str<S: Into<String>>(s: S) -> ListItem {
@@ -419,10 +420,9 @@ where
                     }
                 }
                 None => {
-                    post_snippet.find_uncommented(self.terminator).unwrap_or(
-                        post_snippet
-                            .len(),
-                    )
+                    post_snippet
+                        .find_uncommented(self.terminator)
+                        .unwrap_or(post_snippet.len())
                 }
             };
 
@@ -435,10 +435,9 @@ where
                 let first_newline = test_snippet.find('\n').unwrap_or(test_snippet.len());
                 // From the end of the first line of comments.
                 let test_snippet = &test_snippet[first_newline..];
-                let first = test_snippet.find(|c: char| !c.is_whitespace()).unwrap_or(
-                    test_snippet
-                        .len(),
-                );
+                let first = test_snippet
+                    .find(|c: char| !c.is_whitespace())
+                    .unwrap_or(test_snippet.len());
                 // From the end of the first line of comments to the next non-whitespace char.
                 let test_snippet = &test_snippet[..first];
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -590,10 +590,7 @@ impl Rewrite for ast::PolyTraitRef {
             let max_path_width = try_opt!(shape.width.checked_sub(extra_offset));
             let path_str = try_opt!(self.trait_ref.rewrite(
                 context,
-                Shape::legacy(
-                    max_path_width,
-                    shape.indent + extra_offset,
-                ),
+                Shape::legacy(max_path_width, shape.indent + extra_offset),
             ));
 
             Some(if context.config.spaces_within_angle_brackets() &&
@@ -645,10 +642,7 @@ impl Rewrite for ast::Ty {
                             mut_str,
                             try_opt!(mt.ty.rewrite(
                                 context,
-                                Shape::legacy(
-                                    budget,
-                                    shape.indent + 2 + mut_len + lt_len,
-                                ),
+                                Shape::legacy(budget, shape.indent + 2 + mut_len + lt_len),
                             ))
                         )
                     }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -782,8 +782,8 @@ impl Rewrite for ast::MetaItem {
 
 impl Rewrite for ast::Attribute {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        try_opt!(self.meta()).rewrite(context, shape).map(|rw| {
-            if rw.starts_with("///") {
+        try_opt!(self.meta()).rewrite(context, shape).map(
+            |rw| if rw.starts_with("///") {
                 rw
             } else {
                 let original = context.snippet(self.span);
@@ -793,7 +793,7 @@ impl Rewrite for ast::Attribute {
                     format!("#[{}]", rw)
                 }
             }
-        })
+        )
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -792,7 +792,7 @@ impl Rewrite for ast::Attribute {
                 } else {
                     format!("#[{}]", rw)
                 }
-            }
+            },
         )
     }
 }

--- a/tests/source/closure.rs
+++ b/tests/source/closure.rs
@@ -147,3 +147,7 @@ fn issue325() {
 fn issue1697() {
     Test.func_a(A_VERY_LONG_CONST_VARIABLE_NAME, move |arg1, arg2, arg3, arg4| arg1 + arg2 + arg3 + arg4)
 }
+
+fn issue1694() {
+    foooooo(|_referencefffffffff: _, _target_reference: _, _oid: _, _target_oid: _| format!("refs/pull/{}/merge", pr_id))
+}

--- a/tests/source/closure.rs
+++ b/tests/source/closure.rs
@@ -143,3 +143,7 @@ fn issue1329() {
 fn issue325() {
     let f = || unsafe { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx };
 }
+
+fn issue1697() {
+    Test.func_a(A_VERY_LONG_CONST_VARIABLE_NAME, move |arg1, arg2, arg3, arg4| arg1 + arg2 + arg3 + arg4)
+}

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -174,3 +174,11 @@ fn issue1697() {
         move |arg1, arg2, arg3, arg4| arg1 + arg2 + arg3 + arg4,
     )
 }
+
+fn issue1694() {
+    foooooo(
+        |_referencefffffffff: _, _target_reference: _, _oid: _, _target_oid: _| {
+            format!("refs/pull/{}/merge", pr_id)
+        },
+    )
+}

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -128,11 +128,8 @@ fn issue470() {
     {
         {
             {
-                let explicit_arg_decls =
-                    explicit_arguments.into_iter().enumerate().map(|(
-                        index,
-                        (ty, pattern),
-                    )| {
+                let explicit_arg_decls = explicit_arguments.into_iter().enumerate().map(
+                    |(index, (ty, pattern))| {
                         let lvalue = Lvalue::Arg(index as u32);
                         block = this.pattern(
                             block,
@@ -141,7 +138,8 @@ fn issue470() {
                             &lvalue,
                         );
                         ArgDecl { ty: ty }
-                    });
+                    },
+                );
             }
         }
     }

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -167,3 +167,10 @@ fn issue325() {
     let f =
         || unsafe { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx };
 }
+
+fn issue1697() {
+    Test.func_a(
+        A_VERY_LONG_CONST_VARIABLE_NAME,
+        move |arg1, arg2, arg3, arg4| arg1 + arg2 + arg3 + arg4,
+    )
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -79,14 +79,7 @@ fn main() {
         ),
         Variantttttttttttttttttttttttt => (
             "variant",
-            vec![
-                "id",
-                "name",
-                "qualname",
-                "type",
-                "value",
-                "scopeid",
-            ],
+            vec!["id", "name", "qualname", "type", "value", "scopeid"],
             true,
             true,
         ),


### PR DESCRIPTION
Closes #1697. cc #1681, this PR adds another rule that if the closure's parameters list goes multi line, we avoid overflowing.

Also, this PR fixes a bug when calculating the budget for function call arguments.