### PR TITLE
Add fn_call_trailing_comma option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -696,6 +696,45 @@ lorem("lorem",
       "elit");
 ```
 
+See also: [`fn_call_trailing_comma`](#fn_call_trailing_comma).
+
+## `fn_call_trailing_comma`
+
+Use a trailing comma for multi-line function call argument lists
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `true`
+
+```rust
+fn_with_many_args(
+    my_first_argument,
+    my_second_argument,
+    my_third_argument,
+    my_fourth_argument,
+    my_fifth_argument,
+    my_sixth_argument,
+    my_seventh_argument,
+    my_eighth_argument,
+);
+```
+
+#### `false`
+
+```rust
+fn_with_many_args(
+    my_first_argument,
+    my_second_argument,
+    my_third_argument,
+    my_fourth_argument,
+    my_fifth_argument,
+    my_sixth_argument,
+    my_seventh_argument,
+    my_eighth_argument
+);
+```
+
 ## `fn_call_width`
 
 Maximum width of the args of a function call before falling back to vertical formatting
@@ -1800,7 +1839,7 @@ let Lorem {
 } = elit;
 ```
 
-See also: [`match_block_trailing_comma`](#match_block_trailing_comma).
+See also: [`match_block_trailing_comma`](#match_block_trailing_comma), [`fn_call_trailing_comma`](#fn_call_trailing_comma).
 
 ## `trailing_semicolon`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,8 @@ create_config! {
                                              threshold.";
     remove_blank_lines_at_start_or_end_of_block: bool, true,
         "Remove blank lines at start or end of a block";
+    fn_call_trailing_comma: bool, true,
+        "Use a trailing comma for multi-line function call argument lists.";
 }
 
 #[cfg(test)]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2154,7 +2154,9 @@ where
     let fmt = ListFormatting {
         tactic: tactic,
         separator: ",",
-        trailing_separator: if force_trailing_comma {
+        trailing_separator: if !context.config.fn_call_trailing_comma() {
+            SeparatorTactic::Never
+        } else if force_trailing_comma {
             SeparatorTactic::Always
         } else if context.inside_macro || !context.use_block_indent() {
             SeparatorTactic::Never

--- a/tests/source/configs-fn_call_trailing_comma-false.rs
+++ b/tests/source/configs-fn_call_trailing_comma-false.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_trailing_comma: false
+// Option to insert trailing commas in vertical function calls
+
+fn main() {
+    fn_with_many_args(
+        my_first_argument,
+        my_second_argument,
+        my_third_argument,
+        my_fourth_argument,
+        my_fifth_argument,
+        my_sixth_argument,
+        my_seventh_argument,
+        my_eighth_argument,
+    );
+}

--- a/tests/source/configs-fn_call_trailing_comma-true.rs
+++ b/tests/source/configs-fn_call_trailing_comma-true.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_trailing_comma: true
+// Option to insert trailing commas in vertical function calls
+
+fn main() {
+    fn_with_many_args(
+        my_first_argument,
+        my_second_argument,
+        my_third_argument,
+        my_fourth_argument,
+        my_fifth_argument,
+        my_sixth_argument,
+        my_seventh_argument,
+        my_eighth_argument
+    );
+}

--- a/tests/target/configs-fn_call_trailing_comma-false.rs
+++ b/tests/target/configs-fn_call_trailing_comma-false.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_trailing_comma: false
+// Option to insert trailing commas in vertical function calls
+
+fn main() {
+    fn_with_many_args(
+        my_first_argument,
+        my_second_argument,
+        my_third_argument,
+        my_fourth_argument,
+        my_fifth_argument,
+        my_sixth_argument,
+        my_seventh_argument,
+        my_eighth_argument
+    );
+}

--- a/tests/target/configs-fn_call_trailing_comma-true.rs
+++ b/tests/target/configs-fn_call_trailing_comma-true.rs
@@ -1,0 +1,15 @@
+// rustfmt-fn_call_trailing_comma: true
+// Option to insert trailing commas in vertical function calls
+
+fn main() {
+    fn_with_many_args(
+        my_first_argument,
+        my_second_argument,
+        my_third_argument,
+        my_fourth_argument,
+        my_fifth_argument,
+        my_sixth_argument,
+        my_seventh_argument,
+        my_eighth_argument,
+    );
+}


### PR DESCRIPTION
I find the trailing-commas-on-function-calls change to be a rather radical one (I can't think of another programming language where this is standard), so it seems an oversight to not provide an option to disable it. (Also, in my experience the implementation in rustfmt is a bit buggy and inconsistent, particularly with single-argument function calls and the mixing of function calls and tuples.)

## `fn_call_trailing_comma`

Use a trailing comma for multi-line function call argument lists

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`

```rust
fn_with_many_args(
    my_first_argument,
    my_second_argument,
    my_third_argument,
    my_fourth_argument,
    my_fifth_argument,
    my_sixth_argument,
    my_seventh_argument,
    my_eighth_argument,
);
```

#### `false`

```rust
fn_with_many_args(
    my_first_argument,
    my_second_argument,
    my_third_argument,
    my_fourth_argument,
    my_fifth_argument,
    my_sixth_argument,
    my_seventh_argument,
    my_eighth_argument
);
```