### PR TITLE
Add attributes_on_same_line_as_{field,variant} configs

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -100,6 +100,66 @@ let lorem = vec!["ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "
 #### Lines longer than `array_width`:
 See [`array_layout`](#array_layout).
 
+## `attributes_on_same_line_as_field`
+
+Try to put attributes on the same line as fields
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `true`
+
+```rust
+struct Lorem {
+    #[serde(rename = "Ipsum")] ipsum: usize,
+    #[serde(rename = "Dolor")] dolor: usize,
+    #[serde(rename = "Amet")] amet: usize,
+}
+```
+
+#### `false`
+
+```rust
+struct Lorem {
+    #[serde(rename = "Ipsum")]
+    ipsum: usize,
+    #[serde(rename = "Dolor")]
+    dolor: usize,
+    #[serde(rename = "Amet")]
+    amet: usize,
+}
+```
+
+## `attributes_on_same_line_as_variant`
+
+Try to put attributes on the same line as variants
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `true`
+
+```rust
+enum Lorem {
+    #[serde(skip_serializing)] Ipsum,
+    #[serde(skip_serializing)] Dolor,
+    #[serde(skip_serializing)] Amet,
+}
+```
+
+#### `false`
+
+```rust
+enum Lorem {
+    #[serde(skip_serializing)]
+    Ipsum,
+    #[serde(skip_serializing)]
+    Dolor,
+    #[serde(skip_serializing)]
+    Amet,
+}
+```
+
 ## `chain_indent`
 
 Indentation of chain

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,10 @@ create_config! {
                                              threshold.";
     remove_blank_lines_at_start_or_end_of_block: bool, true,
         "Remove blank lines at start or end of a block";
+    attributes_on_same_line_as_field: bool, true,
+        "Try to put attributes on the same line as fields.";
+    attributes_on_same_line_as_variant: bool, true,
+        "Try to put attributes on the same line as variants in enum declarations.";
 }
 
 #[cfg(test)]

--- a/src/items.rs
+++ b/src/items.rs
@@ -548,13 +548,16 @@ impl<'a> FmtVisitor<'a> {
             },
         };
 
+        let attrs_extendable = attrs_str.is_empty() ||
+            (context.config.attributes_on_same_line_as_variant() &&
+                is_attributes_extendable(&attrs_str));
         combine_strs_with_missing_comments(
             &context,
             &attrs_str,
             &variant_body,
             span,
             shape,
-            is_attributes_extendable(&attrs_str),
+            attrs_extendable,
         )
     }
 }
