### PR TITLE
Fix legacy control format producing too long lines

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1134,10 +1134,17 @@ impl<'a> ControlFlow<'a> {
         // 1 = space after keyword.
         let offset = self.keyword.len() + label_string.len() + 1;
 
+        let brace_overhead =
+            if context.config.control_brace_style() != ControlBraceStyle::AlwaysNextLine {
+                // 2 = ` {`
+                2
+            } else {
+                0
+            };
         let pat_expr_string = match self.cond {
             Some(cond) => {
                 let cond_shape = match context.config.control_style() {
-                    Style::Legacy => try_opt!(constr_shape.shrink_left(offset)),
+                    Style::Legacy => try_opt!(constr_shape.shrink_left(offset + brace_overhead)),
                     Style::Rfc => try_opt!(constr_shape.offset_left(offset)),
                 };
                 try_opt!(rewrite_pat_expr(
@@ -1153,13 +1160,6 @@ impl<'a> ControlFlow<'a> {
             None => String::new(),
         };
 
-        let brace_overhead =
-            if context.config.control_brace_style() != ControlBraceStyle::AlwaysNextLine {
-                // 2 = ` {`
-                2
-            } else {
-                0
-            };
         let one_line_budget = context
             .config
             .max_width()

--- a/tests/source/legacy-control-style-wrap.rs
+++ b/tests/source/legacy-control-style-wrap.rs
@@ -1,0 +1,11 @@
+// rustfmt-max_width: 100
+// rustfmt-control_style: Legacy
+// Ensure legacy control style produces correct wrapping
+
+fn main () {
+    let aaaaaaaaaa_bbbbbb_cccccc_ddddd = if aaaaaaa_bbbb.cc_dddd() && !aaaaaa.bbbbbbbbbb.cc_ddddd() {
+        Some(1)
+    } else {
+        None
+    };
+}

--- a/tests/target/legacy-control-style-wrap.rs
+++ b/tests/target/legacy-control-style-wrap.rs
@@ -1,0 +1,12 @@
+// rustfmt-max_width: 100
+// rustfmt-control_style: Legacy
+// Ensure legacy control style produces correct wrapping
+
+fn main() {
+    let aaaaaaaaaa_bbbbbb_cccccc_ddddd = if aaaaaaa_bbbb.cc_dddd() &&
+                                              !aaaaaa.bbbbbbbbbb.cc_ddddd() {
+        Some(1)
+    } else {
+        None
+    };
+}


### PR DESCRIPTION
Legacy control formatting did not take into account the length of the " {", producing line-too-long errors with lines within two characters of the maximum line width.

With a max line with of 100, rustfmt would enforce the following formatting:

```rust
    let aaaaaaaaaa_bbbbbb_cccccc_ddddd = if aaaaaaa_bbbb.cc_dddd() && !aaaaaa.bbbbbbbbbb.cc_ddddd() {
        // ^ error: 101 chars
        Some(1)
    } else {
        None
    };
```

The correct formatting is:

```rust
    let aaaaaaaaaa_bbbbbb_cccccc_ddddd = if aaaaaaa_bbbb.cc_dddd() &&
                                              !aaaaaa.bbbbbbbbbb.cc_ddddd() {
        Some(1)
    } else {
        None
    };
```