### PR TITLE
Enhance error messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,8 +482,7 @@ impl FormattingError {
 
     fn msg_suffix(&self) -> &str {
         match self.kind {
-            ErrorKind::LineOverflow(..) | ErrorKind::TrailingWhitespace => "(sorry)",
-            ErrorKind::BadIssue(_) => "",
+            _ => String::from(""),
         }
     }
 }

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -12,6 +12,7 @@ use diff;
 use std::collections::VecDeque;
 use std::io;
 use term;
+use utils::isatty;
 
 #[derive(Debug, PartialEq)]
 pub enum DiffLine {
@@ -104,25 +105,6 @@ where
             print_diff_fancy(diff, get_section_title, term::stdout().unwrap())
         }
         _ => print_diff_basic(diff, get_section_title),
-    }
-
-    // isatty shamelessly adapted from cargo.
-    #[cfg(unix)]
-    fn isatty() -> bool {
-        extern crate libc;
-
-        unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
-    }
-    #[cfg(windows)]
-    fn isatty() -> bool {
-        extern crate kernel32;
-        extern crate winapi;
-
-        unsafe {
-            let handle = kernel32::GetStdHandle(winapi::winbase::STD_OUTPUT_HANDLE);
-            let mut out = 0;
-            kernel32::GetConsoleMode(handle, &mut out) != 0
-        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -516,3 +516,22 @@ pub fn left_most_sub_expr(e: &ast::Expr) -> &ast::Expr {
         _ => e,
     }
 }
+
+// isatty shamelessly adapted from cargo.
+#[cfg(unix)]
+pub fn isatty() -> bool {
+    extern crate libc;
+
+    unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
+}
+#[cfg(windows)]
+pub fn isatty() -> bool {
+    extern crate kernel32;
+    extern crate winapi;
+
+    unsafe {
+        let handle = kernel32::GetStdHandle(winapi::winbase::STD_OUTPUT_HANDLE);
+        let mut out = 0;
+        kernel32::GetConsoleMode(handle, &mut out) != 0
+    }
+}


### PR DESCRIPTION
The current rustfmt only emits very dry error messages.
This PR attempts to improve it with more verbose error messages resembling those of rustc.

#### Screenshot
![screenshot_20170815_164433](https://user-images.githubusercontent.com/21980157/29306979-d783b464-81da-11e7-8b12-5e7c0199be2c.png)
