### PR TITLE
Reorder extern crates

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -11,11 +11,11 @@
 #![cfg(not(test))]
 
 
+extern crate env_logger;
+extern crate getopts;
 extern crate log;
 extern crate rustfmt_nightly as rustfmt;
 extern crate toml;
-extern crate env_logger;
-extern crate getopts;
 
 use std::{env, error};
 use std::fs::File;

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,6 +558,8 @@ create_config! {
                                             exceeds `chain_one_line_max`";
     imports_indent: IndentStyle, IndentStyle::Visual, "Indent of imports";
     imports_layout: ListTactic, ListTactic::Mixed, "Item layout inside a import block";
+    reorder_extern_crates: bool, true, "Reorder extern crate statements alphabetically";
+    reorder_extern_crates_in_group: bool, true, "Reorder extern crate statements in group";
     reorder_imports: bool, false, "Reorder import statements alphabetically";
     reorder_imports_in_group: bool, false, "Reorder import statements in group";
     reorder_imported_names: bool, true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,23 +10,19 @@
 
 #![feature(rustc_private)]
 
+extern crate diff;
 #[macro_use]
 extern crate log;
-
+extern crate regex;
+extern crate rustc_errors as errors;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-
-extern crate syntax;
-extern crate rustc_errors as errors;
-
 extern crate strings;
-
-extern crate unicode_segmentation;
-extern crate regex;
-extern crate diff;
+extern crate syntax;
 extern crate term;
+extern crate unicode_segmentation;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -3,6 +3,13 @@
  extern crate       foo    ;   
     extern crate       foo       as bar    ;   
 
+extern crate futures;
+extern crate dotenv;
+extern crate chrono;
+
+extern crate foo;
+extern crate bar;
+
  extern  "C" {
   fn c_func(x: *mut *mut libc::c_void);
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate rustfmt_nightly as rustfmt;
 extern crate diff;
 extern crate regex;
+extern crate rustfmt_nightly as rustfmt;
 extern crate term;
 
 use std::collections::HashMap;

--- a/tests/target/attrib-extern-crate.rs
+++ b/tests/target/attrib-extern-crate.rs
@@ -1,17 +1,17 @@
 // Attributes on extern crate.
 
-extern crate Foo;
 #[Attr1]
 extern crate Bar;
 #[Attr2]
 #[Attr2]
 extern crate Baz;
+extern crate Foo;
 
 fn foo() {
-    extern crate Foo;
     #[Attr1]
     extern crate Bar;
     #[Attr2]
     #[Attr2]
     extern crate Baz;
+    extern crate Foo;
 }

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -1,7 +1,14 @@
 // rustfmt-normalize_comments: true
 
-extern crate foo;
 extern crate foo as bar;
+extern crate foo;
+
+extern crate chrono;
+extern crate dotenv;
+extern crate futures;
+
+extern crate bar;
+extern crate foo;
 
 extern "C" {
     fn c_func(x: *mut *mut libc::c_void);


### PR DESCRIPTION
This PR adds `reorder_extern_crates` and `reorder_extern_crates_in_group` config options.
Closes #1857.