### PR TITLE
Minor fixes

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -854,22 +854,9 @@ impl Rewrite for ast::Stmt {
         let result = match self.node {
             ast::StmtKind::Local(ref local) => local.rewrite(context, shape),
             ast::StmtKind::Expr(ref ex) | ast::StmtKind::Semi(ref ex) => {
-                let suffix = if semicolon_for_stmt(context, self) {
-                    ";"
-                } else {
-                    ""
-                };
-
-                format_expr(
-                    ex,
-                    match self.node {
-                        ast::StmtKind::Expr(_) => ExprType::SubExpression,
-                        ast::StmtKind::Semi(_) => ExprType::Statement,
-                        _ => unreachable!(),
-                    },
-                    context,
-                    try_opt!(shape.sub_width(suffix.len())),
-                ).map(|s| s + suffix)
+                let suffix = semicolon_for_stmt(context, self);
+                let real_shape = try_opt!(shape.sub_width(suffix.len()));
+                format_expr(ex, ExprType::Statement, context, real_shape).map(|s| s + suffix)
             }
             ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
         };

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -133,10 +133,11 @@ pub fn format_expr(
                     } else {
                         // Rewrite block without trying to put it in a single line.
                         if let rw @ Some(_) = rewrite_empty_block(context, block, shape) {
-                            return rw;
+                            rw
+                        } else {
+                            let prefix = try_opt!(block_prefix(context, block, shape));
+                            rewrite_block_with_visitor(context, &prefix, block, shape)
                         }
-                        let prefix = try_opt!(block_prefix(context, block, shape));
-                        rewrite_block_with_visitor(context, &prefix, block, shape)
                     }
                 }
                 ExprType::SubExpression => block.rewrite(context, shape),
@@ -282,17 +283,17 @@ pub fn format_expr(
             shape,
         ),
         ast::ExprKind::Catch(ref block) => {
-            if let rewrite @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape)
-            {
-                return rewrite;
+            if let rw @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape) {
+                rw
+            } else {
+                // 9 = `do catch `
+                let budget = shape.width.checked_sub(9).unwrap_or(0);
+                Some(format!(
+                    "{}{}",
+                    "do catch ",
+                    try_opt!(block.rewrite(&context, Shape::legacy(budget, shape.indent)))
+                ))
             }
