### PR TITLE
Ignore empty lines inside arguments of macro with brace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,16 @@ impl Indent {
         }
     }
 
+    pub fn from_width(config: &Config, width: usize) -> Indent {
+        if config.hard_tabs() {
+            let tab_num = width / config.tab_spaces();
+            let alignment = width % config.tab_spaces();
+            Indent::new(config.tab_spaces() * tab_num, alignment)
+        } else {
+            Indent::new(width, 0)
+        }
+    }
+
     pub fn empty() -> Indent {
         Indent::new(0, 0)
     }

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -134,6 +134,21 @@ fn issue_1885() {
     }).collect::<Vec<_>>();
 }
 
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
 // Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
 // at the end of the file for now.
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -149,6 +149,21 @@ fn issue_1917() {
     }
 }
 
+fn issue_1921() {
+    // Macro with tabs.
+    lazy_static! {
+	static ref ONE: u32 = 1;
+	static ref TWO: u32 = 2;
+	static ref THREE: u32 = 3;
+	static ref FOUR: u32 = {
+		let mut acc = 1;
+		acc += 1;
+		acc += 2;
+		acc
+	}
+}
+}
+
 // Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
 // at the end of the file for now.
 

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -178,6 +178,21 @@ fn issue_1885() {
         .collect::<Vec<_>>();
 }
 
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
 // Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
 // at the end of the file for now.
 

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -193,6 +193,21 @@ fn issue_1917() {
     }
 }
 
+fn issue_1921() {
+    // Macro with tabs.
+    lazy_static! {
+        static ref ONE: u32 = 1;
+        static ref TWO: u32 = 2;
+        static ref THREE: u32 = 3;
+        static ref FOUR: u32 = {
+            let mut acc = 1;
+            acc += 1;
+            acc += 2;
+            acc
+        }
+    }
+}
+
 // Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
 // at the end of the file for now.
 


### PR DESCRIPTION
Closes #1917.
Closes #1921.