### PR TITLE
Add treat_match_arm_bodies_as_statements option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1823,6 +1823,31 @@ fn foo() -> usize {
 }
 ```
 
+## `treat_match_arm_bodies_as_statements`
+
+Format match arm bodies like freestanding statements instead of sub-expressions
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+#### `true`:
+```rust
+match lorem {
+    Ipsum(dolor) => if dolor {
+        0
+    } else {
+        1
+    },
+}
+```
+
+#### `false`:
+```rust
+match lorem {
+    Ipsum(dolor) => if dolor { 0 } else { 1 },
+}
+```
+
 ## `type_punctuation_density`
 
 Determines if `+` or `=` are wrapped in spaces in the punctuation of types

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,8 @@ create_config! {
                                              threshold.";
     remove_blank_lines_at_start_or_end_of_block: bool, true,
         "Remove blank lines at start or end of a block";
+    treat_match_arm_bodies_as_statements: bool, true,
+        "Format match arm bodies like freestanding statements instead of sub-expressions.";
 }
 
 #[cfg(test)]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1774,8 +1774,13 @@ fn rewrite_match_body(
         .offset_left(extra_offset(&pats_str, shape) + 4)
         .and_then(|shape| shape.sub_width(comma.len()));
     let orig_body = if let Some(body_shape) = orig_body_shape {
+        let expr_type = if context.config.treat_match_arm_bodies_as_statements() {
+            ExprType::Statement
+        } else {
+            ExprType::SubExpression
+        };
         let rewrite = nop_block_collapse(
-            format_expr(body, ExprType::Statement, context, body_shape),
+            format_expr(body, expr_type, context, body_shape),
             body_shape.width,
         );
 

--- a/tests/source/configs-treat_match_arm_bodies_as_statements-false.rs
+++ b/tests/source/configs-treat_match_arm_bodies_as_statements-false.rs
@@ -1,0 +1,12 @@
+// rustfmt-treat_match_arm_bodies_as_statements: false
+// Option to format match arm bodies like freestanding statements
+
+fn main() {
+    match lorem {
+        Ipsum(dolor) => if dolor {
+            0
+        } else {
+            1
+        },
+    }
+}

--- a/tests/source/configs-treat_match_arm_bodies_as_statements-true.rs
+++ b/tests/source/configs-treat_match_arm_bodies_as_statements-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-treat_match_arm_bodies_as_statements: true
+// Option to format match arm bodies like freestanding statements
+
+fn main() {
+    match lorem {
+        Ipsum(dolor) => if dolor { 0 } else { 1 },
+    }
+}

--- a/tests/target/configs-treat_match_arm_bodies_as_statements-false.rs
+++ b/tests/target/configs-treat_match_arm_bodies_as_statements-false.rs
@@ -1,0 +1,8 @@
+// rustfmt-treat_match_arm_bodies_as_statements: false
+// Option to format match arm bodies like freestanding statements
+
+fn main() {
+    match lorem {
+        Ipsum(dolor) => if dolor { 0 } else { 1 },
+    }
+}

--- a/tests/target/configs-treat_match_arm_bodies_as_statements-true.rs
+++ b/tests/target/configs-treat_match_arm_bodies_as_statements-true.rs
@@ -1,0 +1,12 @@
+// rustfmt-treat_match_arm_bodies_as_statements: true
+// Option to format match arm bodies like freestanding statements
+
+fn main() {
+    match lorem {
+        Ipsum(dolor) => if dolor {
+            0
+        } else {
+            1
+        },
+    }
+}


### PR DESCRIPTION
## `treat_match_arm_bodies_as_statements`

Format match arm bodies like freestanding statements instead of sub-expressions

- **Default value**: `true`
- **Possible values**: `true`, `false`

#### `true`:
```rust
match lorem {
    Ipsum(dolor) => if dolor {
        0
    } else {
        1
    },
}
```

#### `false`:
```rust
match lorem {
    Ipsum(dolor) => if dolor { 0 } else { 1 },
}
```