### PR TITLE
Do not add trailing comma inside macro invocation unless there alreay is

### DIFF
--- a/tests/target/configs-fn_call_style-block.rs
+++ b/tests/target/configs-fn_call_style-block.rs
@@ -33,7 +33,7 @@ fn main() {
     // nesting macro and function call
     try!(foo(
         xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     ));
     try!(foo(try!(
         xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -152,7 +152,7 @@ fn issue1739() {
             b: types::Timestamptz,
             c: types::Text,
             d: types::Text,
-            e: types::Text,
+            e: types::Text
         )
     );
 


### PR DESCRIPTION
A follow up of #1743.

Currently, rustfmt casually adds a trailing comma to arguments of macro invocation if they look like function call or alike. However, depending on the macro's definition, adding a trailing comma can break the code.
This PR fixes this by disallowing adding a trailing comma unless the original source code has one.