### PR TITLE
Avoid line break when rhs of assignment is an invalid macro

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2719,17 +2719,7 @@ pub fn rewrite_assign_rhs<S: Into<String>>(
         };
     // 1 = space between operator and rhs.
     let orig_shape = try_opt!(shape.offset_left(last_line_width + 1));
-    let rhs = match ex.node {
-        ast::ExprKind::Mac(ref mac) => {
-            match rewrite_macro(mac, None, context, orig_shape, MacroPosition::Expression) {
-                None if !context.snippet(ex.span).contains("\n") => {
-                    context.snippet(ex.span).rewrite(context, orig_shape)
-                }
-                rhs @ _ => rhs,
-            }
-        }
-        _ => ex.rewrite(context, orig_shape),
-    };
+    let rhs = ex.rewrite(context, orig_shape);
 
     fn count_line_breaks(src: &str) -> usize {
         src.chars().filter(|&x| x == '\n').count()

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -79,6 +79,12 @@ fn main() {
         not function like
     );
 
+    // #1712
+    let image = gray_image!(
+        00, 01, 02;
+        10, 11, 12;
+        20, 21, 22);
+
     // #1577
     let json = json!({
         "foo": "bar",

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -110,6 +110,12 @@ fn main() {
         not function like
     );
 
+    // #1712
+    let image = gray_image!(
+        00, 01, 02;
+        10, 11, 12;
+        20, 21, 22);
+
     // #1577
     let json = json!({
         "foo": "bar",


### PR DESCRIPTION
Closes #1712.

rustfmt had heuristic to allow rewriting of macro to fail on the rhs of assignment, so that rustfmt can try to put the macro on the next line.
This worked reasonable when the default was visual indent style. Now that we use block indent style as a default and we have more horizontal budget, this heuristic seems unnecessary.
This PR removes this heuristic all together.