### PR TITLE
Recover removed comment before and after `where`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,53 @@ impl Spanned for ast::Field {
     }
 }
 
+impl Spanned for ast::WherePredicate {
+    fn span(&self) -> Span {
+        match *self {
+            ast::WherePredicate::BoundPredicate(ref p) => p.span,
+            ast::WherePredicate::RegionPredicate(ref p) => p.span,
+            ast::WherePredicate::EqPredicate(ref p) => p.span,
+        }
+    }
+}
+
+impl Spanned for ast::FunctionRetTy {
+    fn span(&self) -> Span {
+        match *self {
+            ast::FunctionRetTy::Default(span) => span,
+            ast::FunctionRetTy::Ty(ref ty) => ty.span,
+        }
+    }
+}
+
+impl Spanned for ast::TyParam {
+    fn span(&self) -> Span {
+        // Note that ty.span is the span for ty.ident, not the whole item.
+        let lo = if self.attrs.is_empty() {
+            self.span.lo
+        } else {
+            self.attrs[0].span.lo
+        };
+        if let Some(ref def) = self.default {
+            return mk_sp(lo, def.span.hi);
+        }
+        if self.bounds.is_empty() {
+            return mk_sp(lo, self.span.hi);
+        }
+        let hi = self.bounds[self.bounds.len() - 1].span().hi;
+        mk_sp(lo, hi)
+    }
+}
+
+impl Spanned for ast::TyParamBound {
+    fn span(&self) -> Span {
+        match *self {
+            ast::TyParamBound::TraitTyParamBound(ref ptr, _) => ptr.span,
+            ast::TyParamBound::RegionTyParamBound(ref l) => l.span,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct Indent {
     // Width of the block indent, in characters. Must be a multiple of

--- a/tests/target/comments-fn.rs
+++ b/tests/target/comments-fn.rs
@@ -27,3 +27,13 @@ where
     T: Eq, // some comment
 {
 }
+
+fn issue458<F>(a: &str, f: F)
+// comment1
+where
+    // comment2
+    F: FnOnce(&str) -> bool,
+{
+    f(a);
+    ()
+}

--- a/tests/target/impl.rs
+++ b/tests/target/impl.rs
@@ -17,3 +17,12 @@ where
         }
     }
 }
+
+impl<T> Foo for T
+// comment1
+where
+    // comment2
+    // blah
+    T: Clone,
+{
+}


### PR DESCRIPTION
This PR covers missing comments before and after `where` by creating `span` manually.

We could also recover missing comments by using `recover_comment_removed` and this is much simpler.
However, using `recover_comment_removed` means we give up formatting the item with `where` entirely.

Closes #458 and closes #1758.