### PR TITLE
Exclude prefix colon from span when rewriting comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,17 @@ impl Spanned for ast::TyParamBound {
     }
 }
 
+impl Spanned for ast::LifetimeDef {
+    fn span(&self) -> Span {
+        let hi = if self.bounds.is_empty() {
+            self.lifetime.span.hi()
+        } else {
+            self.bounds[self.bounds.len() - 1].span.hi()
+        };
+        mk_sp(self.lifetime.span.lo(), hi)
+    }
+}
+
 impl Spanned for MacroArg {
     fn span(&self) -> Span {
         match *self {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -641,7 +641,7 @@ where
             self.prev_span_end = (self.get_hi)(&item) + BytePos(comment_end as u32);
             let post_snippet = post_snippet[..comment_end].trim();
 
-            let post_snippet_trimmed = if post_snippet.starts_with(',') {
+            let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
                 post_snippet[1..].trim_matches(white_space)
             } else if post_snippet.ends_with(',') {
                 post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)

--- a/src/types.rs
+++ b/src/types.rs
@@ -584,11 +584,10 @@ impl Rewrite for ast::TyParam {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let mut result = String::with_capacity(128);
         // FIXME: If there are more than one attributes, this will force multiline.
-        let attr_str = match (&*self.attrs).rewrite(context, shape) {
-            Some(ref rw) if !rw.is_empty() => format!("{} ", rw),
-            _ => String::new(),
-        };
-        result.push_str(&attr_str);
+        match self.attrs.rewrite(context, shape) {
+            Some(ref rw) if !rw.is_empty() => result.push_str(&format!("{} ", rw)),
+            _ => (),
+        }
         result.push_str(&self.ident.to_string());
         if !self.bounds.is_empty() {
             result.push_str(type_bound_colon(context));

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -15,6 +15,11 @@ pub struct Foo {
     pub i: TypeForPublicField
 }
 
+// #1095
+struct S<T: /* comment */> {
+    t: T,
+}
+
 // #1029
 pub struct Foo {
     #[doc(hidden)]

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -14,6 +14,11 @@ pub struct Foo {
     pub i: TypeForPublicField,
 }
 
+// #1095
+struct S<T /* comment */> {
+    t: T,
+}
+
 // #1029
 pub struct Foo {
     #[doc(hidden)]


### PR DESCRIPTION
This PR 
1. closes #1095.
2. avoids cloning string by creating a wrapper type in `rewrite_generics_inner()`.