### PR TITLE
Avoid unnecessary line breaks

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -314,8 +314,8 @@ fn left_trim_comment_line<'a>(line: &'a str, style: &CommentStyle) -> &'a str {
             &line[opener.trim_right().len()..]
         }
     } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
-        line.starts_with("///") ||
-        line.starts_with("** ") || line.starts_with("/*!") ||
+        line.starts_with("///") || line.starts_with("** ") ||
+        line.starts_with("/*!") ||
         (line.starts_with("/**") && !line.starts_with("/**/"))
     {
         &line[3..]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -334,8 +334,7 @@ pub fn format_expr(
             shape,
         ),
         ast::ExprKind::Catch(ref block) => {
-            if let rewrite @ Some(_) =
-                rewrite_single_line_block(context, "do catch ", block, shape)
+            if let rewrite @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape)
             {
                 return rewrite;
             }
@@ -826,8 +825,7 @@ fn rewrite_empty_block(
     block: &ast::Block,
     shape: Shape,
 ) -> Option<String> {
-    if block.stmts.is_empty() && !block_contains_comment(block, context.codemap) &&
-        shape.width >= 2
+    if block.stmts.is_empty() && !block_contains_comment(block, context.codemap) && shape.width >= 2
     {
         return Some("{}".to_owned());
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -657,8 +657,8 @@ fn rewrite_closure(
         }
 
         // Figure out if the block is necessary.
-        let needs_block = block.rules != ast::BlockCheckMode::Default ||
-            block.stmts.len() > 1 || context.inside_macro ||
+        let needs_block = block.rules != ast::BlockCheckMode::Default || block.stmts.len() > 1 ||
+            context.inside_macro ||
             block_contains_comment(block, context.codemap) ||
             prefix.contains('\n');
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2281,10 +2281,10 @@ fn rewrite_last_closure(
         let body_shape = try_opt!(shape.offset_left(extra_offset));
         // When overflowing the closure which consists of a single control flow expression,
         // force to use block if its condition uses multi line.
-        if rewrite_cond(context, body, body_shape)
-            .map(|cond| cond.contains('\n'))
-            .unwrap_or(false)
-        {
+        let is_multi_lined_cond = rewrite_cond(context, body, body_shape)
+            .map(|cond| cond.contains('\n') || cond.len() > body_shape.width)
+            .unwrap_or(false);
+        if is_multi_lined_cond {
             return rewrite_closure_with_block(context, body_shape, &prefix, body);
         }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1156,12 +1156,23 @@ impl<'a> ControlFlow<'a> {
         shape: Shape,
         alt_block_sep: &str,
     ) -> Option<(String, usize)> {
+        // Do not take the rhs overhead from the upper expressions into account
+        // when rewriting pattern.
+        let new_width = context
+            .config
+            .max_width()
+            .checked_sub(shape.used_width())
+            .unwrap_or(0);
+        let fresh_shape = Shape {
+            width: new_width,
+            ..shape
+        };
         let constr_shape = if self.nested_if {
             // We are part of an if-elseif-else chain. Our constraints are tightened.
             // 7 = "} else " .len()
-            try_opt!(shape.offset_left(7))
+            try_opt!(fresh_shape.offset_left(7))
         } else {
-            shape
+            fresh_shape
         };
 
         let label_string = rewrite_label(self.label);

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -482,18 +482,18 @@ fn rewrite_use_list(
     };
     let list_str = try_opt!(write_list(&items[first_index..], &fmt));
 
-    let result =
-        if list_str.contains('\n') && context.config.imports_indent() == IndentStyle::Block {
-            format!(
-                "{}{{\n{}{}\n{}}}",
-                path_str,
-                nested_shape.indent.to_string(context.config),
-                list_str,
-                shape.indent.to_string(context.config)
-            )
-        } else {
-            format!("{}{{{}}}", path_str, list_str)
-        };
+    let result = if list_str.contains('\n') && context.config.imports_indent() == IndentStyle::Block
+    {
+        format!(
+            "{}{{\n{}{}\n{}}}",
+            path_str,
+            nested_shape.indent.to_string(context.config),
+            list_str,
+            shape.indent.to_string(context.config)
+        )
+    } else {
+        format!("{}{{{}}}", path_str, list_str)
+    };
     Some(result)
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -2734,9 +2734,7 @@ fn format_generics(
     let shape = Shape::legacy(context.budget(used_width + offset.width()), offset);
     let mut result = try_opt!(rewrite_generics(context, generics, shape, span));
 
-    let same_line_brace = if !generics.where_clause.predicates.is_empty() ||
-        result.contains('\n')
-    {
+    let same_line_brace = if !generics.where_clause.predicates.is_empty() || result.contains('\n') {
         let budget = context
             .config
             .max_width()

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -291,17 +291,17 @@ fn rewrite_tuple_pat(
     }
 
     let wildcard_suffix_len = count_wildcard_suffix_len(context, &pat_vec, span, shape);
-    let (pat_vec, span) =
-        if context.config.condense_wildcard_suffixes() && wildcard_suffix_len >= 2 {
-            let new_item_count = 1 + pat_vec.len() - wildcard_suffix_len;
-            let sp = pat_vec[new_item_count - 1].span();
-            let snippet = context.snippet(sp);
-            let lo = sp.lo + BytePos(snippet.find_uncommented("_").unwrap() as u32);
-            pat_vec[new_item_count - 1] = TuplePatField::Dotdot(mk_sp(lo, lo + BytePos(1)));
-            (&pat_vec[..new_item_count], mk_sp(span.lo, lo + BytePos(1)))
-        } else {
-            (&pat_vec[..], span)
-        };
+    let (pat_vec, span) = if context.config.condense_wildcard_suffixes() && wildcard_suffix_len >= 2
+    {
+        let new_item_count = 1 + pat_vec.len() - wildcard_suffix_len;
+        let sp = pat_vec[new_item_count - 1].span();
+        let snippet = context.snippet(sp);
+        let lo = sp.lo + BytePos(snippet.find_uncommented("_").unwrap() as u32);
+        pat_vec[new_item_count - 1] = TuplePatField::Dotdot(mk_sp(lo, lo + BytePos(1)));
+        (&pat_vec[..new_item_count], mk_sp(span.lo, lo + BytePos(1)))
+    } else {
+        (&pat_vec[..], span)
+    };
 
     // add comma if `(x,)`
     let add_comma = path_str.is_none() && pat_vec.len() == 1 && dotdot_pos.is_none();

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,12 +44,11 @@ pub fn rewrite_path(
 ) -> Option<String> {
     let skip_count = qself.map_or(0, |x| x.position);
 
-    let mut result =
-        if path.is_global() && qself.is_none() && path_context != PathContext::Import {
-            "::".to_owned()
-        } else {
-            String::new()
-        };
+    let mut result = if path.is_global() && qself.is_none() && path_context != PathContext::Import {
+        "::".to_owned()
+    } else {
+        String::new()
+    };
 
     let mut span_lo = path.span.lo;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -632,13 +632,13 @@ impl Rewrite for ast::PolyTraitRef {
                 Shape::legacy(max_path_width, shape.indent + extra_offset),
             ));
 
-            Some(if context.config.spaces_within_angle_brackets() &&
-                lifetime_str.len() > 0
-            {
-                format!("for< {} > {}", lifetime_str, path_str)
-            } else {
-                format!("for<{}> {}", lifetime_str, path_str)
-            })
+            Some(
+                if context.config.spaces_within_angle_brackets() && lifetime_str.len() > 0 {
+                    format!("for< {} > {}", lifetime_str, path_str)
+                } else {
+                    format!("for<{}> {}", lifetime_str, path_str)
+                },
+            )
         } else {
             self.trait_ref.rewrite(context, shape)
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -328,8 +328,7 @@ impl<'a> FmtVisitor<'a> {
             }
             ast::ItemKind::Trait(..) => {
                 self.format_missing_with_indent(item.span.lo);
-                if let Some(trait_str) =
-                    format_trait(&self.get_context(), item, self.block_indent)
+                if let Some(trait_str) = format_trait(&self.get_context(), item, self.block_indent)
                 {
                     self.buffer.push_str(&trait_str);
                     self.last_pos = source!(self, item.span).hi;

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -119,10 +119,10 @@ fn floaters() {
     .quux();
 
     a + match x {
-        true => "yay!",
-        false => "boo!",
-    }
-    .bar()
+            true => "yay!",
+            false => "boo!",
+        }
+        .bar()
 }
 
 fn is_replaced_content() -> bool {

--- a/tests/target/configs-control_style-rfc.rs
+++ b/tests/target/configs-control_style-rfc.rs
@@ -12,8 +12,7 @@ fn main() {
                 foo
             }
             if ai_timer.elapsed_time().as_microseconds() > ai_time.as_microseconds() {
-                if ball.position().y + ball_radius >
-                    right_paddle.position().y + paddle_size.y / 2.
+                if ball.position().y + ball_radius > right_paddle.position().y + paddle_size.y / 2.
                 {
                     foo
                 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -346,12 +346,10 @@ fn complex_if_else() {
         ha();
     } else if xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx + xxxxxxxx {
         yo();
-    } else if let Some(x) =
-        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    } else if let Some(x) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     {
         ha();
-    } else if xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx +
-        xxxxxxxxx
+    } else if xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx + xxxxxxxxx
     {
         yo();
     }

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -12,9 +12,9 @@ fn main() {
         // Just comments
     }
 
-    'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value >
-        some_other_value
-    {}
+    'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value > some_other_value
+    {
+    }
 
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
     }
@@ -22,8 +22,7 @@ fn main() {
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
     }
 
-    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in
-        some_iter(arg1, arg2)
+    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in some_iter(arg1, arg2)
     {
         // do smth
     }


### PR DESCRIPTION
This PR
1. fixes impatient line breaks of condition ([examples](https://github.com/rust-lang-nursery/rustfmt/pull/1821/commits/e523f053a3cd06453733f5543492d80e10bf8964)).
2. simplify `rewrite_pair`.