### PR TITLE
Add favor_indenting_rhs_in_locals option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -387,6 +387,36 @@ Error if unable to get all lines within max_width
 
 See also [`max_width`](#max_width).
 
+## `favor_indenting_rhs_in_locals`
+
+Prefer indenting the entire RHS in locals when it involves less line breaks in
+the RHS itself
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+
+#### `false`:
+
+```rust
+let a_really_long_variable_name = if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaaaaaa"
+{
+    Some(42)
+} else {
+    None
+};
+```
+
+#### `true`:
+
+```rust
+let a_really_long_variable_name =
+    if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaaaaaa" {
+        Some(42)
+    } else {
+        None
+    };
+```
+
 ## `fn_args_density`
 
 Argument density in functions

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,9 @@ create_config! {
                                              threshold.";
     remove_blank_lines_at_start_or_end_of_block: bool, true,
         "Remove blank lines at start or end of a block";
+    favor_indenting_rhs_in_locals: bool, false,
+        "Prefer indenting the entire RHS in locals when it involves less line breaks in the RHS \
+         itself.";
 }
 
 #[cfg(test)]

--- a/tests/source/configs-favor_indenting_rhs_in_locals-false.rs
+++ b/tests/source/configs-favor_indenting_rhs_in_locals-false.rs
@@ -1,0 +1,10 @@
+// rustfmt-favor_indenting_rhs_in_locals: false
+// Option to prefer indenting RHS in locals vs splitting lines
+
+fn main() {
+    let a_really_long_variable_name = if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaa" {
+        Some(42)
+    } else {
+        None
+    };
+}

--- a/tests/source/configs-favor_indenting_rhs_in_locals-true.rs
+++ b/tests/source/configs-favor_indenting_rhs_in_locals-true.rs
@@ -1,0 +1,10 @@
+// rustfmt-favor_indenting_rhs_in_locals: true
+// Option to prefer indenting RHS in locals vs splitting lines
+
+fn main() {
+    let a_really_long_variable_name = if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaa" {
+        Some(42)
+    } else {
+        None
+    };
+}

--- a/tests/target/configs-favor_indenting_rhs_in_locals-false.rs
+++ b/tests/target/configs-favor_indenting_rhs_in_locals-false.rs
@@ -1,0 +1,11 @@
+// rustfmt-favor_indenting_rhs_in_locals: false
+// Option to prefer indenting RHS in locals vs splitting lines
+
+fn main() {
+    let a_really_long_variable_name = if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaa"
+    {
+        Some(42)
+    } else {
+        None
+    };
+}

--- a/tests/target/configs-favor_indenting_rhs_in_locals-true.rs
+++ b/tests/target/configs-favor_indenting_rhs_in_locals-true.rs
@@ -1,0 +1,11 @@
+// rustfmt-favor_indenting_rhs_in_locals: true
+// Option to prefer indenting RHS in locals vs splitting lines
+
+fn main() {
+    let a_really_long_variable_name =
+        if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaa" {
+            Some(42)
+        } else {
+            None
+        };
+}


### PR DESCRIPTION
## `favor_indenting_rhs_in_locals`

Prefer indenting the entire RHS in locals when it involves less line breaks in
the RHS itself

- **Default value**: `false`
- **Possible values**: `true`, `false`

#### `false`:

```rust
let a_really_long_variable_name = if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaaaaaa"
{
    Some(42)
} else {
    None
};
```

#### `true`:

```rust
let a_really_long_variable_name =
    if lorem_ipsum_dolor.amet() == 0 && foo_bar_baz.quux != "aaaaaaa" {
        Some(42)
    } else {
        None
    };
```