-            // 9 = `do catch `
-            let budget = shape.width.checked_sub(9).unwrap_or(0);
-            Some(format!(
-                "{}{}",
-                "do catch ",
-                try_opt!(block.rewrite(&context, Shape::legacy(budget, shape.indent)))
-            ))
         }
     };
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -55,7 +55,16 @@ impl Rewrite for ast::Local {
 
         skip_out_of_file_lines_range!(context, self.span);
 
-        let mut result = "let ".to_owned();
+        let attrs_str = try_opt!(self.attrs.rewrite(context, shape));
+        let missing_span = missing_span_between_attrs!(self);
+        let mut result = try_opt!(combine_strs_with_missing_comments(
+            context,
+            &attrs_str,
+            "let ",
+            missing_span,
+            shape,
+            false,
+        ));
 
         // 4 = "let ".len()
         let pat_shape = try_opt!(shape.offset_left(4));

--- a/src/items.rs
+++ b/src/items.rs
@@ -1413,11 +1413,7 @@ pub fn rewrite_struct_field(
     let prefix = try_opt!(rewrite_struct_field_prefix(context, field));
 
     let attrs_str = try_opt!(field.attrs.rewrite(context, shape));
-    let missing_span = if field.attrs.is_empty() {
-        mk_sp(field.span.lo, field.span.lo)
-    } else {
-        mk_sp(field.attrs.last().unwrap().span.hi, field.span.lo)
-    };
+    let missing_span = missing_span_between_attrs!(field);
     let mut spacing = String::from(if field.ident.is_some() {
         type_annotation_spacing.1
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,15 +107,30 @@ impl Spanned for ast::Item {
     }
 }
 
+impl Spanned for ast::Local {
+    fn span(&self) -> Span {
+        span_with_attrs!(self)
+    }
+}
+
 impl Spanned for ast::Stmt {
     fn span(&self) -> Span {
-        match self.node {
-            // Cover attributes
-            ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {
-                mk_sp(expr.span().lo, self.span.hi)
+        // Cover attributes
+        let hi = self.span.hi;
+        let lo = match self.node {
+            ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span().lo,
+            ast::StmtKind::Local(ref local) => local.span().lo,
+            ast::StmtKind::Item(ref item) => item.span().lo,
+            ast::StmtKind::Mac(ref mac) => {
+                let (_, _, ref attrs) = **mac;
+                if attrs.is_empty() {
+                    self.span.lo
+                } else {
+                    attrs[0].span.lo
+                }
             }
-            _ => self.span,
-        }
+        };
+        mk_sp(lo, hi)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ mod patterns;
 mod summary;
 mod vertical;
 
+/// Spanned will cover attributes as well if available.
 pub trait Spanned {
     fn span(&self) -> Span;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -222,20 +222,24 @@ pub fn semicolon_for_expr(context: &RewriteContext, expr: &ast::Expr) -> bool {
 }
 
 #[inline]
-pub fn semicolon_for_stmt(context: &RewriteContext, stmt: &ast::Stmt) -> bool {
+pub fn semicolon_for_stmt(context: &RewriteContext, stmt: &ast::Stmt) -> &'static str {
     match stmt.node {
         ast::StmtKind::Semi(ref expr) => match expr.node {
             ast::ExprKind::While(..) |
             ast::ExprKind::WhileLet(..) |
             ast::ExprKind::Loop(..) |
-            ast::ExprKind::ForLoop(..) => false,
+            ast::ExprKind::ForLoop(..) => "",
             ast::ExprKind::Break(..) | ast::ExprKind::Continue(..) | ast::ExprKind::Ret(..) => {
-                context.config.trailing_semicolon()
+                if context.config.trailing_semicolon() {
+                    ";"
+                } else {
+                    ""
+                }
             }
-            _ => true,
+            _ => ";",
         },
-        ast::StmtKind::Expr(..) => false,
-        _ => true,
+        ast::StmtKind::Expr(..) => "",
+        _ => ";",
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -362,6 +362,18 @@ macro_rules! source {
     }
 }
 
+// Return the span between the end of the attributes of the given item and the beginning of the
+// given item. Returns an empty span if there are no attributes.
+macro_rules! missing_span_between_attrs {
+    ($this:ident) => {
+        if $this.attrs.is_empty() {
+            mk_sp($this.span.lo, $this.span.lo)
+        } else {
+            mk_sp($this.attrs[$this.attrs.len() - 1].span.hi, $this.span.lo)
+        }
+    }
+}
+
 pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
     Span {
         lo,

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -47,11 +47,7 @@ impl AlignedItem for ast::StructField {
 
     fn rewrite_prefix(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let attrs_str = try_opt!(self.attrs.rewrite(context, shape));
-        let missing_span = if self.attrs.is_empty() {
-            mk_sp(self.span.lo, self.span.lo)
-        } else {
-            mk_sp(self.attrs.last().unwrap().span.hi, self.span.lo)
-        };
+        let missing_span = missing_span_between_attrs!(self);
         rewrite_struct_field_prefix(context, self).and_then(|field_str| {
             combine_strs_with_missing_comments(
                 context,
@@ -86,11 +82,7 @@ impl AlignedItem for ast::Field {
     fn rewrite_prefix(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let attrs_str = try_opt!(self.attrs.rewrite(context, shape));
         let name = &self.ident.node.to_string();
-        let missing_span = if self.attrs.is_empty() {
-            mk_sp(self.span.lo, self.span.lo)
-        } else {
-            mk_sp(self.attrs.last().unwrap().span.hi, self.span.lo)
-        };
+        let missing_span = missing_span_between_attrs!(self);
         combine_strs_with_missing_comments(
             context,
             &attrs_str,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -76,33 +76,14 @@ impl<'a> FmtVisitor<'a> {
                         Shape::indented(self.block_indent, self.config),
                     )
                 };
-                self.push_rewrite(stmt.span, rewrite);
+                self.push_rewrite(stmt.span(), rewrite);
             }
-            ast::StmtKind::Expr(ref expr) => {
-                let rewrite = format_expr(
-                    expr,
-                    ExprType::Statement,
-                    &self.get_context(),
-                    Shape::indented(self.block_indent, self.config),
-                );
-                let span = if expr.attrs.is_empty() {
-                    stmt.span
-                } else {
-                    mk_sp(expr.span().lo, stmt.span.hi)
-                };
-                self.push_rewrite(span, rewrite)
-            }
-            ast::StmtKind::Semi(ref expr) => {
+            ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let rewrite = stmt.rewrite(
                     &self.get_context(),
                     Shape::indented(self.block_indent, self.config),
                 );
-                let span = if expr.attrs.is_empty() {
-                    stmt.span
-                } else {
-                    mk_sp(expr.span().lo, stmt.span.hi)
-                };
-                self.push_rewrite(span, rewrite)
+                self.push_rewrite(stmt.span(), rewrite)
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, _macro_style, ref attrs) = **mac;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -18,10 +18,10 @@ use syntax::parse::ParseSess;
 
 use {Indent, Shape, Spanned};
 use codemap::{LineRangeUtils, SpanUtils};
-use comment::{contains_comment, CodeCharKind, CommentCodeSlices, FindUncommented};
+use comment::{combine_strs_with_missing_comments, contains_comment, CodeCharKind,
+              CommentCodeSlices, FindUncommented};
 use comment::rewrite_comment;
 use config::{BraceStyle, Config};
-use expr::{format_expr, ExprType};
 use items::{format_impl, format_trait, rewrite_associated_impl_type, rewrite_associated_type,
             rewrite_static, rewrite_type_alias};
 use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorTactic};
@@ -86,11 +86,16 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(stmt.span(), rewrite)
             }
             ast::StmtKind::Mac(ref mac) => {
-                let (ref mac, _macro_style, ref attrs) = **mac;
+                let (ref mac, macro_style, ref attrs) = **mac;
                 if contains_skip(attrs) {
-                    self.push_rewrite(mac.span, None);
+                    self.push_rewrite(stmt.span(), None);
                 } else {
-                    self.visit_mac(mac, None, MacroPosition::Statement);
+                    let position = if macro_style == ast::MacStmtStyle::Semicolon {
+                        MacroPosition::StatementSemicolon
+                    } else {
+                        MacroPosition::Statement
+                    };
+                    self.visit_mac(mac, None, position, stmt.span(), Some(&**attrs));
                 }
                 self.format_missing(stmt.span.hi);
             }
@@ -413,11 +418,11 @@ impl<'a> FmtVisitor<'a> {
                 self.format_mod(module, &item.vis, item.span, item.ident, &attrs);
             }
             ast::ItemKind::Mac(ref mac) => {
-                self.visit_mac(mac, Some(item.ident), MacroPosition::Item);
+                self.visit_mac(mac, Some(item.ident), MacroPosition::Item, item.span, None);
             }
             ast::ItemKind::ForeignMod(ref foreign_mod) => {
                 self.format_missing_with_indent(source!(self, item.span).lo);
-                self.format_foreign_mod(foreign_mod, item.span);
+                self.format_foreign_mod(foreign_mod, item.span());
             }
             ast::ItemKind::Static(ref ty, mutability, ref expr) => {
                 let rewrite = rewrite_static(
@@ -555,7 +560,13 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(ti.span, rewrite);
             }
             ast::TraitItemKind::Macro(ref mac) => {
-                self.visit_mac(mac, Some(ti.ident), MacroPosition::Item);
+                self.visit_mac(
+                    mac,
+                    Some(ti.ident),
+                    MacroPosition::TraitItem,
+                    mac.span,
+                    None,
+                );
             }
         }
     }
@@ -605,20 +616,52 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(ii.span, rewrite);
             }
             ast::ImplItemKind::Macro(ref mac) => {
-                self.visit_mac(mac, Some(ii.ident), MacroPosition::Item);
+                self.visit_mac(mac, Some(ii.ident), MacroPosition::ImplItem, mac.span, None);
             }
         }
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac, ident: Option<ast::Ident>, pos: MacroPosition) {
-        skip_out_of_file_lines_range_visitor!(self, mac.span);
+    fn visit_mac(
+        &mut self,
+        mac: &ast::Mac,
+        ident: Option<ast::Ident>,
+        pos: MacroPosition,
+        span: Span, // span including attributes, if available.
+        attrs: Option<&[ast::Attribute]>,
+    ) {
+        skip_out_of_file_lines_range_visitor!(self, span);
 
         // 1 = ;
         let shape = Shape::indented(self.block_indent, self.config)
             .sub_width(1)
             .unwrap();
-        let rewrite = rewrite_macro(mac, ident, &self.get_context(), shape, pos);
-        self.push_rewrite(mac.span, rewrite);
+        let rewrite = if let Some(ref attrs) = attrs {
+            let attrs_str = match attrs.rewrite(&self.get_context(), shape) {
+                Some(s) => s,
+                None => {
+                    self.push_rewrite(span, None);
+                    return;
+                }
+            };
+            let missing_span = if attrs.is_empty() {
+                mk_sp(mac.span.lo, mac.span.lo)
+            } else {
+                mk_sp(attrs[attrs.len() - 1].span.hi, mac.span.lo)
+            };
+            rewrite_macro(mac, ident, &self.get_context(), shape, pos).and_then(|macro_str| {
+                combine_strs_with_missing_comments(
+                    &self.get_context(),
+                    &attrs_str,
+                    &macro_str,
+                    missing_span,
+                    shape,
+                    false,
+                )
+            })
+        } else {
+            rewrite_macro(mac, ident, &self.get_context(), shape, pos)
+        };
+        self.push_rewrite(span, rewrite);
     }
 
     fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -108,3 +108,22 @@ impl InnerAttributes() {
 mod InnerAttributes {
     #![ this_is_an_inner_attribute ( foo ) ]
 }
+
+// #1813
+fn attributes_on_statements() {
+    // ast::StmtKind::Semi
+    # [ an_attribute ( rustfmt ) ]
+    foo( 1 ) ; 
+    // ast::StmtKind::Local
+    # [ an_attribute ( rustfmt ) ]
+    let  x= foo( 1 ) ; 
+    // ast::StmtKind::Item
+    # [ an_attribute ( rustfmt ) ]
+    use foobar ; 
+    // ast::StmtKind::Mac
+    # [ an_attribute ( rustfmt ) ]
+    vec![ 1, 2 , ]; 
+    // ast::StmtKind::Expr
+    # [ an_attribute ( rustfmt ) ]
+    {}
+}

--- a/tests/source/catch.rs
+++ b/tests/source/catch.rs
@@ -24,4 +24,7 @@ fn main() {
     do catch {
         // Regular do catch block
     };
+
+    #[ an_attribute_on_single_line_catch ]
+    do catch { foo() ? };
 }

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -107,3 +107,22 @@ impl InnerAttributes() {
 mod InnerAttributes {
     #![this_is_an_inner_attribute(foo)]
 }
+
+// #1813
+fn attributes_on_statements() {
+    // ast::StmtKind::Semi
+    #[an_attribute(rustfmt)]
+    foo(1);
+    // ast::StmtKind::Local
+    #[an_attribute(rustfmt)]
+    let x = foo(1);
+    // ast::StmtKind::Item
+    #[an_attribute(rustfmt)]
+    use foobar;
+    // ast::StmtKind::Mac
+    #[an_attribute(rustfmt)]
+    vec![1, 2];
+    // ast::StmtKind::Expr
+    #[an_attribute(rustfmt)]
+    {}
+}

--- a/tests/target/catch.rs
+++ b/tests/target/catch.rs
@@ -18,4 +18,7 @@ fn main() {
     do catch {
         // Regular do catch block
     };
+
+    #[an_attribute_on_single_line_catch]
+    do catch { foo()? };
 }

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -42,7 +42,9 @@ fn main() {
     });
 
     fffffffffffffffffffffffffffffffffff(a, {
-        SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+        SCRIPT_TASK_ROOT.with(|root| {
+            *root.borrow_mut() = Some(&script_task);
+        });
     });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum =

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -45,7 +45,9 @@ fn main() {
         });
 
     fffffffffffffffffffffffffffffffffff(a, {
-        SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+        SCRIPT_TASK_ROOT.with(|root| {
+            *root.borrow_mut() = Some(&script_task);
+        });
     });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum =

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -80,7 +80,9 @@ fn main() {
 	});
 
 	fffffffffffffffffffffffffffffffffff(a, {
-		SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+		SCRIPT_TASK_ROOT.with(|root| {
+			*root.borrow_mut() = Some(&script_task);
+		});
 	});
 	a.b.c.d();
 


### PR DESCRIPTION
This PR consists of several minor fixes.
1. Preserve attributes on single line block. Currently rustfmt removes them.
```rust
#[foo]
{}
```
2. Do not allow closure with a single statement to be formatted as a single-lined block. I think this is specified in Rfc, please correct me if I am wrong.
```rust
SCRIPT_TASK_ROOT.with(|root| {
    *root.borrow_mut() = Some(&script_task);
}); 
```
3. Format and preserve attributes on statements. Closes #1813.
4. Format trailing semicolon on the macro. rustfmt currently relies on recovering method.