### PR TITLE
RFC: patterns in condition and match arm

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -155,8 +155,13 @@ enum TargetKind {
 impl TargetKind {
     fn should_format(&self) -> bool {
         match *self {
-            TargetKind::Lib | TargetKind::Bin | TargetKind::Example | TargetKind::Test |
-            TargetKind::Bench | TargetKind::CustomBuild | TargetKind::ProcMacro => true,
+            TargetKind::Lib |
+            TargetKind::Bin |
+            TargetKind::Example |
+            TargetKind::Test |
+            TargetKind::Bench |
+            TargetKind::CustomBuild |
+            TargetKind::ProcMacro => true,
             _ => false,
         }
     }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -390,8 +390,9 @@ fn join_rewrites(rewrites: &[String], subexps: &[ast::Expr], connector: &str) ->
 // parens, braces, and brackets in its idiomatic formatting.
 fn is_block_expr(context: &RewriteContext, expr: &ast::Expr, repr: &str) -> bool {
     match expr.node {
-        ast::ExprKind::Mac(..) |
-        ast::ExprKind::Call(..) => context.use_block_indent() && repr.contains('\n'),
+        ast::ExprKind::Mac(..) | ast::ExprKind::Call(..) => {
+            context.use_block_indent() && repr.contains('\n')
+        }
         ast::ExprKind::Struct(..) |
         ast::ExprKind::While(..) |
         ast::ExprKind::WhileLet(..) |

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -71,8 +71,7 @@ impl<'a> CommentStyle<'a> {
             CommentStyle::Custom(..) |
             CommentStyle::Doc => "",
             CommentStyle::DoubleBullet => " **/",
-            CommentStyle::SingleBullet |
-            CommentStyle::Exclamation => " */",
+            CommentStyle::SingleBullet | CommentStyle::Exclamation => " */",
         }
     }
 
@@ -81,8 +80,7 @@ impl<'a> CommentStyle<'a> {
             CommentStyle::DoubleSlash => "// ",
             CommentStyle::TripleSlash => "/// ",
             CommentStyle::Doc => "//! ",
-            CommentStyle::SingleBullet |
-            CommentStyle::Exclamation => " * ",
+            CommentStyle::SingleBullet | CommentStyle::Exclamation => " * ",
             CommentStyle::DoubleBullet => " ** ",
             CommentStyle::Custom(opener) => opener,
         }
@@ -94,15 +92,11 @@ impl<'a> CommentStyle<'a> {
 
     pub fn line_with_same_comment_style(&self, line: &str, normalize_comments: bool) -> bool {
         match *self {
-            CommentStyle::DoubleSlash |
-            CommentStyle::TripleSlash |
-            CommentStyle::Doc => {
+            CommentStyle::DoubleSlash | CommentStyle::TripleSlash | CommentStyle::Doc => {
                 line.trim_left().starts_with(self.line_start().trim_left()) ||
                     comment_style(line, normalize_comments) == *self
             }
-            CommentStyle::DoubleBullet |
-            CommentStyle::SingleBullet |
-            CommentStyle::Exclamation => {
+            CommentStyle::DoubleBullet | CommentStyle::SingleBullet | CommentStyle::Exclamation => {
                 line.trim_left().starts_with(self.closer().trim_left()) ||
                     line.trim_left().starts_with(self.line_start().trim_left()) ||
                     comment_style(line, normalize_comments) == *self

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,8 +98,7 @@ impl Density {
     pub fn to_list_tactic(self) -> ListTactic {
         match self {
             Density::Compressed => ListTactic::Mixed,
-            Density::Tall |
-            Density::CompressedIfEmpty => ListTactic::HorizontalVertical,
+            Density::Tall | Density::CompressedIfEmpty => ListTactic::HorizontalVertical,
             Density::Vertical => ListTactic::Vertical,
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -419,11 +419,7 @@ where
         }
         Style::Rfc => {
             // Try to calculate the initial constraint on the right hand side.
-            let rhs_overhead = context
-                .config
-                .max_width()
-                .checked_sub(shape.used_width() + shape.width)
-                .unwrap_or(0);
+            let rhs_overhead = shape.rhs_overhead(context.config);
             try_opt!(
                 Shape::indented(shape.indent.block_indent(context.config), context.config)
                     .sub_width(rhs_overhead)
@@ -2543,12 +2539,8 @@ fn rewrite_index(
     }
 
     // Try putting index on the next line and see if it fits in a single line.
-    let indent = shape.indent.block_indent(&context.config);
-    let rhs_overhead = context
-        .config
-        .max_width()
-        .checked_sub(shape.used_width() + shape.width)
-        .unwrap_or(0);
+    let indent = shape.indent.block_indent(context.config);
+    let rhs_overhead = shape.rhs_overhead(context.config);
     let index_shape = try_opt!(Shape::indented(indent, context.config).offset_left(lbr.len()));
     let index_shape = try_opt!(index_shape.sub_width(rbr.len() + rhs_overhead));
     let new_index_rw = index.rewrite(context, index_shape);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -315,8 +315,7 @@ pub fn format_expr(
         }
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
-        ast::ExprKind::InPlace(..) |
-        ast::ExprKind::InlineAsm(..) => {
+        ast::ExprKind::InPlace(..) | ast::ExprKind::InlineAsm(..) => {
             wrap_str(
                 context.snippet(expr.span),
                 context.config.max_width(),
@@ -930,8 +929,7 @@ impl Rewrite for ast::Stmt {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let result = match self.node {
             ast::StmtKind::Local(ref local) => local.rewrite(context, shape),
-            ast::StmtKind::Expr(ref ex) |
-            ast::StmtKind::Semi(ref ex) => {
+            ast::StmtKind::Expr(ref ex) | ast::StmtKind::Semi(ref ex) => {
                 let suffix = if semicolon_for_stmt(self) { ";" } else { "" };
 
                 format_expr(
@@ -945,8 +943,7 @@ impl Rewrite for ast::Stmt {
                     try_opt!(shape.sub_width(suffix.len())),
                 ).map(|s| s + suffix)
             }
-            ast::StmtKind::Mac(..) |
-            ast::StmtKind::Item(..) => None,
+            ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
         };
         result.and_then(|res| {
             recover_comment_removed(res, self.span, context, shape)
@@ -1404,8 +1401,9 @@ impl<'a> Rewrite for ControlFlow<'a> {
             let after_else_comment = extract_comment(after_else, context, shape);
 
             let between_sep = match context.config.control_brace_style() {
-                ControlBraceStyle::AlwaysNextLine |
-                ControlBraceStyle::ClosingNextLine => &*alt_block_sep,
+                ControlBraceStyle::AlwaysNextLine | ControlBraceStyle::ClosingNextLine => {
+                    &*alt_block_sep
+                }
                 ControlBraceStyle::AlwaysSameLine => " ",
             };
             let after_sep = match context.config.control_brace_style() {
@@ -1729,9 +1727,10 @@ impl Rewrite for ast::Arm {
                 }
             }
             ast::ExprKind::Call(_, ref args) => (args.len() == 1, &**body),
-            ast::ExprKind::Closure(..) |
-            ast::ExprKind::Struct(..) |
-            ast::ExprKind::Tup(..) => (true, &**body),
+            ast::ExprKind::Closure(..) | ast::ExprKind::Struct(..) | ast::ExprKind::Tup(..) => (
+                true,
+                &**body,
+            ),
             _ => (false, &**body),
         };
         extend &= context.use_block_indent();
@@ -2402,8 +2401,7 @@ pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_l
         ast::ExprKind::WhileLet(..) => {
             context.config.combine_control_expr() && context.use_block_indent() && args_len == 1
         }
-        ast::ExprKind::Block(..) |
-        ast::ExprKind::Closure(..) => {
+        ast::ExprKind::Block(..) | ast::ExprKind::Closure(..) => {
             context.use_block_indent() ||
                 context.config.fn_call_style() == IndentStyle::Visual && args_len > 1
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1687,14 +1687,14 @@ impl Rewrite for ast::Arm {
                 .collect::<Option<Vec<_>>>()
         );
 
-        let all_simple = pat_strs.iter().all(|p| pat_is_simple(p));
+        let all_simple = pat_strs.iter().all(|p| !p.contains('\n'));
         let items: Vec<_> = pat_strs.into_iter().map(ListItem::from_str).collect();
+        let mut tactic = definitive_tactic(&items, ListTactic::HorizontalVertical, pat_shape.width);
+        if tactic == DefinitiveListTactic::Horizontal && all_simple {
+            tactic = DefinitiveListTactic::Mixed;
+        }
         let fmt = ListFormatting {
-            tactic: if all_simple {
-                DefinitiveListTactic::Mixed
-            } else {
-                DefinitiveListTactic::Vertical
-            },
+            tactic: tactic,
             separator: " |",
             trailing_separator: SeparatorTactic::Never,
             shape: pat_shape,

--- a/src/items.rs
+++ b/src/items.rs
@@ -517,8 +517,7 @@ impl<'a> FmtVisitor<'a> {
         }
 
         let variant_body = match field.node.data {
-            ast::VariantData::Tuple(..) |
-            ast::VariantData::Struct(..) => {
+            ast::VariantData::Tuple(..) | ast::VariantData::Struct(..) => {
                 // FIXME: Should limit the width, as we have a trailing comma
                 format_struct(
                     &context,
@@ -732,16 +731,15 @@ fn format_impl_ref_and_type(
 
         if let Some(ref trait_ref) = *trait_ref {
             let result_len = result.len();
-            if let Some(trait_ref_str) =
-                rewrite_trait_ref(
-                    context,
-                    &trait_ref,
-                    offset,
-                    &generics_str,
-                    true,
-                    polarity_str,
-                    result_len,
-                ) {
+            if let Some(trait_ref_str) = rewrite_trait_ref(
+                context,
+                &trait_ref,
+                offset,
+                &generics_str,
+                true,
+                polarity_str,
+                result_len,
+            ) {
                 result.push_str(&trait_ref_str);
             } else {
                 let generics_str = try_opt!(rewrite_generics_inner(
@@ -2062,18 +2060,17 @@ fn rewrite_fn_base(
                 .max_width()
                 .checked_sub(last_line_width(&result))
         );
-        if let Some(where_clause_str) =
-            rewrite_where_clause(
-                context,
-                where_clause,
-                context.config.fn_brace_style(),
-                Shape::legacy(budget, indent),
-                Density::Compressed,
-                "{",
-                !has_braces,
-                put_args_in_block && ret_str.is_empty(),
-                Some(span.hi),
-            ) {
+        if let Some(where_clause_str) = rewrite_where_clause(
+            context,
+            where_clause,
+            context.config.fn_brace_style(),
+            Shape::legacy(budget, indent),
+            Density::Compressed,
+            "{",
+            !has_braces,
+            put_args_in_block && ret_str.is_empty(),
+            Some(span.hi),
+        ) {
             if !where_clause_str.contains('\n') {
                 if last_line_width(&result) + where_clause_str.len() > context.config.max_width() {
                     result.push('\n');
@@ -2628,8 +2625,7 @@ fn rewrite_where_clause(
         // If the brace is on the next line we don't need to count it otherwise it needs two
         // characters " {"
         match brace_style {
-            BraceStyle::AlwaysNextLine |
-            BraceStyle::SameLineWhere => 0,
+            BraceStyle::AlwaysNextLine | BraceStyle::SameLineWhere => 0,
             BraceStyle::PreferSameLine => 2,
         }
     } else if terminator == "=" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,16 +407,14 @@ pub struct FormattingError {
 impl FormattingError {
     fn msg_prefix(&self) -> &str {
         match self.kind {
-            ErrorKind::LineOverflow(..) |
-            ErrorKind::TrailingWhitespace => "Rustfmt failed at",
+            ErrorKind::LineOverflow(..) | ErrorKind::TrailingWhitespace => "Rustfmt failed at",
             ErrorKind::BadIssue(_) => "WARNING:",
         }
     }
 
     fn msg_suffix(&self) -> &str {
         match self.kind {
-            ErrorKind::LineOverflow(..) |
-            ErrorKind::TrailingWhitespace => "(sorry)",
+            ErrorKind::LineOverflow(..) | ErrorKind::TrailingWhitespace => "(sorry)",
             ErrorKind::BadIssue(_) => "",
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,13 @@ impl Shape {
     pub fn used_width(&self) -> usize {
         self.indent.block_indent + self.offset
     }
+
+    pub fn rhs_overhead(&self, config: &Config) -> usize {
+        config
+            .max_width()
+            .checked_sub(self.used_width() + self.width)
+            .unwrap_or(0)
+    }
 }
 
 pub enum ErrorKind {

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -252,11 +252,10 @@ pub fn can_be_overflowed_pat(context: &RewriteContext, pat: &TuplePatField, len:
     match pat {
         &TuplePatField::Pat(ref pat) => {
             match pat.node {
-                ast::PatKind::Path(..) |
-                ast::PatKind::Tuple(..) |
-                ast::PatKind::Struct(..) => context.use_block_indent() && len == 1,
-                ast::PatKind::Ref(ref p, _) |
-                ast::PatKind::Box(ref p) => {
+                ast::PatKind::Path(..) | ast::PatKind::Tuple(..) | ast::PatKind::Struct(..) => {
+                    context.use_block_indent() && len == 1
+                }
+                ast::PatKind::Ref(ref p, _) | ast::PatKind::Box(ref p) => {
                     can_be_overflowed_pat(context, &TuplePatField::Pat(p), len)
                 }
                 ast::PatKind::Lit(ref expr) => can_be_overflowed_expr(context, expr, len),

--- a/src/types.rs
+++ b/src/types.rs
@@ -758,8 +758,7 @@ impl Rewrite for ast::Ty {
                 it.rewrite(context, shape)
                     .map(|it_str| format!("impl {}", it_str))
             }
-            ast::TyKind::Err |
-            ast::TyKind::Typeof(..) => unreachable!(),
+            ast::TyKind::Err | ast::TyKind::Typeof(..) => unreachable!(),
         }
     }
 }
@@ -837,10 +836,10 @@ pub fn join_bounds(context: &RewriteContext, shape: Shape, type_strs: &Vec<Strin
 
 pub fn can_be_overflowed_type(context: &RewriteContext, ty: &ast::Ty, len: usize) -> bool {
     match ty.node {
-        ast::TyKind::Path(..) |
-        ast::TyKind::Tup(..) => context.use_block_indent() && len == 1,
-        ast::TyKind::Rptr(_, ref mutty) |
-        ast::TyKind::Ptr(ref mutty) => can_be_overflowed_type(context, &*mutty.ty, len),
+        ast::TyKind::Path(..) | ast::TyKind::Tup(..) => context.use_block_indent() && len == 1,
+        ast::TyKind::Rptr(_, ref mutty) | ast::TyKind::Ptr(ref mutty) => {
+            can_be_overflowed_type(context, &*mutty.ty, len)
+        }
         _ => false,
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -160,9 +160,7 @@ pub fn end_typaram(typaram: &ast::TyParam) -> BytePos {
 #[inline]
 pub fn semicolon_for_expr(expr: &ast::Expr) -> bool {
     match expr.node {
-        ast::ExprKind::Ret(..) |
-        ast::ExprKind::Continue(..) |
-        ast::ExprKind::Break(..) => true,
+        ast::ExprKind::Ret(..) | ast::ExprKind::Continue(..) | ast::ExprKind::Break(..) => true,
         _ => false,
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -307,23 +307,18 @@ impl<'a> FmtVisitor<'a> {
                 let where_span_end = snippet
                     .find_uncommented("{")
                     .map(|x| (BytePos(x as u32)) + source!(self, item.span).lo);
-                if let Some(impl_str) = format_impl(
-                    &self.get_context(),
-                    item,
-                    self.block_indent,
-                    where_span_end,
-                ) {
+                if let Some(impl_str) =
+                    format_impl(&self.get_context(), item, self.block_indent, where_span_end)
+                {
                     self.buffer.push_str(&impl_str);
                     self.last_pos = source!(self, item.span).hi;
                 }
             }
             ast::ItemKind::Trait(..) => {
                 self.format_missing_with_indent(item.span.lo);
-                if let Some(trait_str) = format_trait(
-                    &self.get_context(),
-                    item,
-                    self.block_indent,
-                ) {
+                if let Some(trait_str) =
+                    format_trait(&self.get_context(), item, self.block_indent)
+                {
                     self.buffer.push_str(&trait_str);
                     self.last_pos = source!(self, item.span).hi;
                 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -48,8 +48,8 @@ fn foo() -> bool {
         // Nothing
     }
 
-    if let Some(x) = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-                          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+    if let Some(x) =
+        (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
     {}
 
     if let (

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -24,13 +24,12 @@ fn foo() {
         Patternnnnnnnnnnnnnnnnnnn |
         Patternnnnnnnnnnnnnnnnnnn => meh,
 
-        Patternnnnnnnnnnnnnnnnnnn |
-        Patternnnnnnnnnnnnnnnnnnn if looooooooooooooooooong_guard => meh,
-
-        Patternnnnnnnnnnnnnnnnnnnnnnnnn |
-        Patternnnnnnnnnnnnnnnnnnnnnnnnn if looooooooooooooooooooooooooooooooooooooooong_guard => {
+        Patternnnnnnnnnnnnnnnnnnn | Patternnnnnnnnnnnnnnnnnnn if looooooooooooooooooong_guard => {
             meh
         }
+
+        Patternnnnnnnnnnnnnnnnnnnnnnnnn | Patternnnnnnnnnnnnnnnnnnnnnnnnn
+            if looooooooooooooooooooooooooooooooooooooooong_guard => meh,
 
         // Test that earlier patterns can take the guard space
         (aaaa, bbbbb, ccccccc, aaaaa, bbbbbbbb, cccccc, aaaa, bbbbbbbb, cccccc, dddddd) |
@@ -230,8 +229,9 @@ fn issue355() {
 fn issue280() {
     {
         match x {
-            CompressionMode::DiscardNewline |
-            CompressionMode::CompressWhitespaceNewline => ch == '\n',
+            CompressionMode::DiscardNewline | CompressionMode::CompressWhitespaceNewline => {
+                ch == '\n'
+            }
             ast::ItemConst(ref typ, ref expr) => {
                 self.process_static_or_const_item(item, &typ, &expr)
             }
@@ -270,8 +270,7 @@ fn issue496() {
         {
             {
                 match def {
-                    def::DefConst(def_id) |
-                    def::DefAssociatedConst(def_id) => {
+                    def::DefConst(def_id) | def::DefAssociatedConst(def_id) => {
                         match const_eval::lookup_const_by_id(cx.tcx, def_id, Some(self.pat.id)) {
                             Some(const_expr) => x,
                         }
@@ -285,8 +284,7 @@ fn issue496() {
 fn issue494() {
     {
         match stmt.node {
-            hir::StmtExpr(ref expr, id) |
-            hir::StmtSemi(ref expr, id) => {
+            hir::StmtExpr(ref expr, id) | hir::StmtSemi(ref expr, id) => {
                 result.push(StmtRef::Mirror(Box::new(Stmt {
                     span: stmt.span,
                     kind: StmtKind::Expr {
@@ -302,8 +300,18 @@ fn issue494() {
 fn issue386() {
     match foo {
         BiEq | BiLt | BiLe | BiNe | BiGt | BiGe => true,
-        BiAnd | BiOr | BiAdd | BiSub | BiMul | BiDiv | BiRem | BiBitXor | BiBitAnd | BiBitOr |
-        BiShl | BiShr => false,
+        BiAnd |
+        BiOr |
+        BiAdd |
+        BiSub |
+        BiMul |
+        BiDiv |
+        BiRem |
+        BiBitXor |
+        BiBitAnd |
+        BiBitOr |
+        BiShl |
+        BiShr => false,
     }
 }
 


### PR DESCRIPTION
This PR implements part of RFC style for match arm and condition pattern (cc https://github.com/rust-lang-nursery/fmt-rfcs/issues/34#issue-185204114).

> ## large patterns
>
>If using a compound pattern (pat1 | pat2), prefer to put the whole pattern on one line. If it does not fit, put each sub-pattern on a new line, with the line terminated by |:

