### PR TITLE
Some Fixes

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -630,22 +630,10 @@ fn rewrite_closure(
             false
         };
         if no_return_type && !needs_block {
-            // lock.stmts.len() == 1
+            // block.stmts.len() == 1
             if let Some(expr) = stmt_expr(&block.stmts[0]) {
                 if let Some(rw) = rewrite_closure_expr(expr, &prefix, context, body_shape) {
                     return Some(rw);
-                }
-            }
-        }
-
-        if !needs_block {
-            // We need braces, but we might still prefer a one-liner.
-            let stmt = &block.stmts[0];
-            // 4 = braces and spaces.
-            if let Some(body_shape) = body_shape.sub_width(4) {
-                // Checks if rewrite succeeded and fits on a single line.
-                if let Some(rewrite) = and_one_line(stmt.rewrite(context, body_shape)) {
-                    return Some(format!("{} {{ {} }}", prefix, rewrite));
                 }
             }
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -876,13 +876,8 @@ impl Rewrite for ast::Stmt {
                     ""
                 };
 
-                let expr_type = match self.node {
-                    ast::StmtKind::Expr(_) => ExprType::SubExpression,
-                    ast::StmtKind::Semi(_) => ExprType::Statement,
-                    _ => unreachable!(),
-                };
                 let shape = try_opt!(shape.sub_width(suffix.len()));
-                format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
+                format_expr(ex, ExprType::Statement, context, shape).map(|s| s + suffix)
             }
             ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
         };

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -22,7 +22,6 @@ use comment::{contains_comment, recover_missing_comment_in_span, CodeCharKind, C
               FindUncommented};
 use comment::rewrite_comment;
 use config::{BraceStyle, Config};
-use expr::{format_expr, ExprType};
 use items::{format_impl, format_trait, rewrite_associated_impl_type, rewrite_associated_type,
             rewrite_static, rewrite_type_alias};
 use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorPlace,
@@ -77,12 +76,7 @@ impl<'a> FmtVisitor<'a> {
                 let rewrite = stmt.rewrite(&self.get_context(), self.shape());
                 self.push_rewrite(stmt.span(), rewrite);
             }
-            ast::StmtKind::Expr(ref expr) => {
-                let rewrite =
-                    format_expr(expr, ExprType::Statement, &self.get_context(), self.shape());
-                self.push_rewrite(stmt.span(), rewrite)
-            }
-            ast::StmtKind::Semi(..) => {
+            ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let rewrite = stmt.rewrite(&self.get_context(), self.shape());
                 self.push_rewrite(stmt.span(), rewrite)
             }

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -146,3 +146,7 @@ fn attributes_on_statements() {
     # [ attr ( on ( mac ) ) ]
     foo!();
 }
+
+// Large derive
+#[derive(Add, Sub, Mul, Div, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Serialize, Deserialize)]
+pub struct HP(pub u8);

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -146,3 +146,8 @@ fn attributes_on_statements() {
     #[attr(on(mac))]
     foo!();
 }
+
+// Large derive
+#[derive(Add, Sub, Mul, Div, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Serialize,
+         Deserialize)]
+pub struct HP(pub u8);

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -42,7 +42,9 @@ fn main() {
     });
 
     fffffffffffffffffffffffffffffffffff(a, {
-        SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+        SCRIPT_TASK_ROOT.with(|root| {
+            *root.borrow_mut() = Some(&script_task);
+        });
     });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum =

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -45,7 +45,9 @@ fn main() {
         });
 
     fffffffffffffffffffffffffffffffffff(a, {
-        SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+        SCRIPT_TASK_ROOT.with(|root| {
+            *root.borrow_mut() = Some(&script_task);
+        });
     });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum =

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -80,7 +80,9 @@ fn main() {
 	});
 
 	fffffffffffffffffffffffffffffffffff(a, {
-		SCRIPT_TASK_ROOT.with(|root| { *root.borrow_mut() = Some(&script_task); });
+		SCRIPT_TASK_ROOT.with(|root| {
+			*root.borrow_mut() = Some(&script_task);
+		});
 	});
 	a.b.c.d();
 


### PR DESCRIPTION
This PR
1. adds small refactoring (https://github.com/topecongiro/rustfmt/commit/737186b8901a4c843f5b7eed2f3a9a8a3e41e397).
2. disables single-lined closure with block body w.r.t. Rfc style (https://github.com/topecongiro/rustfmt/commit/f8bdcd62e8f4087f602018c97063733590367ffe).
3. formats long derive (https://github.com/topecongiro/rustfmt/commit/47062c8f0a3a197a8e2f83e070c4be1e866514fa).

Closes #1941.