### PR TITLE
Add mach_pattern_separator_break_point config option 

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1163,6 +1163,39 @@ match lorem {
 
 See also: [`indent_match_arms`](#indent_match_arms), [`trailing_comma`](#trailing_comma), [`wrap_match_arms`](#wrap_match_arms).
 
+## `match_pattern_separator_break_point`
+
+Put a match sub-patterns' separator (`|`) in front or back.
+
+- **Default value**: `"Back"`
+- **Possible values**: `"Back"`, `"Front"`
+
+#### `"Back"`
+
+```rust
+match m {
+    Variant::Tag |
+    Variant::Tag2 |
+    Variant::Tag3 |
+    Variant::Tag4 |
+    Variant::Tag5 |
+    Variant::Tag6 => {}
+}
+```
+
+#### `Front`
+
+```rust
+match m {
+    Variant::Tag
+    | Variant::Tag2
+    | Variant::Tag3
+    | Variant::Tag4
+    | Variant::Tag5
+    | Variant::Tag6 => {}
+}
+```
+
 ## `max_width`
 
 Maximum width of each line

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use std::io::{Error, ErrorKind, Read};
 use std::path::{Path, PathBuf};
 
 use file_lines::FileLines;
-use lists::{ListTactic, SeparatorTactic};
+use lists::{ListTactic, SeparatorPlace, SeparatorTactic};
 
 macro_rules! configuration_option_enum{
     ($e:ident: $( $x:ident ),+ $(,)*) => {
@@ -581,6 +581,8 @@ create_config! {
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
     indent_match_arms: bool, true, "Indent match arms instead of keeping them at the same \
                                     indentation level as the match keyword";
+    match_pattern_separator_break_point: SeparatorPlace, SeparatorPlace::Back,
+        "Put a match sub-patterns' separator in front or back.";
     closure_block_indent_threshold: isize, 7, "How many lines a closure must have before it is \
                                                block indented. -1 means never use block indent.";
     space_before_type_annotation: bool, false,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -25,7 +25,7 @@ use config::{Config, ControlBraceStyle, IndentStyle, MultilineStyle, Style};
 use items::{span_hi_for_arg, span_lo_for_arg};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
             struct_lit_shape, struct_lit_tactic, write_list, DefinitiveListTactic, ListFormatting,
-            ListItem, ListTactic, Separator, SeparatorTactic};
+            ListItem, ListTactic, Separator, SeparatorPlace, SeparatorTactic};
 use macros::{rewrite_macro, MacroPosition};
 use patterns::{can_be_overflowed_pat, TuplePatField};
 use rewrite::{Rewrite, RewriteContext};
@@ -473,6 +473,7 @@ where
         } else {
             SeparatorTactic::Vertical
         },
+        separator_place: SeparatorPlace::Back,
         shape: nested_shape,
         ends_with_newline: ends_with_newline,
         preserve_newline: false,
@@ -555,6 +556,7 @@ fn rewrite_closure_fn_decl(
         tactic: tactic,
         separator: ",",
         trailing_separator: SeparatorTactic::Never,
+        separator_place: SeparatorPlace::Back,
         shape: arg_shape,
         ends_with_newline: false,
         preserve_newline: true,
@@ -1578,6 +1580,7 @@ fn rewrite_match_arms(
         // We will add/remove commas inside `arm.rewrite()`, and hence no separator here.
         separator: "",
         trailing_separator: SeparatorTactic::Never,
+        separator_place: SeparatorPlace::Back,
         shape: arm_shape,
         ends_with_newline: true,
         preserve_newline: true,
@@ -1659,6 +1662,7 @@ fn rewrite_match_pattern(
         tactic: tactic,
         separator: " |",
         trailing_separator: SeparatorTactic::Never,
+        separator_place: context.config.match_pattern_separator_break_point(),
         shape: pat_shape,
         ends_with_newline: false,
         preserve_newline: false,
@@ -2161,6 +2165,7 @@ where
         } else {
             context.config.trailing_comma()
         },
+        separator_place: SeparatorPlace::Back,
         shape: shape,
         ends_with_newline: context.use_block_indent() && tactic == DefinitiveListTactic::Vertical,
         preserve_newline: false,
@@ -2761,6 +2766,7 @@ where
         tactic: tactic,
         separator: ",",
         trailing_separator: SeparatorTactic::Never,
+        separator_place: SeparatorPlace::Back,
         shape: shape,
         ends_with_newline: false,
         preserve_newline: false,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -17,7 +17,7 @@ use Shape;
 use codemap::SpanUtils;
 use config::IndentStyle;
 use lists::{definitive_tactic, itemize_list, write_list, DefinitiveListTactic, ListFormatting,
-            ListItem, Separator, SeparatorTactic};
+            ListItem, Separator, SeparatorPlace, SeparatorTactic};
 use rewrite::{Rewrite, RewriteContext};
 use types::{rewrite_path, PathContext};
 use utils;
@@ -496,6 +496,7 @@ fn rewrite_use_list(
         } else {
             SeparatorTactic::Never
         },
+        separator_place: SeparatorPlace::Back,
         shape: nested_shape,
         ends_with_newline: ends_with_newline,
         preserve_newline: true,

--- a/src/items.rs
+++ b/src/items.rs
@@ -24,7 +24,7 @@ use config::{BraceStyle, Config, Density, IndentStyle, ReturnIndent, Style};
 use expr::{format_expr, is_empty_block, is_simple_block_stmt, rewrite_assign_rhs,
            rewrite_call_inner, ExprType};
 use lists::{definitive_tactic, itemize_list, write_list, DefinitiveListTactic, ListFormatting,
-            ListItem, ListTactic, Separator, SeparatorTactic};
+            ListItem, ListTactic, Separator, SeparatorPlace, SeparatorTactic};
 use rewrite::{Rewrite, RewriteContext};
 use types::join_bounds;
 use utils::{colon_spaces, contains_skip, end_typaram, first_line_width, format_abi,
@@ -481,6 +481,7 @@ impl<'a> FmtVisitor<'a> {
             tactic: DefinitiveListTactic::Vertical,
             separator: ",",
             trailing_separator: self.config.trailing_comma(),
+            separator_place: SeparatorPlace::Back,
             shape: shape,
             ends_with_newline: true,
             preserve_newline: true,
@@ -2267,6 +2268,7 @@ fn rewrite_args(
         } else {
             trailing_comma
         },
+        separator_place: SeparatorPlace::Back,
         shape: Shape::legacy(budget, indent),
         ends_with_newline: tactic.ends_with_newline(context.config.fn_args_layout()),
         preserve_newline: true,
@@ -2462,6 +2464,7 @@ where
         } else {
             context.config.trailing_comma()
         },
+        separator_place: SeparatorPlace::Back,
         shape: shape,
         ends_with_newline: tactic.ends_with_newline(context.config.generics_indent()),
         preserve_newline: true,
@@ -2574,6 +2577,7 @@ fn rewrite_where_clause_rfc_style(
         tactic: DefinitiveListTactic::Vertical,
         separator: ",",
         trailing_separator: comma_tactic,
+        separator_place: SeparatorPlace::Back,
         shape: clause_shape,
         ends_with_newline: true,
         preserve_newline: true,
@@ -2685,6 +2689,7 @@ fn rewrite_where_clause(
         tactic: tactic,
         separator: ",",
         trailing_separator: comma_tactic,
+        separator_place: SeparatorPlace::Back,
         shape: Shape::legacy(budget, offset),
         ends_with_newline: tactic.ends_with_newline(context.config.where_pred_indent()),
         preserve_newline: true,

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,7 +23,7 @@ use config::{IndentStyle, Style, TypeDensity};
 use expr::{rewrite_pair, rewrite_tuple, rewrite_unary_prefix, wrap_args_with_parens};
 use items::{format_generics_item_list, generics_shape_from_config};
 use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListTactic, Separator,
-            SeparatorTactic};
+            SeparatorPlace, SeparatorTactic};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{colon_spaces, extra_offset, format_mutability, last_line_width, mk_sp, wrap_str};
 
@@ -365,6 +365,7 @@ where
         } else {
             context.config.trailing_comma()
         },
+        separator_place: SeparatorPlace::Back,
         shape: list_shape,
         ends_with_newline: tactic.ends_with_newline(context.config.fn_call_style()),
         preserve_newline: true,

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -20,7 +20,8 @@ use codemap::SpanUtils;
 use comment::{combine_strs_with_missing_comments, contains_comment};
 use expr::rewrite_field;
 use items::{rewrite_struct_field, rewrite_struct_field_prefix};
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListTactic, Separator};
+use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListTactic, Separator,
+            SeparatorPlace};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{contains_skip, is_attributes_extendable, mk_sp};
 
