### PR TITLE
Remove whitespace between words in extern declarations

### DIFF
--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -1,5 +1,8 @@
 // rustfmt-normalize_comments: true
 
+ extern crate       foo    ;   
+    extern crate       foo       as bar    ;   
+
  extern  "C" {
   fn c_func(x: *mut *mut libc::c_void);
 

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -1,5 +1,8 @@
 // rustfmt-normalize_comments: true
 
+extern crate foo;
+extern crate foo as bar;
+
 extern "C" {
     fn c_func(x: *mut *mut libc::c_void);
 


### PR DESCRIPTION
These changes aim to fix #1815

This is my first PR here and although the added test cases pass I'm pretty sure my implementation is extremely naive and doesn't use the available tools in `rustfmt`. Also it allocates (probably) unnecessarily.

Any suggestions?