### PR TITLE
Fix #1858 - "Don't erase a use with attributes attached"

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -293,7 +293,7 @@ impl<'a> FmtVisitor<'a> {
 
         match item.node {
             ast::ItemKind::Use(ref vp) => {
-                self.format_import(&item.vis, vp, item.span);
+                self.format_import(&item.vis, vp, item.span, &item.attrs);
             }
             ast::ItemKind::Impl(..) => {
                 self.format_missing_with_indent(source!(self, item.span).lo);

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -72,3 +72,7 @@ use ::*;
 // spaces used to cause glob imports to disappear (#1356)
 use super:: * ;
 use foo::issue_1356:: * ;
+
+// We shouldn't remove imports which have attributes attached (#1858)
+#[cfg(unix)]
+use self::unix::{};

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -67,3 +67,7 @@ use ::*;
 // spaces used to cause glob imports to disappear (#1356)
 use super::*;
 use foo::issue_1356::*;
+
+// We shouldn't remove imports which have attributes attached (#1858)
+#[cfg(unix)]
+use self::unix::{};


### PR DESCRIPTION
This prevents code like

```rust
#[cfg(unix)]
pub use self::unix::{};
```

from becoming

```rust
#[cfg(unix)]
```

which would cause the attribute to be attached to the next item.
