### PR TITLE
Add overflow_closures and overflow_match_arms opts

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1265,6 +1265,64 @@ Maximum width of each line
 
 See also [`error_on_line_overflow`](#error_on_line_overflow).
 
+## `multiline_closure_forces_block`
+
+Force multiline closure bodies to be wrapped in a block
+
+- **Default value**: `false`
+- **Possible values**: `false`, `true`
+
+#### `false`:
+
+```rust
+result.and_then(|maybe_value| match maybe_value {
+    None => ...,
+    Some(value) => ...,
+})
+```
+
+#### `true`:
+
+```rust
+result.and_then(|maybe_value| {
+    match maybe_value {
+        None => ...,
+        Some(value) => ...,
+    }
+})
+```
+
+## `multiline_match_arm_forces_block`
+
+Force multiline match arm bodies to be wrapped in a block
+
+- **Default value**: `false`
+- **Possible values**: `false`, `true`
+
+#### `false`:
+
+```rust
+match lorem {
+    None => if ipsum {
+        println!("Hello World");
+    },
+    Some(dolor) => ...,
+}
+```
+
+#### `true`:
+
+```rust
+match lorem {
+    None => {
+        if ipsum {
+            println!("Hello World");
+        }
+    }
+    Some(dolor) => ...,
+}
+```
+
 ## `newline_style`
 
 Unix or Windows line endings

--- a/src/config.rs
+++ b/src/config.rs
@@ -615,6 +615,10 @@ create_config! {
         "Try to put attributes on the same line as fields.";
     attributes_on_same_line_as_variant: bool, true,
         "Try to put attributes on the same line as variants in enum declarations.";
+    multiline_closure_forces_block: bool, false,
+        "Force multiline closure bodies to be wrapped in a block";
+    multiline_match_arm_forces_block: bool, false,
+        "Force multiline match arm bodies to be wrapped in a block";
 }
 
 #[cfg(test)]

--- a/tests/source/configs-multiline_closure_forces_block-false.rs
+++ b/tests/source/configs-multiline_closure_forces_block-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-multiline_closure_forces_block: false
+// Option forces multiline closure bodies to be wrapped in a block
+
+fn main() {
+    result.and_then(|maybe_value| {
+        match maybe_value {
+            None => Err("oops"),
+            Some(value) => Ok(1),
+        }
+    });
+}

--- a/tests/source/configs-multiline_closure_forces_block-true.rs
+++ b/tests/source/configs-multiline_closure_forces_block-true.rs
@@ -1,0 +1,9 @@
+// rustfmt-multiline_closure_forces_block: true
+// Option forces multiline closure bodies to be wrapped in a block
+
+fn main() {
+    result.and_then(|maybe_value| match maybe_value {
+        None => Err("oops"),
+        Some(value) => Ok(1),
+    });
+}

--- a/tests/source/configs-multiline_match_arm_forces_block-false.rs
+++ b/tests/source/configs-multiline_match_arm_forces_block-false.rs
@@ -1,0 +1,13 @@
+// rustfmt-multiline_match_arm_forces_block: false
+// Option forces multiline match arm bodies to be wrapped in a block
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            if ipsum {
+                println!("dolor");
+            }
+        }
+        Lorem::Dolor => println!("amet"),
+    }
+}

--- a/tests/source/configs-multiline_match_arm_forces_block-true.rs
+++ b/tests/source/configs-multiline_match_arm_forces_block-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-multiline_match_arm_forces_block: true
+// Option forces multiline match arm bodies to be wrapped in a block
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => if ipsum {
+            println!("dolor");
+        },
+        Lorem::Dolor => println!("amet"),
+    }
+}

--- a/tests/target/configs-multiline_closure_forces_block-false.rs
+++ b/tests/target/configs-multiline_closure_forces_block-false.rs
@@ -1,0 +1,9 @@
+// rustfmt-multiline_closure_forces_block: false
+// Option forces multiline closure bodies to be wrapped in a block
+
+fn main() {
+    result.and_then(|maybe_value| match maybe_value {
+        None => Err("oops"),
+        Some(value) => Ok(1),
+    });
+}

--- a/tests/target/configs-multiline_closure_forces_block-true.rs
+++ b/tests/target/configs-multiline_closure_forces_block-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-multiline_closure_forces_block: true
+// Option forces multiline closure bodies to be wrapped in a block
+
+fn main() {
+    result.and_then(|maybe_value| {
+        match maybe_value {
+            None => Err("oops"),
+            Some(value) => Ok(1),
+        }
+    });
+}

--- a/tests/target/configs-multiline_match_arm_forces_block-false.rs
+++ b/tests/target/configs-multiline_match_arm_forces_block-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-multiline_match_arm_forces_block: false
+// Option forces multiline match arm bodies to be wrapped in a block
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => if ipsum {
+            println!("dolor");
+        },
+        Lorem::Dolor => println!("amet"),
+    }
+}

--- a/tests/target/configs-multiline_match_arm_forces_block-true.rs
+++ b/tests/target/configs-multiline_match_arm_forces_block-true.rs
@@ -1,0 +1,13 @@
+// rustfmt-multiline_match_arm_forces_block: true
+// Option forces multiline match arm bodies to be wrapped in a block
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            if ipsum {
+                println!("dolor");
+            }
+        }
+        Lorem::Dolor => println!("amet"),
+    }
+}


### PR DESCRIPTION
cc https://github.com/rust-lang-nursery/rustfmt/issues/1791

## `overflow_closures`

Allow overflow on closures

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`:

```rust
result.and_then(|maybe_value| match maybe_value {
    None => ...,
    Some(value) => ...,
})
```

#### `false`:

```rust
result.and_then(|maybe_value| {
    match maybe_value {
        None => ...,
        Some(value) => ...,
    }
})
```

## `overflow_match_arms`

Allow overflow on match arms

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`:

```rust
match lorem {
    None => if ipsum {
        println!("Hello World");
    },
    Some(dolor) => ...,
}
```

#### `false`:

```rust
match lorem {
    None => {
        if ipsum {
            println!("Hello World");
        }
    }
    Some(dolor) => ...,
}
```