### PR TITLE
Implement Rewrite trait for ast::ForeignItem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod patterns;
 mod summary;
 mod vertical;
 
+/// Spanned returns a span including attributes, if available.
 pub trait Spanned {
     fn span(&self) -> Span;
 }
@@ -204,6 +205,12 @@ impl Spanned for ast::TyParamBound {
             ast::TyParamBound::TraitTyParamBound(ref ptr, _) => ptr.span,
             ast::TyParamBound::RegionTyParamBound(ref l) => l.span,
         }
+    }
+}
+
+impl Spanned for ast::ForeignItem {
+    fn span(&self) -> Span {
+        span_with_attrs!(self)
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -641,7 +641,7 @@ impl<'a> FmtVisitor<'a> {
         self.push_rewrite(mac.span, rewrite);
     }
 
-    fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {
+    pub fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {
         self.format_missing_with_indent(source!(self, span).lo);
         let result = rewrite.unwrap_or_else(|| self.snippet(span));
         self.buffer.push_str(&result);

--- a/tests/source/issue-1914.rs
+++ b/tests/source/issue-1914.rs
@@ -1,0 +1,6 @@
+// rustfmt-max_width: 80
+
+extern "C" {
+#[link_name = "_ZN7MyClass26example_check_no_collisionE"]
+    pub static mut  MyClass_example_check_no_collision  :  * const :: std :: os :: raw :: c_int ;
+}

--- a/tests/target/issue-1914.rs
+++ b/tests/target/issue-1914.rs
@@ -1,0 +1,7 @@
+// rustfmt-max_width: 80
+
+extern "C" {
+    #[link_name = "_ZN7MyClass26example_check_no_collisionE"]
+    pub static mut MyClass_example_check_no_collision:
+        *const ::std::os::raw::c_int;
+}


### PR DESCRIPTION
When formatting `ast::ForeignItem`, rustfmt used to ignore attributes and did not take max width into account.

Closes #1914. Closes #1915.