### PR TITLE
Format attributes on stmt and single line block

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -950,11 +950,7 @@ impl Rewrite for ast::Stmt {
 
                 format_expr(
                     ex,
-                    match self.node {
-                        ast::StmtKind::Expr(_) => ExprType::SubExpression,
-                        ast::StmtKind::Semi(_) => ExprType::Statement,
-                        _ => unreachable!(),
-                    },
+                    ExprType::Statement,
                     context,
                     try_opt!(shape.sub_width(suffix.len())),
                 ).map(|s| s + suffix)

--- a/src/items.rs
+++ b/src/items.rs
@@ -50,7 +50,13 @@ impl Rewrite for ast::Local {
             shape.width,
             shape.indent
         );
-        let mut result = "let ".to_owned();
+        let mut result = if self.attrs.is_empty() {
+            "let ".to_owned()
+        } else {
+            let attrs_str = try_opt!(self.attrs.rewrite(context, shape));
+            let indent_str = shape.indent.to_string(context.config);
+            format!("{}\n{}let ", attrs_str, indent_str)
+        };
 
         // 4 = "let ".len()
         let pat_shape = try_opt!(shape.offset_left(4));

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -15,12 +15,11 @@ use syntax::{ast, ptr, visit};
 use syntax::codemap::{BytePos, CodeMap, Span};
 use syntax::parse::ParseSess;
 
-use {Indent, Shape};
+use {Indent, Shape, Spanned};
 use codemap::{LineRangeUtils, SpanUtils};
 use comment::{contains_comment, FindUncommented};
 use comment::rewrite_comment;
 use config::{BraceStyle, Config};
-use expr::{format_expr, ExprType};
 use items::{format_impl, format_trait, rewrite_associated_impl_type, rewrite_associated_type,
             rewrite_static, rewrite_type_alias};
 use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorTactic};
@@ -90,31 +89,12 @@ impl<'a> FmtVisitor<'a> {
                 };
                 self.push_rewrite(stmt.span(), rewrite);
             }
-            ast::StmtKind::Expr(ref expr) => {
-                let rewrite = format_expr(
-                    expr,
-                    ExprType::Statement,
-                    &self.get_context(),
-                    Shape::indented(self.block_indent, self.config),
-                );
-                let span = if expr.attrs.is_empty() {
-                    stmt.span
-                } else {
-                    mk_sp(expr.attrs[0].span.lo, stmt.span.hi)
-                };
-                self.push_rewrite(span, rewrite)
-            }
-            ast::StmtKind::Semi(ref expr) => {
+            ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let rewrite = stmt.rewrite(
                     &self.get_context(),
                     Shape::indented(self.block_indent, self.config),
                 );
-                let span = if expr.attrs.is_empty() {
-                    stmt.span
-                } else {
-                    mk_sp(expr.attrs[0].span.lo, stmt.span.hi)
-                };
-                self.push_rewrite(span, rewrite)
+                self.push_rewrite(stmt.span(), rewrite)
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, _macro_style, ref attrs) = **mac;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -88,7 +88,7 @@ impl<'a> FmtVisitor<'a> {
                         Shape::indented(self.block_indent, self.config),
                     )
                 };
-                self.push_rewrite(stmt.span, rewrite);
+                self.push_rewrite(stmt.span(), rewrite);
             }
             ast::StmtKind::Expr(ref expr) => {
                 let rewrite = format_expr(
@@ -121,6 +121,12 @@ impl<'a> FmtVisitor<'a> {
                 if contains_skip(attrs) {
                     self.push_rewrite(mac.span, None);
                 } else {
+                    if !attrs.is_empty() {
+                        let shape = Shape::indented(self.block_indent, self.config);
+                        let attrs_rw = attrs.rewrite(&self.get_context(), shape);
+                        let span = mk_sp(attrs[0].span.lo, attrs.last().unwrap().span.hi);
+                        self.push_rewrite(span, attrs_rw);
+                    }
                     self.visit_mac(mac, None, MacroPosition::Statement);
                 }
                 self.format_missing(stmt.span.hi);

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -91,3 +91,26 @@ fn issue_1799() {
     // https://github.com/rust-lang/rust/issues/43336
     Some( Err(error) ) ;
 }
+
+// #1813
+fn attributes_on_statemetns() {
+    // Semi
+    # [ an_attribute ( rustfmt ) ]
+    foo(1);
+
+    // Local
+    # [ an_attribute ( rustfmt ) ]
+    let x = foo(a, b, c);
+
+    // Item
+    # [ an_attribute ( rustfmt ) ]
+    use foobar;
+
+    // Mac
+    # [ an_attribute ( rustfmt ) ]
+    vec![1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 1, 1, 2, 1];
+
+    // Expr
+    # [ an_attribute ( rustfmt ) ]
+    {}
+}

--- a/tests/source/catch.rs
+++ b/tests/source/catch.rs
@@ -24,4 +24,7 @@ fn main() {
     do catch {
         // Regular do catch block
     };
+
+    #[ an_attribute(rustfmt) ]
+    do catch { foo()? };
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -346,10 +346,6 @@ fn handle_result(
 
         if fmt_text != text {
             let diff = make_diff(&text, &fmt_text, DIFF_CONTEXT_SIZE);
-            assert!(
-                !diff.is_empty(),
-                "Empty diff? Maybe due to a missing a newline at the end of a file?"
-            );
             failures.insert(file_name, diff);
         }
     }

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -91,3 +91,26 @@ fn issue_1799() {
     // https://github.com/rust-lang/rust/issues/43336
     Some(Err(error));
 }
+
+// #1813
+fn attributes_on_statemetns() {
+    // Semi
+    #[an_attribute(rustfmt)]
+    foo(1);
+
+    // Local
+    #[an_attribute(rustfmt)]
+    let x = foo(a, b, c);
+
+    // Item
+    #[an_attribute(rustfmt)]
+    use foobar;
+
+    // Mac
+    #[an_attribute(rustfmt)]
+    vec![1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 1, 1, 2, 1];
+
+    // Expr
+    #[an_attribute(rustfmt)]
+    {}
+}

--- a/tests/target/catch.rs
+++ b/tests/target/catch.rs
@@ -18,4 +18,7 @@ fn main() {
     do catch {
         // Regular do catch block
     };
+
+    #[an_attribute(rustfmt)]
+    do catch { foo()? };
 }


### PR DESCRIPTION
This PR adds an implementation to format attributes on statements and single line block.
Closes #1813.

While trying to solve #1813, I found that rustfmt removes attributes on top of a single line block.
Unfortunately, since `do` is not covered in the span from rust parser for `do catch`, there are some dirty hacks when we must use span.