### PR TITLE
Keep the pre-comment on the same line with item if it fits max width

### DIFF
--- a/tests/source/expr-block.rs
+++ b/tests/source/expr-block.rs
@@ -272,3 +272,13 @@ fn combine_block() {
         ),
     }
 }
+
+fn issue_1862() {
+    foo(
+        /* bar = */ None ,
+        something_something,
+        /* baz = */ None ,
+        /* This comment waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay too long to be kept on the same line */ None ,
+        /* com */ this_last_arg_is_tooooooooooooooooooooooooooooooooo_long_to_be_kept_with_the_pre_comment ,
+    )
+}

--- a/tests/target/expr-block.rs
+++ b/tests/target/expr-block.rs
@@ -81,8 +81,7 @@ fn arrays() {
     ];
 
     let y = [
-        /* comment */
-        1,
+        /* comment */ 1,
         2, /* post comment */
         3,
     ];
@@ -92,8 +91,7 @@ fn arrays() {
             test123: value_one_two_three_four,
             turbo: coolio(),
         },
-        /* comment  */
-        1,
+        /* comment  */ 1,
     ];
 
     let a = WeightedChoice::new(&mut [
@@ -322,4 +320,16 @@ fn combine_block() {
             zzz,
         ),
     }
+}
+
+fn issue_1862() {
+    foo(
+        /* bar = */ None,
+        something_something,
+        /* baz = */ None,
+        /* This comment waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay too long to be kept on the same line */
+        None,
+        /* com */
+        this_last_arg_is_tooooooooooooooooooooooooooooooooo_long_to_be_kept_with_the_pre_comment,
+    )
 }


### PR DESCRIPTION
Currently rustfmt forces the pre-comment of the item to be placed on the different line.
This PR changes this behaviour and let the comment keep the original layout as long as it does not exceed the max width.
Closes #1862.