### PR TITLE
Use the last line's width for indent width in rewriting missed span to fix unindented comments

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use Shape;
+use {Indent, Shape};
 use comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};
 use config::WriteMode;
 use syntax::codemap::{BytePos, Pos, Span};
@@ -169,11 +169,12 @@ impl<'a> FmtVisitor<'a> {
                         self.config.comment_width(),
                         self.config.max_width() - self.block_indent.width(),
                     );
+                    let comment_indent = Indent::from_width(self.config, self.buffer.cur_offset());
 
                     self.buffer.push_str(&rewrite_comment(
                         subslice,
                         false,
-                        Shape::legacy(comment_width, self.block_indent),
+                        Shape::legacy(comment_width, comment_indent),
                         self.config,
                     ).unwrap());
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -72,11 +72,7 @@ impl<'a> FmtVisitor<'a> {
             ast::StmtKind::Item(ref item) => {
                 self.visit_item(item);
             }
-            ast::StmtKind::Local(..) => {
-                let rewrite = stmt.rewrite(&self.get_context(), self.shape());
-                self.push_rewrite(stmt.span(), rewrite);
-            }
-            ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
+            ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let rewrite = stmt.rewrite(&self.get_context(), self.shape());
                 self.push_rewrite(stmt.span(), rewrite)
             }

--- a/tests/source/comment.rs
+++ b/tests/source/comment.rs
@@ -9,7 +9,6 @@ fn test() {
 // comment
         // comment2
 
-    // FIXME(1275)
     code(); /* leave this comment alone!
              * ok? */
 

--- a/tests/source/comment4.rs
+++ b/tests/source/comment4.rs
@@ -5,7 +5,6 @@ fn test() {
 // comment
         // comment2
 
-    // FIXME(1275)
     code(); /* leave this comment alone!
              * ok? */
 

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -9,9 +9,8 @@ fn test() {
     // comment
     // comment2
 
-    // FIXME(1275)
     code(); // leave this comment alone!
-    // ok?
+            // ok?
 
     // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a
     // diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
@@ -33,7 +32,7 @@ fn test() {
     //                           .unwrap());
 
     funk(); // dontchangeme
-    // or me
+            // or me
 
     // #1388
     const EXCEPTION_PATHS: &'static [&'static str] = &[

--- a/tests/target/comment4.rs
+++ b/tests/target/comment4.rs
@@ -5,9 +5,8 @@ fn test() {
     // comment
     // comment2
 
-    // FIXME(1275)
     code(); /* leave this comment alone!
-     * ok? */
+             * ok? */
 
     /* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a
      * diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
@@ -28,7 +27,7 @@ fn test() {
     //                           .unwrap());
 
     funk(); //dontchangeme
-    // or me
+            // or me
 }
 
 /// test123


### PR DESCRIPTION
Closes #1275.