### PR TITLE
Restore comments in file-lines tests

### DIFF
--- a/tests/source/file-lines-1.rs
+++ b/tests/source/file-lines-1.rs
@@ -17,6 +17,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/source/file-lines-2.rs
+++ b/tests/source/file-lines-2.rs
@@ -17,6 +17,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/source/file-lines-3.rs
+++ b/tests/source/file-lines-3.rs
@@ -18,6 +18,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/source/file-lines-4.rs
+++ b/tests/source/file-lines-4.rs
@@ -18,6 +18,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/target/file-lines-1.rs
+++ b/tests/target/file-lines-1.rs
@@ -17,6 +17,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/target/file-lines-2.rs
+++ b/tests/target/file-lines-2.rs
@@ -12,6 +12,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/target/file-lines-3.rs
+++ b/tests/target/file-lines-3.rs
@@ -13,6 +13,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),

--- a/tests/target/file-lines-4.rs
+++ b/tests/target/file-lines-4.rs
@@ -18,6 +18,7 @@ fn floaters() {
     {
         match x {
             PushParam => {
+                // comment
                 stack.push(mparams[match cur.to_digit(10) {
                                             Some(d) => d as usize - 1,
                                             None => return Err("bad param number".to_owned()),


### PR DESCRIPTION
Looks like the issue in #1159 was fixed at some point, so this PR adds deleted comments to the file-lines tests.
Closes #1159.