### PR TITLE
Allow block-like rhs expression to stay on the same line with lhs

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2899,12 +2899,11 @@ pub fn rewrite_assign_rhs<S: Into<String>>(
     shape: Shape,
 ) -> Option<String> {
     let lhs = lhs.into();
-    let last_line_width = last_line_width(&lhs) -
-        if lhs.contains('\n') {
-            shape.indent.width()
-        } else {
-            0
-        };
+    let last_line_width = last_line_width(&lhs) - if lhs.contains('\n') {
+        shape.indent.width()
+    } else {
+        0
+    };
     // 1 = space between operator and rhs.
     let orig_shape = try_opt!(shape.offset_left(last_line_width + 1));
     let rhs = try_opt!(choose_rhs(

--- a/src/items.rs
+++ b/src/items.rs
@@ -829,12 +829,11 @@ fn rewrite_trait_ref(
     result_len: usize,
 ) -> Option<String> {
     // 1 = space between generics and trait_ref
-    let used_space = 1 + polarity_str.len() +
-        if generics_str.contains('\n') {
-            last_line_width(&generics_str)
-        } else {
-            result_len + generics_str.len()
-        };
+    let used_space = 1 + polarity_str.len() + if generics_str.contains('\n') {
+        last_line_width(&generics_str)
+    } else {
+        result_len + generics_str.len()
+    };
     let shape = Shape::indented(offset + used_space, context.config);
     if let Some(trait_ref_str) = trait_ref.rewrite(context, shape) {
         if !(retry && trait_ref_str.contains('\n')) {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -630,14 +630,12 @@ impl<'a> FmtVisitor<'a> {
                 let use_item_length = items_left
                     .iter()
                     .take_while(|ppi| {
-                        is_use_item(&***ppi) &&
-                            (!reorder_imports_in_group ||
-                                {
-                                    let current = self.codemap.lookup_line_range(item_bound(&ppi));
-                                    let in_same_group = current.lo < last.hi + 2;
-                                    last = current;
-                                    in_same_group
-                                })
+                        is_use_item(&***ppi) && (!reorder_imports_in_group || {
+                            let current = self.codemap.lookup_line_range(item_bound(&ppi));
+                            let in_same_group = current.lo < last.hi + 2;
+                            last = current;
+                            in_same_group
+                        })
                     })
                     .count();
                 let (use_items, rest) = items_left.split_at(use_item_length);

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -118,12 +118,11 @@ fn floaters() {
     })
     .quux();
 
-    a +
-        match x {
-            true => "yay!",
-            false => "boo!",
-        }
-        .bar()
+    a + match x {
+        true => "yay!",
+        false => "boo!",
+    }
+    .bar()
 }
 
 fn is_replaced_content() -> bool {

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -114,11 +114,10 @@ fn floaters() {
     })
         .quux();
 
-    a +
-        match x {
-            true => "yay!",
-            false => "boo!",
-        }.bar()
+    a + match x {
+        true => "yay!",
+        false => "boo!",
+    }.bar()
 }
 
 fn is_replaced_content() -> bool {

--- a/tests/target/issue-831.rs
+++ b/tests/target/issue-831.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let y = a.iter().any(|x| {
+        println!("a");
+    }) || b.iter().any(|x| {
+        println!("b");
+    }) || c.iter().any(|x| {
+        println!("c");
+    });
+}


### PR DESCRIPTION
This PR adds a heuristic to `rewrite_pair` that if the right hand side expression looks like block (more specifically, ends with `{`), then allow the rhs to stay on the same line with lhs even if it gets multi-lined.

Closes #831.