@@ -1413,6 +1416,8 @@ pub fn rewrite_struct_field(
     let prefix = try_opt!(rewrite_struct_field_prefix(context, field));
 
     let attrs_str = try_opt!(field.attrs.rewrite(context, shape));
+    let attrs_extendable = attrs_str.is_empty() ||
+        (context.config.attributes_on_same_line_as_field() && is_attributes_extendable(&attrs_str));
     let missing_span = if field.attrs.is_empty() {
         mk_sp(field.span.lo, field.span.lo)
     } else {
@@ -1430,7 +1435,7 @@ pub fn rewrite_struct_field(
         &prefix,
         missing_span,
         shape,
-        is_attributes_extendable(&attrs_str),
+        attrs_extendable,
     ));
     let overhead = last_line_width(&attr_prefix);
     let lhs_offset = lhs_max_width.checked_sub(overhead).unwrap_or(0);
@@ -1438,9 +1443,7 @@ pub fn rewrite_struct_field(
         spacing.push(' ');
     }
     // In this extreme case we will be missing a space betweeen an attribute and a field.
-    if prefix.is_empty() && !attrs_str.is_empty() && is_attributes_extendable(&attrs_str) &&
-        spacing.is_empty()
-    {
+    if prefix.is_empty() && !attrs_str.is_empty() && attrs_extendable && spacing.is_empty() {
         spacing.push(' ');
     }
     let ty_rewritten = rewrite_struct_field_type(context, overhead, field, &spacing, shape);
@@ -1488,7 +1491,7 @@ pub fn rewrite_struct_field(
         &field_str,
         missing_span,
         shape,
-        is_attributes_extendable(&attrs_str),
+        attrs_extendable,
     )
 }
 

--- a/tests/source/configs-attributes_on_same_line_as_field-false.rs
+++ b/tests/source/configs-attributes_on_same_line_as_field-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_field: false
+// Option to place attributes on the same line as fields where possible
+
+struct Lorem {
+    #[ serde(rename = "Ipsum") ]
+    ipsum: usize,
+    #[ serde(rename = "Dolor") ]
+    dolor: usize,
+    #[ serde(rename = "Amet") ]
+    amet: usize,
+}

--- a/tests/source/configs-attributes_on_same_line_as_field-true.rs
+++ b/tests/source/configs-attributes_on_same_line_as_field-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_field: true
+// Option to place attributes on the same line as fields where possible
+
+struct Lorem {
+    #[ serde(rename = "Ipsum") ]
+    ipsum: usize,
+    #[ serde(rename = "Dolor") ]
+    dolor: usize,
+    #[ serde(rename = "Amet") ]
+    amet: usize,
+}

--- a/tests/source/configs-attributes_on_same_line_as_variant-false.rs
+++ b/tests/source/configs-attributes_on_same_line_as_variant-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_variant: false
+// Option to place attributes on the same line as variants where possible
+
+enum Lorem {
+    #[ serde(skip_serializing) ]
+    Ipsum,
+    #[ serde(skip_serializing) ]
+    Dolor,
+    #[ serde(skip_serializing) ]
+    Amet,
+}

--- a/tests/source/configs-attributes_on_same_line_as_variant-true.rs
+++ b/tests/source/configs-attributes_on_same_line_as_variant-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_variant: true
+// Option to place attributes on the same line as variants where possible
+
+enum Lorem {
+    #[ serde(skip_serializing) ]
+    Ipsum,
+    #[ serde(skip_serializing) ]
+    Dolor,
+    #[ serde(skip_serializing) ]
+    Amet,
+}

--- a/tests/target/configs-attributes_on_same_line_as_field-false.rs
+++ b/tests/target/configs-attributes_on_same_line_as_field-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_field: false
+// Option to place attributes on the same line as fields where possible
+
+struct Lorem {
+    #[serde(rename = "Ipsum")]
+    ipsum: usize,
+    #[serde(rename = "Dolor")]
+    dolor: usize,
+    #[serde(rename = "Amet")]
+    amet: usize,
+}

--- a/tests/target/configs-attributes_on_same_line_as_field-true.rs
+++ b/tests/target/configs-attributes_on_same_line_as_field-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-attributes_on_same_line_as_field: true
+// Option to place attributes on the same line as fields where possible
+
+struct Lorem {
+    #[serde(rename = "Ipsum")] ipsum: usize,
+    #[serde(rename = "Dolor")] dolor: usize,
+    #[serde(rename = "Amet")] amet: usize,
+}

--- a/tests/target/configs-attributes_on_same_line_as_variant-false.rs
+++ b/tests/target/configs-attributes_on_same_line_as_variant-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-attributes_on_same_line_as_variant: false
+// Option to place attributes on the same line as variants where possible
+
+enum Lorem {
+    #[serde(skip_serializing)]
+    Ipsum,
+    #[serde(skip_serializing)]
+    Dolor,
+    #[serde(skip_serializing)]
+    Amet,
+}

--- a/tests/target/configs-attributes_on_same_line_as_variant-true.rs
+++ b/tests/target/configs-attributes_on_same_line_as_variant-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-attributes_on_same_line_as_variant: true
+// Option to place attributes on the same line as variants where possible
+
+enum Lorem {
+    #[serde(skip_serializing)] Ipsum,
+    #[serde(skip_serializing)] Dolor,
+    #[serde(skip_serializing)] Amet,
+}


### PR DESCRIPTION
## `attributes_on_same_line_as_field`

Try to put attributes on the same line as fields

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`

```rust
struct Lorem {
    #[serde(rename = "Ipsum")] ipsum: usize,
    #[serde(rename = "Dolor")] dolor: usize,
    #[serde(rename = "Amet")] amet: usize,
}
```

#### `false`

```rust
struct Lorem {
    #[serde(rename = "Ipsum")]
    ipsum: usize,
    #[serde(rename = "Dolor")]
    dolor: usize,
    #[serde(rename = "Amet")]
    amet: usize,
}
```

## `attributes_on_same_line_as_variant`

Try to put attributes on the same line as variants

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`

```rust
enum Lorem {
    #[serde(skip_serializing)] Ipsum,
    #[serde(skip_serializing)] Dolor,
    #[serde(skip_serializing)] Amet,
}
```

#### `false`

```rust
enum Lorem {
    #[serde(skip_serializing)]
    Ipsum,
    #[serde(skip_serializing)]
    Dolor,
    #[serde(skip_serializing)]
    Amet,
}
```