### PR TITLE
Rfc: fix up match arm pattern

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1714,7 +1714,7 @@ impl Rewrite for ast::Arm {
         let (mut extend, body) = match body.node {
             ast::ExprKind::Block(ref block)
                 if !is_unsafe_block(block) && is_simple_block(block, context.codemap) &&
-                       context.config.wrap_match_arms() => {
+                    context.config.wrap_match_arms() => {
                 if let ast::StmtKind::Expr(ref expr) = block.stmts[0].node {
                     (false, &**expr)
                 } else {
@@ -1756,9 +1756,10 @@ impl Rewrite for ast::Arm {
             match rewrite {
                 Some(ref body_str)
                     if (!body_str.contains('\n') && body_str.len() <= arm_shape.width) ||
-                           !context.config.wrap_match_arms() ||
-                           (extend && first_line_width(body_str) <= arm_shape.width) ||
-                           is_block => {
+                        !context.config.wrap_match_arms() ||
+                        (extend && first_line_width(body_str) <= arm_shape.width) ||
+                        is_block =>
+                {
                     let block_sep = match context.config.control_brace_style() {
                         ControlBraceStyle::AlwaysNextLine if is_block => alt_block_sep.as_str(),
                         _ if guard.is_some() && pats_str.contains('\n') && is_block &&

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,7 +210,8 @@ fn rewrite_segment(
         match **params {
             ast::PathParameters::AngleBracketed(ref data)
                 if !data.lifetimes.is_empty() || !data.types.is_empty() ||
-                       !data.bindings.is_empty() => {
+                    !data.bindings.is_empty() =>
+            {
                 let param_list = data.lifetimes
                     .iter()
                     .map(SegmentParam::LifeTime)

--- a/tests/source/long-match-arms-brace-newline.rs
+++ b/tests/source/long-match-arms-brace-newline.rs
@@ -1,4 +1,5 @@
 // rustfmt-format_strings: true
+// rustfmt-force_format_strings: true
 // rustfmt-max_width: 80
 // rustfmt-control_brace_style: AlwaysNextLine
 

--- a/tests/target/configs-control_style-rfc.rs
+++ b/tests/target/configs-control_style-rfc.rs
@@ -28,9 +28,10 @@ fn issue1656() {
             match rewrite {
                 Some(ref body_str)
                     if (!body_str.contains('\n') && body_str.len() <= arm_shape.width) ||
-                           !context.config.wrap_match_arms() ||
-                           (extend && first_line_width(body_str) <= arm_shape.width) ||
-                           is_block => {
+                        !context.config.wrap_match_arms() ||
+                        (extend && first_line_width(body_str) <= arm_shape.width) ||
+                        is_block =>
+                {
                     return None;
                 }
                 _ => {}

--- a/tests/target/long-match-arms-brace-newline.rs
+++ b/tests/target/long-match-arms-brace-newline.rs
@@ -1,4 +1,5 @@
 // rustfmt-format_strings: true
+// rustfmt-force_format_strings: true
 // rustfmt-max_width: 80
 // rustfmt-control_brace_style: AlwaysNextLine
 

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -324,8 +324,8 @@ fn guards() {
             if foooooooooooooo && barrrrrrrrrrrr => {}
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             if fooooooooooooooooooooo &&
-                   (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
-                        cccccccccccccccccccccccccccccccccccccccc) => {}
+                (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
+                    cccccccccccccccccccccccccccccccccccccccc) => {}
     }
 }
 


### PR DESCRIPTION
This PR implements part of RFC style for match arm.
1. Put `{` on a newline if we break before `if`
2. Do not add visual offset (`if `) when the condition goes multi line (like we do in normal `if` expression)