### PR TITLE
Keep brace on same line as `match` when using `ClosingNextLine`.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1461,8 +1461,8 @@ fn rewrite_match(
     let cond_str = try_opt!(cond.rewrite(context, cond_shape));
     let alt_block_sep = String::from("\n") + &shape.indent.block_only().to_string(context.config);
     let block_sep = match context.config.control_brace_style() {
-        ControlBraceStyle::AlwaysSameLine => " ",
-        _ => alt_block_sep.as_str(),
+        ControlBraceStyle::AlwaysNextLine => alt_block_sep.as_str(),
+        _ => " ",
     };
     let mut result = format!("match {}{}{{", cond_str, block_sep);
 

--- a/tests/source/configs-control_brace_style-always_next_line.rs
+++ b/tests/source/configs-control_brace_style-always_next_line.rs
@@ -3,4 +3,8 @@
 
 fn main() {
     if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+    match magi {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }

--- a/tests/source/configs-control_brace_style-always_same_line.rs
+++ b/tests/source/configs-control_brace_style-always_same_line.rs
@@ -3,4 +3,8 @@
 
 fn main() {
     if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+    match magi {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }

--- a/tests/source/configs-control_brace_style-closing_next_line.rs
+++ b/tests/source/configs-control_brace_style-closing_next_line.rs
@@ -3,4 +3,8 @@
 
 fn main() {
     if lorem { println!("ipsum!"); } else { println!("dolor!"); }
+    match magi {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }

--- a/tests/target/configs-control_brace_style-always_next_line.rs
+++ b/tests/target/configs-control_brace_style-always_next_line.rs
@@ -10,4 +10,9 @@ fn main() {
     {
         println!("dolor!");
     }
+    match magi
+    {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }

--- a/tests/target/configs-control_brace_style-always_same_line.rs
+++ b/tests/target/configs-control_brace_style-always_same_line.rs
@@ -7,4 +7,8 @@ fn main() {
     } else {
         println!("dolor!");
     }
+    match magi {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }

--- a/tests/target/configs-control_brace_style-closing_next_line.rs
+++ b/tests/target/configs-control_brace_style-closing_next_line.rs
@@ -8,4 +8,8 @@ fn main() {
     else {
         println!("dolor!");
     }
+    match magi {
+        Homura => "Akemi",
+        Madoka => "Kaname",
+    }
 }


### PR DESCRIPTION
This small PR fixes #1377 and keeps braces on the same line as `match` when using `AlwaysSameLine` and `ClosingNextLine` for `control_brace_style`. Using `AlwaysNextLine` works as expected.