### PR TITLE
Add struct_remove_empty_body config option

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -387,8 +387,6 @@ impl<'a> FmtVisitor<'a> {
             Some(ref body_str) => self.buffer.push_str(body_str),
             None => if contains_comment(&enum_snippet[brace_pos..]) {
                 self.format_missing_no_indent(span.hi() - BytePos(1))
-            } else {
-                self.format_missing(span.hi() - BytePos(1))
             },
         }
         self.block_indent = self.block_indent.block_unindent(self.config);
@@ -1092,12 +1090,10 @@ pub fn format_struct_struct(
     };
     // 1 = `}`
     let overhead = if fields.is_empty() { 1 } else { 0 };
-    let max_len = context
-        .config
-        .max_width()
-        .checked_sub(offset.width())
-        .unwrap_or(0);
-    if !generics_str.contains('\n') && result.len() + generics_str.len() + overhead > max_len {
+    let total_width = result.len() + generics_str.len() + overhead;
+    if !generics_str.is_empty() && !generics_str.contains('\n') &&
+        total_width > context.config.max_width()
+    {
         result.push('\n');
         result.push_str(&offset.to_string(context.config));
         result.push_str(&generics_str.trim_left());

--- a/tests/source/configs-item_brace_style-always_next_line.rs
+++ b/tests/source/configs-item_brace_style-always_next_line.rs
@@ -1,6 +1,10 @@
 // rustfmt-item_brace_style: AlwaysNextLine
 // Item brace style
 
+enum Foo {}
+
+struct Bar {}
+
 struct Lorem {
     ipsum: bool,
 }

--- a/tests/target/configs-item_brace_style-always_next_line.rs
+++ b/tests/target/configs-item_brace_style-always_next_line.rs
@@ -1,6 +1,10 @@
 // rustfmt-item_brace_style: AlwaysNextLine
 // Item brace style
 
+enum Foo {}
+
+struct Bar {}
+
 struct Lorem
 {
     ipsum: bool,


### PR DESCRIPTION
This PR

1. adds `struct_remove_empty_body` config option which removes the empty braces from struct when set to `true`. 
2. puts the opening and the closing braces of empty struct and enum on the same line, even when `item_brace_style = AlwaysNextLine`.

~~Closes #1892.~~

## `struct_remove_empty_body`

Remove braces of empty struct definition.

- **Default value**: `false`
- **Possible values**: `false`, `true`.

*Note*: Braces with comments will not be removed.

#### `false`

```rust
struct Foo {}
Struct Bar()
struct FooBar { /* comment */ }
```

#### `true`

```rust
struct Foo;
struct Bar;
struct FooBar { /* comment */ }
```
