### PR TITLE
Combine control flow condition and body

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -226,8 +226,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
                         total_span,
                         context,
                         shape,
-                    )
-                    {
+                    ) {
                         // If the first line of the last method does not fit into a single line
                         // after the others, allow new lines.
                         almost_total + first_line_width(&last[0]) < context.config.max_width()

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -78,7 +78,7 @@
 
 use Shape;
 use rewrite::{Rewrite, RewriteContext};
-use utils::{wrap_str, first_line_width, last_line_width, mk_sp};
+use utils::{wrap_str, first_line_width, last_line_width, mk_sp, last_line_extendable};
 use expr::rewrite_call;
 use config::IndentStyle;
 use macros::convert_try_mac;
@@ -322,12 +322,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
 }
 
 fn is_extendable_parent(context: &RewriteContext, parent_str: &str) -> bool {
-    context.config.chain_indent() == IndentStyle::Block &&
-        parent_str.lines().last().map_or(false, |s| {
-            s.trim()
-                .chars()
-                .all(|c| c == ')' || c == ']' || c == '}' || c == '?')
-        })
+    context.config.chain_indent() == IndentStyle::Block && last_line_extendable(parent_str)
 }
 
 // True if the chain is only `?`s.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -21,7 +21,7 @@ use lists::{write_list, itemize_list, ListFormatting, SeparatorTactic, ListTacti
 use string::{StringFormat, rewrite_string};
 use utils::{extra_offset, last_line_width, wrap_str, binary_search, first_line_width,
             semicolon_for_stmt, trimmed_last_line_width, left_most_sub_expr, stmt_expr,
-            colon_spaces, contains_skip, mk_sp};
+            colon_spaces, contains_skip, mk_sp, last_line_extendable};
 use visitor::FmtVisitor;
 use config::{Config, IndentStyle, MultilineStyle, ControlBraceStyle, Style};
 use comment::{FindUncommented, rewrite_comment, contains_comment, recover_comment_removed};
@@ -1145,7 +1145,8 @@ impl<'a> ControlFlow<'a> {
         };
 
         let force_newline_brace = context.config.control_style() == Style::Rfc &&
-            pat_expr_string.contains('\n');
+            pat_expr_string.contains('\n') &&
+            !last_line_extendable(&pat_expr_string);
 
         // Try to format if-else on single line.
         if self.allow_single_line && context.config.single_line_if_else_max_width() > 0 {

--- a/src/items.rs
+++ b/src/items.rs
@@ -588,8 +588,7 @@ pub fn format_impl(
             &result,
             &where_clause_str,
             &item,
-        ))
-        {
+        )) {
             result.push_str(&where_clause_str);
             if where_clause_str.contains('\n') {
                 let white_space = offset.to_string(context.config);
@@ -736,8 +735,7 @@ fn format_impl_ref_and_type(
                     true,
                     polarity_str,
                     result_len,
-                )
-            {
+                ) {
                 result.push_str(&trait_ref_str);
             } else {
                 let generics_str = try_opt!(rewrite_generics_inner(
@@ -2114,8 +2112,7 @@ fn rewrite_fn_base(
                 !has_braces,
                 put_args_in_block && ret_str.is_empty(),
                 Some(span.hi),
-            )
-        {
+            ) {
             if !where_clause_str.contains('\n') {
                 if last_line_width(&result) + where_clause_str.len() > context.config.max_width() {
                     result.push('\n');

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -376,8 +376,7 @@ fn count_wildcard_suffix_len(
     for item in items.iter().rev().take_while(|i| match i.item {
         Some(ref internal_string) if internal_string == "_" => true,
         _ => false,
-    })
-    {
+    }) {
         suffix_len += 1;
 
         if item.pre_comment.is_some() || item.post_comment.is_some() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -109,6 +109,15 @@ pub fn trimmed_last_line_width(s: &str) -> usize {
 }
 
 #[inline]
+pub fn last_line_extendable(s: &str) -> bool {
+    s.lines().last().map_or(false, |s| {
+        s.trim()
+            .chars()
+            .all(|c| c == ')' || c == ']' || c == '}' || c == '?')
+    })
+}
+
+#[inline]
 fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.node {
         MetaItemKind::Word => meta_item.name == SKIP_ANNOTATION,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -298,8 +298,7 @@ impl<'a> FmtVisitor<'a> {
                     item,
                     self.block_indent,
                     where_span_end,
-                )
-                {
+                ) {
                     self.buffer.push_str(&impl_str);
                     self.last_pos = source!(self, item.span).hi;
                 }
@@ -310,8 +309,7 @@ impl<'a> FmtVisitor<'a> {
                     &self.get_context(),
                     item,
                     self.block_indent,
-                )
-                {
+                ) {
                     self.buffer.push_str(&trait_str);
                     self.last_pos = source!(self, item.span).hi;
                 }


### PR DESCRIPTION
If the condition of control flow expressions ends with closing parens and alike,
put the opening bracket of the body on the same line with closing parens.