### PR TITLE
Add error_on_line_overflow_comments config option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -501,6 +501,7 @@ create_config! {
          via the --file-lines option";
     max_width: usize, 100, "Maximum width of each line";
     error_on_line_overflow: bool, true, "Error if unable to get all lines within max_width";
+    error_on_line_overflow_comments: bool, true, "Error if unable to get comments within max_width";
     tab_spaces: usize, 4, "Number of spaces per tab";
     fn_call_width: usize, 60,
         "Maximum width of the args of a function call before falling back to vertical formatting";

--- a/tests/target/configs-error_on_line_overflow_comment-false.rs
+++ b/tests/target/configs-error_on_line_overflow_comment-false.rs
@@ -1,0 +1,7 @@
+// rustfmt-error_on_line_overflow_comments: false
+// Error on line overflow comment
+
+// aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+fn main() {
+    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}


### PR DESCRIPTION
This PR adds an option `error_on_line_overflow_comments` which when set to `false` prevents rustfmt from emitting errors about comments that overflowed the max width (cc #1770).

This option is not perfect in that it only works against single-lined comments (e.g. `//`, `///` and alike).
Dealing with block comments (`/* .. */`) is left for future work.