### PR TITLE
Force vertical layout when struct_variant_width is 0

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1128,16 +1128,18 @@ pub fn format_struct_struct(
         .max_width()
         .checked_sub(result.len() + 3 + offset.width())
         .unwrap_or(0);
+    let one_line_budget =
+        one_line_width.map_or(0, |one_line_width| min(one_line_width, one_line_budget));
 
     let items_str = try_opt!(rewrite_with_alignment(
         fields,
         context,
         Shape::indented(offset, context.config),
         mk_sp(body_lo, span.hi),
-        one_line_width.map_or(0, |one_line_width| min(one_line_width, one_line_budget)),
+        one_line_budget,
     ));
 
-    if one_line_width.is_some() && !items_str.contains('\n') && !result.contains('\n') {
+    if !items_str.contains('\n') && !result.contains('\n') && items_str.len() <= one_line_budget {
         Some(format!("{} {} }}", result, items_str))
     } else {
         Some(format!(

--- a/tests/target/configs-struct_variant_width-0.rs
+++ b/tests/target/configs-struct_variant_width-0.rs
@@ -1,0 +1,29 @@
+// rustfmt-struct_variant_width: 0
+
+// Force vertical layout when struct_variant_width is set to 0.
+
+enum State {
+    TryRecv {
+        pos: usize,
+        lap: u8,
+        closed_count: usize,
+    },
+    Subscribe {
+        pos: usize,
+    },
+    IsReady {
+        pos: usize,
+        ready: bool,
+    },
+    Unsubscribe {
+        pos: usize,
+        lap: u8,
+        id_woken: usize,
+    },
+    FinalTryRecv {
+        pos: usize,
+        id_woken: usize,
+    },
+    TimedOut,
+    Disconnected,
+}


### PR DESCRIPTION
Currently rustfmt does not force vertical layout. Closes #1809.