@@ -257,6 +258,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         tactic: tactic,
         separator: ",",
         trailing_separator: context.config.trailing_comma(),
+        separator_place: SeparatorPlace::Back,
         shape: item_shape,
         ends_with_newline: true,
         preserve_newline: true,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -24,7 +24,8 @@ use config::{BraceStyle, Config};
 use expr::{format_expr, ExprType};
 use items::{format_impl, format_trait, rewrite_associated_impl_type, rewrite_associated_type,
             rewrite_static, rewrite_type_alias};
-use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorTactic};
+use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorPlace,
+            SeparatorTactic};
 use macros::{rewrite_macro, MacroPosition};
 use regex::Regex;
 use rewrite::{Rewrite, RewriteContext};
@@ -917,6 +918,7 @@ impl Rewrite for ast::MetaItem {
                     tactic: DefinitiveListTactic::Mixed,
                     separator: ",",
                     trailing_separator: SeparatorTactic::Never,
+                    separator_place: SeparatorPlace::Back,
                     shape: item_shape,
                     ends_with_newline: false,
                     preserve_newline: false,

--- a/tests/source/configs-match_pattern_separator_break_point-Front.rs
+++ b/tests/source/configs-match_pattern_separator_break_point-Front.rs
@@ -1,0 +1,9 @@
+// rustfmt-match_pattern_separator_break_point: Front
+// Whether `|` goes to front or to back.
+
+fn main() {
+    match lorem {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb | cccccccccccccccccccccccccccccccccccccccc | dddddddddddddddddddddddddddddddddddddddd => (),
+        _ => (),
+    }
+}

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -159,10 +159,9 @@ fn issue339() {
         // t comment
         t => 1,
         u => 2,
-        // TODO uncomment when block-support exists
-        // v => {
-        // } /* funky block
-        //    * comment */
+        v => {
+        } /* funky block
+           * comment */
         // final comment
     }
 }

