### PR TITLE
Format and preserve attributes on `ast::Stmt`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -180,17 +180,11 @@ pub fn format_expr(
                 )
             }
         }
-        ast::ExprKind::Yield(ref opt_expr) => {
-            if let Some(ref expr) = *opt_expr {
-                rewrite_unary_prefix(context, "yield ", &**expr, shape)
-            } else {
-                wrap_str(
-                    "yield".to_string(),
-                    context.config.max_width(),
-                    shape,
-                )
-            }
-        }
+        ast::ExprKind::Yield(ref opt_expr) => if let Some(ref expr) = *opt_expr {
+            rewrite_unary_prefix(context, "yield ", &**expr, shape)
+        } else {
+            wrap_str("yield".to_string(), context.config.max_width(), shape)
+        },
         ast::ExprKind::Closure(capture, ref fn_decl, ref body, _) => {
             rewrite_closure(capture, fn_decl, body, expr.span, context, shape)
         }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -260,7 +260,7 @@ impl<'a> FmtVisitor<'a> {
     ) {
         let vis = utils::format_visibility(vis);
         // 4 = `use `, 1 = `;`
-        let rw = Shape::indented(self.block_indent, self.config)
+        let rw = self.shape()
             .offset_left(vis.len() + 4)
             .and_then(|shape| shape.sub_width(1))
             .and_then(|shape| match vp.node {

--- a/src/items.rs
+++ b/src/items.rs
@@ -187,8 +187,7 @@ impl<'a> FmtVisitor<'a> {
 
 
     fn format_foreign_item(&mut self, item: &ast::ForeignItem) {
-        let shape = Shape::indented(self.block_indent, self.config);
-        let rewrite = item.rewrite(&self.get_context(), shape);
+        let rewrite = item.rewrite(&self.get_context(), self.shape());
         self.push_rewrite(item.span(), rewrite);
         self.last_pos = item.span.hi;
     }
@@ -312,18 +311,11 @@ impl<'a> FmtVisitor<'a> {
                                 ""
                             };
 
-                            format_expr(
-                                &e,
-                                ExprType::Statement,
-                                &self.get_context(),
-                                Shape::indented(self.block_indent, self.config),
-                            ).map(|s| s + suffix)
+                            format_expr(&e, ExprType::Statement, &self.get_context(), self.shape())
+                                .map(|s| s + suffix)
                                 .or_else(|| Some(self.snippet(e.span)))
                         }
-                        None => stmt.rewrite(
-                            &self.get_context(),
-                            Shape::indented(self.block_indent, self.config),
-                        ),
+                        None => stmt.rewrite(&self.get_context(), self.shape()),
                     }
                 } else {
                     None
@@ -421,9 +413,7 @@ impl<'a> FmtVisitor<'a> {
             false,
         );
 
-        let shape = Shape::indented(self.block_indent, self.config)
-            .sub_width(2)
-            .unwrap();
+        let shape = self.shape().sub_width(2).unwrap();
         let fmt = ListFormatting {
             tactic: DefinitiveListTactic::Vertical,
             separator: ",",
@@ -451,7 +441,7 @@ impl<'a> FmtVisitor<'a> {
 
         let context = self.get_context();
         let indent = self.block_indent;
-        let shape = Shape::indented(indent, self.config);
+        let shape = self.shape();
         let attrs_str = try_opt!(field.node.attrs.rewrite(&context, shape));
         let lo = field
             .node

--- a/src/items.rs
+++ b/src/items.rs
@@ -55,7 +55,23 @@ impl Rewrite for ast::Local {
 
         skip_out_of_file_lines_range!(context, self.span);
 
-        let mut result = "let ".to_owned();
+        if contains_skip(&self.attrs) {
+            return None;
+        }
+
+        let attrs_str = try_opt!(self.attrs.rewrite(context, shape));
+        let mut result = if attrs_str.is_empty() {
+            "let ".to_owned()
+        } else {
+            try_opt!(combine_strs_with_missing_comments(
+                context,
+                &attrs_str,
+                "let ",
+                mk_sp(self.attrs.last().map(|a| a.span.hi).unwrap(), self.span.lo),
+                shape,
+                false,
+            ))
+        };
 
         // 4 = "let ".len()
         let pat_shape = try_opt!(shape.offset_left(4));

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -124,3 +124,25 @@ impl InnerAttributes() {
 mod InnerAttributes {
     #![ this_is_an_inner_attribute ( foo ) ]
 }
+
+fn attributes_on_statements() {
+    // Local
+    # [ attr ( on ( local ) ) ]
+    let x = 3;
+
+    // Item
+    # [ attr ( on ( item ) ) ]
+    use foo;
+
+    // Expr
+    # [ attr ( on ( expr ) ) ]
+    {}
+
+    // Semi
+    # [ attr ( on ( semi ) ) ]
+    foo();
+
+    // Mac
+    # [ attr ( on ( mac ) ) ]
+    foo!();
+}

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -124,3 +124,25 @@ impl InnerAttributes() {
 mod InnerAttributes {
     #![this_is_an_inner_attribute(foo)]
 }
+
+fn attributes_on_statements() {
+    // Local
+    #[attr(on(local))]
+    let x = 3;
+
+    // Item
+    #[attr(on(item))]
+    use foo;
+
+    // Expr
+    #[attr(on(expr))]
+    {}
+
+    // Semi
+    #[attr(on(semi))]
+    foo();
+
+    // Mac
+    #[attr(on(mac))]
+    foo!();
+}


### PR DESCRIPTION
Closes #1813.