### PR TITLE
Create imported_names_layout option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1069,6 +1069,10 @@ fn dolor() -> usize {}
 fn adipiscing() -> usize {}
 ```
 
+## `imported_names_layout`
+
+XXX TBD.
+
 ## `reorder_imported_names`
 
 Reorder lists of names in import statements alphabetically

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,6 +561,8 @@ create_config! {
     reorder_imports_in_group: bool, false, "Reorder import statements in group";
     reorder_imported_names: bool, false,
         "Reorder lists of names in import statements alphabetically";
+    imported_names_layout: ListTactic, ListTactic::Mixed,
+        "Layout of lists of names in import statements";
     single_line_if_else_max_width: usize, 50, "Maximum line length for single line if-else \
                                                 expressions. A value of zero means always break \
                                                 if-else expressions.";

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -374,7 +374,7 @@ pub fn rewrite_use_list(
 
     let tactic = definitive_tactic(
         &items[first_index..],
-        ::lists::ListTactic::Mixed,
+        context.config.imported_names_layout(),
         remaining_width,
     );
 

--- a/tests/source/configs-imported_names_layout-default.rs
+++ b/tests/source/configs-imported_names_layout-default.rs
@@ -1,0 +1,6 @@
+// Default rustfmt-imported_names_layout
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/source/configs-imported_names_layout-horizontal.rs
+++ b/tests/source/configs-imported_names_layout-horizontal.rs
@@ -1,0 +1,6 @@
+// rustfmt-imported_names_layout: Horizontal
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+// Horizontal mode should not exceed length of 100
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaar};

--- a/tests/source/configs-imported_names_layout-horizontal_vertical.rs
+++ b/tests/source/configs-imported_names_layout-horizontal_vertical.rs
@@ -1,0 +1,6 @@
+// rustfmt-imported_names_layout: HorizontalVertical
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/source/configs-imported_names_layout-mixed.rs
+++ b/tests/source/configs-imported_names_layout-mixed.rs
@@ -1,0 +1,6 @@
+// rustfmt-imported_names_layout: Mixed
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/source/configs-imported_names_layout-vertical.rs
+++ b/tests/source/configs-imported_names_layout-vertical.rs
@@ -1,0 +1,6 @@
+// rustfmt-imported_names_layout: Vertical
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/target/configs-imported_names_layout-default.rs
+++ b/tests/target/configs-imported_names_layout-default.rs
@@ -1,0 +1,7 @@
+// Default rustfmt-imported_names_layout
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/target/configs-imported_names_layout-horizontal.rs
+++ b/tests/target/configs-imported_names_layout-horizontal.rs
@@ -1,0 +1,6 @@
+// rustfmt-imported_names_layout: Horizontal
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+// Horizontal mode should not exceed length of 100
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaar};

--- a/tests/target/configs-imported_names_layout-horizontal_vertical.rs
+++ b/tests/target/configs-imported_names_layout-horizontal_vertical.rs
@@ -1,0 +1,12 @@
+// rustfmt-imported_names_layout: HorizontalVertical
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar,
+            baaaaar,
+            baaaaaaaaar,
+            baaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/target/configs-imported_names_layout-mixed.rs
+++ b/tests/target/configs-imported_names_layout-mixed.rs
@@ -1,0 +1,7 @@
+// rustfmt-imported_names_layout: Mixed
+// Layout of imported names
+
+use super::{foo, foooooo, foooooooooo, foooooooooooooo};
+
+use super::{bar, baaaaar, baaaaaaaaar, baaaaaaaaaaaaar, baaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaar, baaaaaaaaaaaaaaaaaaaaaaaaar};

--- a/tests/target/configs-imported_names_layout-vertical.rs
+++ b/tests/target/configs-imported_names_layout-vertical.rs
@@ -1,0 +1,15 @@
+// rustfmt-imported_names_layout: Vertical
+// Layout of imported names
+
+use super::{foo,
+            foooooo,
+            foooooooooo,
+            foooooooooooooo};
+
+use super::{bar,
+            baaaaar,
+            baaaaaaaaar,
+            baaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaar,
+            baaaaaaaaaaaaaaaaaaaaaaaaar};


### PR DESCRIPTION
This is a WIP for #788. I have implemented the option using bare `ListTactic`, which now looking at the outcome, I see that it needs more work. But there are some open questions now:

* Do we want to support anything like "Visual" mode? I think not, but we need to make sure, to some level.

* Would a trailing comma be optional in this list? Do we need to add an option for it? (Again, I think *No* and *No*.)

* And the important question: should I just hard-code the "Block" style for "Vertical" option here, or should we split this option into two, or maybe create a new type for it, so we can have "Horizontal" and "Block" in one option. (I don't have an answer for this myself, but until I hear back, will try to get it work as "Block" with the simplest diff possible.)

Fixes https://github.com/rust-lang-nursery/rustfmt/issues/788