### PR TITLE
Enhance macro rewrite

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -26,7 +26,7 @@ use items::{span_hi_for_arg, span_lo_for_arg};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
             struct_lit_shape, struct_lit_tactic, write_list, DefinitiveListTactic, ListFormatting,
             ListItem, ListTactic, Separator, SeparatorPlace, SeparatorTactic};
-use macros::{rewrite_macro, MacroPosition};
+use macros::{rewrite_macro, MacroArg, MacroPosition};
 use patterns::{can_be_overflowed_pat, TuplePatField};
 use rewrite::{Rewrite, RewriteContext};
 use string::{rewrite_string, StringFormat};
@@ -3013,5 +3013,22 @@ impl<'a> ToExpr for ast::StructField {
 
     fn can_be_overflowed(&self, _: &RewriteContext, _: usize) -> bool {
         false
+    }
+}
+
+impl<'a> ToExpr for MacroArg {
+    fn to_expr(&self) -> Option<&ast::Expr> {
+        match self {
+            &MacroArg::Expr(ref expr) => Some(expr),
+            _ => None,
+        }
+    }
+
+    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
+        match self {
+            &MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
+            &MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
+            &MacroArg::Pat(..) => false,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use std::rc::Rc;
 
 use errors::{DiagnosticBuilder, Handler};
 use errors::emitter::{ColorConfig, EmitterWriter};
+use macros::MacroArg;
 use strings::string_buffer::StringBuffer;
 use syntax::ast;
 use syntax::codemap::{CodeMap, FilePathMapping, Span};
@@ -212,6 +213,16 @@ impl Spanned for ast::TyParamBound {
         match *self {
             ast::TyParamBound::TraitTyParamBound(ref ptr, _) => ptr.span,
             ast::TyParamBound::RegionTyParamBound(ref l) => l.span,
+        }
+    }
+}
+
+impl Spanned for MacroArg {
+    fn span(&self) -> Span {
+        match *self {
+            MacroArg::Expr(ref expr) => expr.span(),
+            MacroArg::Ty(ref ty) => ty.span(),
+            MacroArg::Pat(ref pat) => pat.span(),
         }
     }
 }
@@ -682,7 +693,6 @@ fn format_ast<F>(
     parse_session: &mut ParseSess,
     main_file: &Path,
     config: &Config,
-    codemap: &Rc<CodeMap>,
     mut after_file: F,
 ) -> Result<(FileMap, bool), io::Error>
 where
@@ -703,29 +713,19 @@ where
         if config.verbose() {
             println!("Formatting {}", path_str);
         }
-        {
-            let mut visitor = FmtVisitor::from_codemap(parse_session, config);
-            let filemap = visitor.codemap.lookup_char_pos(module.inner.lo()).file;
-            // Format inner attributes if available.
-            if !krate.attrs.is_empty() && path == main_file {
-                visitor.visit_attrs(&krate.attrs, ast::AttrStyle::Inner);
-            } else {
-                visitor.last_pos = filemap.start_pos;
-            }
-            visitor.format_separate_mod(module, &*filemap);
-
-            has_diff |= after_file(path_str, &mut visitor.buffer)?;
-
-            result.push((path_str.to_owned(), visitor.buffer));
+        let mut visitor = FmtVisitor::from_codemap(parse_session, config);
+        let filemap = visitor.codemap.lookup_char_pos(module.inner.lo()).file;
+        // Format inner attributes if available.
+        if !krate.attrs.is_empty() && path == main_file {
+            visitor.visit_attrs(&krate.attrs, ast::AttrStyle::Inner);
+        } else {
+            visitor.last_pos = filemap.start_pos;
         }
-        // Reset the error count.
-        if parse_session.span_diagnostic.has_errors() {
-            let silent_emitter = Box::new(EmitterWriter::new(
-                Box::new(Vec::new()),
-                Some(codemap.clone()),
-            ));
-            parse_session.span_diagnostic = Handler::with_emitter(true, false, silent_emitter);
-        }
+        visitor.format_separate_mod(module, &*filemap);
+
+        has_diff |= after_file(path_str, &mut visitor.buffer)?;
+
+        result.push((path_str.to_owned(), visitor.buffer));
     }
 
     Ok((result, has_diff))
@@ -913,7 +913,6 @@ pub fn format_input<T: Write>(
         &mut parse_session,
         &main_file,
         config,
-        &codemap,
         |file_name, file| {
             // For some reason, the codemap does not include terminating
             // newlines so we must add one on for each file. This is sad.

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -164,9 +164,6 @@ fn issue_1921() {
 }
 }
 
-// Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
-// at the end of the file for now.
-
 // #1577
 fn issue1577() {
     let json = json!({
@@ -178,3 +175,17 @@ gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     out: gfx::RenderTarget<ColorFormat> = "Target0",
 });
+
+// #1919
+#[test]
+fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify ! ( HandleWithDtor < :: std :: os :: raw :: c_int > )
+        )
+    );
+    assert_eq ! ( :: std :: mem :: align_of :: < HandleWithDtor < :: std :: os :: raw :: c_int > > ( ) , 8usize , concat ! ( "Alignment of template specialization: " , stringify ! ( HandleWithDtor < :: std :: os :: raw :: c_int > ) ) );
+}

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -208,9 +208,6 @@ fn issue_1921() {
     }
 }
 
-// Put the following tests with macro invocations whose arguments cannot be parsed as expressioins
-// at the end of the file for now.
-
 // #1577
 fn issue1577() {
     let json = json!({
@@ -222,3 +219,24 @@ gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     out: gfx::RenderTarget<ColorFormat> = "Target0",
 });
+
+// #1919
+#[test]
+fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(HandleWithDtor<::std::os::raw::c_int>)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<HandleWithDtor<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(HandleWithDtor<::std::os::raw::c_int>)
+        )
+    );
+}


### PR DESCRIPTION
This PR enhances macro rewrite in two folds:
1. Closes #1742.
2. Allow `ast::Ty` and `ast::Pat` to appear in macro arguments (currently rustfmt is only capable of `ast::Expr`). Closes #1919.
