### PR TITLE
Add struct_lit_pattern_width option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1643,7 +1643,7 @@ See also: [`struct_lit_multiline_style`](#struct_lit_multiline_style), [`struct_
 
 ## `struct_lit_width`
 
-Maximum width in the body of a struct lit before falling back to vertical formatting
+Maximum width in the body of a struct lit *expression* before falling back to vertical formatting
 
 - **Default value**: `18`
 - **Possible values**: any positive integer
@@ -1658,7 +1658,26 @@ let lorem = Lorem { ipsum: dolor, sit: amet };
 #### Lines longer than `struct_lit_width`:
 See [`struct_lit_style`](#struct_lit_style).
 
-See also: [`struct_lit_multiline_style`](#struct_lit_multiline_style), [`struct_lit_style`](#struct_lit_style).
+See also: [`struct_lit_multiline_style`](#struct_lit_multiline_style), [`struct_lit_style`](#struct_lit_style), [`struct_lit_pattern_width`](#struct_lit_pattern_width).
+
+## `struct_lit_pattern_width`
+
+Maximum width in the body of a struct lit *pattern* before falling back to vertical formatting
+
+- **Default value**: `18`
+- **Possible values**: any positive integer
+
+**Note:** A value of `0` results in vertical formatting being applied regardless of a line's width.
+
+#### Lines shorter than `struct_lit_pattern_width`:
+```rust
+let Lorem { ipsum: dolor, sit: amet } = lorem;
+```
+
+#### Lines longer than `struct_lit_pattern_width`:
+See [`struct_lit_style`](#struct_lit_style).
+
+See also: [`struct_lit_multiline_style`](#struct_lit_multiline_style), [`struct_lit_style`](#struct_lit_style), [`struct_lit_width`](#struct_lit_pattern_width).
 
 ## `struct_variant_width`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -506,7 +506,11 @@ create_config! {
     fn_call_width: usize, 60,
         "Maximum width of the args of a function call before falling back to vertical formatting";
     struct_lit_width: usize, 18,
-        "Maximum width in the body of a struct lit before falling back to vertical formatting";
+        "Maximum width in the body of a struct lit expressions before falling back to vertical \
+         formatting";
+    struct_lit_pattern_width: usize, 18,
+        "Maximum width in the body of a struct lit patterns before falling back to vertical \
+         formatting";
     struct_variant_width: usize, 35,
         "Maximum width in the body of a struct variant before falling back to vertical formatting";
     force_explicit_abi: bool, true, "Always print the abi for extern items";

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -25,7 +25,7 @@ use config::{Config, ControlBraceStyle, IndentStyle, MultilineStyle, Style};
 use items::{span_hi_for_arg, span_lo_for_arg};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
             struct_lit_shape, struct_lit_tactic, write_list, DefinitiveListTactic, ListFormatting,
-            ListItem, ListTactic, Separator, SeparatorTactic};
+            ListItem, ListTactic, Separator, SeparatorTactic, StructLitKind};
 use macros::{rewrite_macro, MacroPosition};
 use patterns::{can_be_overflowed_pat, TuplePatField};
 use rewrite::{Rewrite, RewriteContext};
@@ -2541,7 +2541,13 @@ fn rewrite_struct_lit<'a>(
     }
 
     // Foo { a: Foo } - indent is +3, width is -5.
-    let (h_shape, v_shape) = try_opt!(struct_lit_shape(shape, context, path_str.len() + 3, 2));
+    let (h_shape, v_shape) = try_opt!(struct_lit_shape(
+        shape,
+        context,
+        StructLitKind::Expr,
+        path_str.len() + 3,
+        2,
+    ));
 
     let one_line_width = h_shape.map_or(0, |shape| shape.width);
     let body_lo = context.codemap.span_after(span, "{");

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -680,10 +680,17 @@ fn comment_len(comment: Option<&str>) -> usize {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum StructLitKind {
+    Expr,
+    Pat,
+}
+
 // Compute horizontal and vertical shapes for a struct-lit-like thing.
 pub fn struct_lit_shape(
     shape: Shape,
     context: &RewriteContext,
+    kind: StructLitKind,
     prefix_width: usize,
     suffix_width: usize,
 ) -> Option<(Option<Shape>, Shape)> {
@@ -701,7 +708,11 @@ pub fn struct_lit_shape(
     };
     let shape_width = shape.width.checked_sub(prefix_width + suffix_width);
     if let Some(w) = shape_width {
-        let shape_width = cmp::min(w, context.config.struct_lit_width());
+        let cap = match kind {
+            StructLitKind::Expr => context.config.struct_lit_width(),
+            StructLitKind::Pat => context.config.struct_lit_pattern_width(),
+        };
+        let shape_width = cmp::min(w, cap);
         Some((Some(Shape::legacy(shape_width, shape.indent)), v_shape))
     } else {
         Some((None, v_shape))

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -18,7 +18,7 @@ use comment::FindUncommented;
 use expr::{can_be_overflowed_expr, rewrite_call_inner, rewrite_pair, rewrite_unary_prefix,
            wrap_struct_field};
 use lists::{itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
-            struct_lit_tactic, write_list, DefinitiveListTactic, SeparatorTactic};
+            struct_lit_tactic, write_list, DefinitiveListTactic, SeparatorTactic, StructLitKind};
 use rewrite::{Rewrite, RewriteContext};
 use types::{rewrite_path, PathContext};
 use utils::{format_mutability, mk_sp, wrap_str};
@@ -149,6 +149,7 @@ fn rewrite_struct_pat(
     let (h_shape, v_shape) = try_opt!(struct_lit_shape(
         shape,
         context,
+        StructLitKind::Pat,
         path_str.len() + 3,
         elipses_str.len() + 2,
     ));

--- a/tests/source/configs-struct_lit_pattern_width-above.rs
+++ b/tests/source/configs-struct_lit_pattern_width-above.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_pattern_width: 10
+// Struct literal-style
+
+fn main() {
+    let Lorem { ipsum: dolor, sit: amet } = lorem;
+}

--- a/tests/source/configs-struct_lit_pattern_width-below.rs
+++ b/tests/source/configs-struct_lit_pattern_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_pattern_width: 100
+// Struct literal-style
+
+fn main() {
+    let Lorem { ipsum: dolor, sit: amet } = lorem;
+}

--- a/tests/target/configs-struct_lit_pattern_width-above.rs
+++ b/tests/target/configs-struct_lit_pattern_width-above.rs
@@ -1,0 +1,9 @@
+// rustfmt-struct_lit_pattern_width: 10
+// Struct literal-style
+
+fn main() {
+    let Lorem {
+        ipsum: dolor,
+        sit: amet,
+    } = lorem;
+}

--- a/tests/target/configs-struct_lit_pattern_width-below.rs
+++ b/tests/target/configs-struct_lit_pattern_width-below.rs
@@ -1,0 +1,6 @@
+// rustfmt-struct_lit_pattern_width: 100
+// Struct literal-style
+
+fn main() {
+    let Lorem { ipsum: dolor, sit: amet } = lorem;
+}


### PR DESCRIPTION
This allows controlling the width of struct literal patterns separately from struct literal expressions.