### PR TITLE
Fix wrapping of bounds in associated types

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1551,7 +1551,8 @@ pub fn rewrite_associated_type(
     let prefix = format!("type {}", ident);
 
     let type_bounds_str = if let Some(ty_param_bounds) = ty_param_bounds_opt {
-        let shape = Shape::indented(indent, context.config);
+        // 2 = ": ".len()
+        let shape = try_opt!(Shape::indented(indent, context.config).offset_left(prefix.len() + 2));
         let bounds: &[_] = ty_param_bounds;
         let bound_str = try_opt!(
             bounds

--- a/tests/source/associated-types-bounds-wrapping.rs
+++ b/tests/source/associated-types-bounds-wrapping.rs
@@ -1,0 +1,6 @@
+// rustfmt-max_width: 100
+// Test proper wrapping of long associated type bounds
+
+pub trait HttpService {
+    type WsService: 'static + Service<Request = WsCommand, Response = WsResponse, Error = ServerError>;
+}

--- a/tests/target/associated-types-bounds-wrapping.rs
+++ b/tests/target/associated-types-bounds-wrapping.rs
@@ -1,0 +1,7 @@
+// rustfmt-max_width: 100
+// Test proper wrapping of long associated type bounds
+
+pub trait HttpService {
+    type WsService: 'static
+        + Service<Request = WsCommand, Response = WsResponse, Error = ServerError>;
+}


### PR DESCRIPTION
Bounds were wrapped to the full width of the line rather then the width available after the "type ...: ", resulting in rustfmt unnecessarily producing lines that were longer than the maximum width.

With a max line width of 100, rustfmt would force the following formatting:

```rust
pub trait HttpService {
    type WsService: 'static + Service<Request = WsCommand, Response = WsResponse, Error = ServerError>;
    // ^ error: line width 103
}
```

whereas the correct formatting is:

```rust
pub trait HttpService {
    type WsService: 'static
        + Service<Request = WsCommand, Response = WsResponse, Error = ServerError>;
}
```