--- a/tests/target/configs-match_pattern_separator_break_point-Front.rs
+++ b/tests/target/configs-match_pattern_separator_break_point-Front.rs
@@ -1,0 +1,12 @@
+// rustfmt-match_pattern_separator_break_point: Front
+// Whether `|` goes to front or to back.
+
+fn main() {
+    match lorem {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        | cccccccccccccccccccccccccccccccccccccccc
+        | dddddddddddddddddddddddddddddddddddddddd => (),
+        _ => (),
+    }
+}

--- a/tests/target/control-brace-style-always-next-line.rs
+++ b/tests/target/control-brace-style-always-next-line.rs
@@ -41,7 +41,8 @@ fn main() {
     }
 
     match some_var
-    { // match comment
+    {
+        // match comment
         pattern0 => val0,
         pattern1 => val1,
         pattern2 | pattern3 =>

--- a/tests/target/control-brace-style-always-same-line.rs
+++ b/tests/target/control-brace-style-always-same-line.rs
@@ -34,7 +34,8 @@ fn main() {
         }
     }
 
-    match some_var { // match comment
+    match some_var {
+        // match comment
         pattern0 => val0,
         pattern1 => val1,
         pattern2 | pattern3 => {

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -128,13 +128,15 @@ fn issue339() {
         h => {
             // comment above block
         }
-        i => {} // comment below block
+        i => {}
+        // comment below block
         j => {
             // comment inside block
         }
         j2 => {
             // comments inside...
-        } // ... and after
+        }
+        // ... and after
         // TODO uncomment when vertical whitespace is handled better
         // k => {
         //
@@ -156,11 +158,9 @@ fn issue339() {
         // t comment
         t => 1,
         u => 2,
-        // TODO uncomment when block-support exists
-        // v => {
-        // } /* funky block
-        //    * comment */
-        // final comment
+        v => {} /* funky block
+                 * comment */
+                /* final comment */
     }
 }
 
@@ -173,8 +173,8 @@ fn issue355() {
         e => vec![1, 2],
         f => vec![3; 4],
         h => println!("a", b), // h comment
-        i => vec![1, 2], // i comment
-        j => vec![3; 4], // j comment
+        i => vec![1, 2],       // i comment
+        j => vec![3; 4],       // j comment
         // k comment
         k => println!("a", b),
         // l comment
@@ -213,11 +213,11 @@ fn issue355() {
         y => vec![3; 4],
         // Brackets with comments
         tc => println!{"a", b}, // comment
-        uc => vec![1, 2], // comment
-        vc => vec![3; 4], // comment
+        uc => vec![1, 2],       // comment
+        vc => vec![3; 4],       // comment
         wc => println!["a", b], // comment
-        xc => vec![1, 2], // comment
-        yc => vec![3; 4], // comment
+        xc => vec![1, 2],       // comment
+        yc => vec![3; 4],       // comment
         yd => looooooooooooooooooooooooooooooooooooooooooooooooooooooooong_func(
             aaaaaaaaaa,
             bbbbbbbbbb,


### PR DESCRIPTION
This PR implements `match_pattern_separator_break_point` config option, which controls where to break match sub-patterns (before or after `|`).

#### `"Front"`
```rust
match m {
    Variant::Tag
    | Variant::Tag2
    | Variant::Tag3
    | Variant::Tag4
    | Variant::Tag5
    | Variant::Tag6 => {}
}
```

#### `"Back"`
```rust
match m {
    Variant::Tag |
    Variant::Tag2 |
    Variant::Tag3 |
    Variant::Tag4 |
    Variant::Tag5 |
    Variant::Tag6 => {}
}
```

Related issue: https://github.com/rust-lang-nursery/fmt-rfcs/issues/34