### PR TITLE
Enhance comment formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang-nursery/rustfmt"
 readme = "README.md"
 license = "Apache-2.0/MIT"
-include = ["src/*.rs", "Cargo.toml", "build.rs", "LICENSE-*"]
+include = ["src/**", "Cargo.toml", "build.rs", "LICENSE-*"]
 build = "build.rs"
 categories = ["development-tools"]
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -153,11 +153,10 @@ pub fn combine_strs_with_missing_comments(
     let mut one_line_width =
         last_line_width(prev_str) + first_line_width(next_str) + first_sep.len();
 
-    let original_snippet = context.snippet(span);
-    let trimmed_snippet = original_snippet.trim();
     let indent_str = shape.indent.to_string(context.config);
+    let missing_comment = try_opt!(rewrite_missing_comment(span, shape, context));
 
-    if trimmed_snippet.is_empty() {
+    if missing_comment.is_empty() {
         if allow_extend && prev_str.len() + first_sep.len() + next_str.len() <= shape.width {
             return Some(format!("{}{}{}", prev_str, first_sep, next_str));
         } else {
@@ -175,18 +174,13 @@ pub fn combine_strs_with_missing_comments(
     // Peek the the original source code and find out whether there is a newline between the first
     // expression and the second expression or the missing comment. We will preserve the orginal
     // layout whenever possible.
+    let original_snippet = context.snippet(span);
     let prefer_same_line = if let Some(pos) = original_snippet.chars().position(|c| c == '/') {
         !original_snippet[..pos].contains('\n')
     } else {
         !original_snippet.contains('\n')
     };
 
-    let missing_comment = try_opt!(rewrite_comment(
-        trimmed_snippet,
-        false,
-        shape,
-        context.config
-    ));
     one_line_width -= first_sep.len();
     let first_sep = if prev_str.is_empty() || missing_comment.is_empty() {
         String::new()

--- a/src/items.rs
+++ b/src/items.rs
@@ -66,7 +66,7 @@ impl Rewrite for ast::Local {
 
         // String that is placed within the assignment pattern and expression.
         let infix = {
-            let mut infix = String::new();
+            let mut infix = String::with_capacity(32);
 
             if let Some(ref ty) = self.ty {
                 let separator = type_annotation_separator(context.config);
@@ -668,7 +668,7 @@ fn format_impl_ref_and_type(
         _,
     ) = item.node
     {
-        let mut result = String::new();
+        let mut result = String::with_capacity(128);
 
         result.push_str(&format_visibility(&item.vis));
         result.push_str(&format_defaultness(defaultness));
@@ -1265,7 +1265,7 @@ pub fn rewrite_type_alias(
     vis: &ast::Visibility,
     span: Span,
 ) -> Option<String> {
-    let mut result = String::new();
+    let mut result = String::with_capacity(128);
 
     result.push_str(&format_visibility(vis));
     result.push_str("type ");

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -920,10 +920,10 @@ impl Rewrite for ast::Attribute {
 
 impl<'a> Rewrite for [ast::Attribute] {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        let mut result = String::new();
         if self.is_empty() {
-            return Some(result);
+            return Some(String::new());
         }
+        let mut result = String::with_capacity(128);
         let indent = shape.indent.to_string(context.config);
 
         let mut derive_args = Vec::new();

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -1,6 +1,19 @@
 // rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
 
+//! Doc comment
+
+#![attribute]
+
+//! Crate doc comment
+
+// Comment
+
+// Comment on attribute
+#![the(attribute)]
+
+// Another comment
+
 #[invalid attribute]
 fn foo() {}
 

--- a/tests/source/trait.rs
+++ b/tests/source/trait.rs
@@ -53,3 +53,7 @@ trait FooBar<T> : Tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt
 
 trait WhereList<T, J> where T: Foo, J: Bar {}
 
+trait X /* comment */ {}
+trait Y // comment
+{
+}

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -1,6 +1,19 @@
 // rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
 
+//! Doc comment
+
+#![attribute]
+
+//! Crate doc comment
+
+// Comment
+
+// Comment on attribute
+#![the(attribute)]
+
+// Another comment
+
 #[invalid attribute]
 fn foo() {}
 
@@ -33,11 +46,12 @@ impl Bar {
     fn f3(self) -> Dog {}
 
     /// Blah blah bing.
+
     #[attrib1]
     /// Blah blah bing.
     #[attrib2]
-    // Another comment that needs rewrite because it's
-    // tooooooooooooooooooooooooooooooo loooooooooooong.
+    // Another comment that needs rewrite because it's tooooooooooooooooooooooooooooooo
+    // loooooooooooong.
     /// Blah blah bing.
     fn f4(self) -> Cat {}
 

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -83,6 +83,7 @@ fn some_fn3() // some comment some comment some comment some comment some commen
 }
 
 fn some_fn4()
-// some comment some comment some comment some comment some comment some comment some comment
+// some comment some comment some comment some comment some comment some comment
+// some comment
 {
 }

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -1,5 +1,5 @@
-#![allow(dead_code)]
-// bar
+#![allow(dead_code)] // bar
+
 //! Doc comment
 fn test() {
     // comment

--- a/tests/target/impl.rs
+++ b/tests/target/impl.rs
@@ -18,6 +18,11 @@ where
     }
 }
 
+impl X<T> /* comment */ {}
+impl Y<T> // comment
+{
+}
+
 impl<T> Foo for T
 // comment1
 where

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -79,3 +79,8 @@ where
     J: Bar,
 {
 }
+
+trait X /* comment */ {}
+trait Y // comment
+{
+}


### PR DESCRIPTION
This PR 
1. implements `recover_missing_comments_in_span()`, which is generalized function for recovering missing comments in the given span.
2. use it to recover missing comments.
3. preserve blank line between doc comment and attribute
4. apply some refactoring (e.g. use `String::with_capacity()` instead of `String::new()`)

Closes #1887.
Closes #1911.