### PR TITLE
Add merge_derives config option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1230,7 +1230,7 @@ Put a match sub-patterns' separator (`|`) in front or back.
 - **Default value**: `"Back"`
 - **Possible values**: `"Back"`, `"Front"`
 
-#### `"Back"`
+#### `"Back"`:
 
 ```rust
 match m {
@@ -1243,7 +1243,7 @@ match m {
 }
 ```
 
-#### `Front`
+#### `Front`:
 
 ```rust
 match m {
@@ -1265,6 +1265,31 @@ Maximum width of each line
 
 See also [`error_on_line_overflow`](#error_on_line_overflow).
 
+## `merge_derives`
+
+Merge multiple derives into a single one.
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+
+*Note*: The merged derives will be put after all other attributes or doc comments.
+
+#### `true`:
+
+```rust
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Foo {}
+```
+
+#### `false`:
+
+```rust
+#[derive(Eq, PartialEq)]
+#[derive(Debug)]
+#[derive(Copy, Clone)]
+pub enum Foo {}
+```
+
 ## `multiline_closure_forces_block`
 
 Force multiline closure bodies to be wrapped in a block
@@ -1272,23 +1297,24 @@ Force multiline closure bodies to be wrapped in a block
 - **Default value**: `false`
 - **Possible values**: `false`, `true`
 
+#### `true`:
+
+```rust
+
+result.and_then(|maybe_value| {
+    match maybe_value {
+        None => ...,
+        Some(value) => ...,
+    }
+})
+```
+
 #### `false`:
 
 ```rust
 result.and_then(|maybe_value| match maybe_value {
     None => ...,
     Some(value) => ...,
-})
-```
-
-#### `true`:
-
-```rust
-result.and_then(|maybe_value| {
-    match maybe_value {
-        None => ...,
-        Some(value) => ...,
-    }
 })
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1272,8 +1272,6 @@ Merge multiple derives into a single one.
 - **Default value**: `true`
 - **Possible values**: `true`, `false`
 
-*Note*: The merged derives will be put after all other attributes or doc comments.
-
 #### `true`:
 
 ```rust

--- a/src/config.rs
+++ b/src/config.rs
@@ -619,6 +619,7 @@ create_config! {
         "Force multiline closure bodies to be wrapped in a block";
     multiline_match_arm_forces_block: bool, false,
         "Force multiline match arm bodies to be wrapped in a block";
+    merge_derives: bool, true, "Merge multiple `#[derive(...)]` into a single one";
 }
 
 #[cfg(test)]

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -19,10 +19,10 @@ use config::{Config, IndentStyle};
 use rewrite::RewriteContext;
 use utils::{first_line_width, last_line_width, mk_sp};
 
-#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 /// Formatting tactic for lists. This will be cast down to a
 /// DefinitiveListTactic depending on the number and length of the items and
 /// their comments.
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum ListTactic {
     // One item per row.
     Vertical,
@@ -144,8 +144,8 @@ impl ListItem {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 /// The definitive formatting tactic for lists.
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum DefinitiveListTactic {
     Vertical,
     Horizontal,

--- a/tests/source/configs-merge_derives-true.rs
+++ b/tests/source/configs-merge_derives-true.rs
@@ -1,0 +1,10 @@
+// rustfmt-merge_derives: true
+// Merge multiple derives to a single one.
+
+#[bar]
+#[derive(Eq, PartialEq)]
+#[foo]
+#[derive(Debug)]
+#[foobar]
+#[derive(Copy, Clone)]
+pub enum Foo {}

--- a/tests/source/configs-merge_derives-true.rs
+++ b/tests/source/configs-merge_derives-true.rs
@@ -8,3 +8,39 @@
 #[foobar]
 #[derive(Copy, Clone)]
 pub enum Foo {}
+
+#[derive(Eq, PartialEq)]
+#[derive(Debug)]
+#[foobar]
+#[derive(Copy, Clone)]
+pub enum Bar {}
+
+#[derive(Eq, PartialEq)]
+#[derive(Debug)]
+#[derive(Copy, Clone)]
+pub enum FooBar {}
+
+mod foo {
+#[bar]
+#[derive(Eq, PartialEq)]
+#[foo]
+#[derive(Debug)]
+#[foobar]
+#[derive(Copy, Clone)]
+pub enum Foo {}
+}
+
+mod bar {
+#[derive(Eq, PartialEq)]
+#[derive(Debug)]
+#[foobar]
+#[derive(Copy, Clone)]
+pub enum Bar {}
+}
+
+mod foobar {
+#[derive(Eq, PartialEq)]
+#[derive(Debug)]
+#[derive(Copy, Clone)]
+pub enum FooBar {}
+}

--- a/tests/target/configs-merge_derives-true.rs
+++ b/tests/target/configs-merge_derives-true.rs
@@ -2,7 +2,39 @@
 // Merge multiple derives to a single one.
 
 #[bar]
+#[derive(Eq, PartialEq)]
 #[foo]
+#[derive(Debug)]
 #[foobar]
-#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub enum Foo {}
+
+#[derive(Eq, PartialEq, Debug)]
+#[foobar]
+#[derive(Copy, Clone)]
+pub enum Bar {}
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum FooBar {}
+
+mod foo {
+    #[bar]
+    #[derive(Eq, PartialEq)]
+    #[foo]
+    #[derive(Debug)]
+    #[foobar]
+    #[derive(Copy, Clone)]
+    pub enum Foo {}
+}
+
+mod bar {
+    #[derive(Eq, PartialEq, Debug)]
+    #[foobar]
+    #[derive(Copy, Clone)]
+    pub enum Bar {}
+}
+
+mod foobar {
+    #[derive(Eq, PartialEq, Debug, Copy, Clone)]
+    pub enum FooBar {}
+}

--- a/tests/target/configs-merge_derives-true.rs
+++ b/tests/target/configs-merge_derives-true.rs
@@ -1,0 +1,8 @@
+// rustfmt-merge_derives: true
+// Merge multiple derives to a single one.
+
+#[bar]
+#[foo]
+#[foobar]
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Foo {}


### PR DESCRIPTION
cc https://github.com/rust-lang-nursery/fmt-rfcs/issues/72.

Note that when there are other attributes other than `#[derive(...)]` or doc comments, the merged derives will be put after all other attributes. See the diffs in lists.rs for example.