### PR TITLE
RFC: binop

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -160,6 +160,43 @@ enum Lorem {
 }
 ```
 
+## `binop_separator`
+
+Where to put a binary operator when a binary expression goes multiline.
+
+- **Default value**: `"Front"`
+- **Possible values**: `"Front"`, `"Back"`
+
+#### `"Front"`
+
+```rust
+let or = foo
+    || bar
+    || foobar;
+
+let sum = 1234
+    + 5678
+    + 910;
+
+let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+```
+
+#### `"Back"`
+
+```rust
+let or = foo ||
+    bar ||
+    foobar;
+
+let sum = 1234 +
+    5678 +
+    910;
+
+let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+```
+
 ## `chain_indent`
 
 Indentation of chain

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -183,9 +183,9 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     } else {
         min(shape.width, context.config.chain_one_line_max())
     };
-    let all_in_one_line = !parent_rewrite_contains_newline &&
-        rewrites.iter().all(|s| !s.contains('\n')) &&
-        almost_total < one_line_budget;
+    let all_in_one_line = !parent_rewrite_contains_newline
+        && rewrites.iter().all(|s| !s.contains('\n'))
+        && almost_total < one_line_budget;
     let rewrite_last = || rewrite_chain_subexpr(last_subexpr, total_span, context, nested_shape);
     let (last_subexpr_str, fits_single_line) = try_opt!(if all_in_one_line || extend_last_subexr {
         parent_shape.offset_left(almost_total).map(|shape| {
@@ -224,9 +224,9 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         format!("\n{}", nested_shape.indent.to_string(context.config))
     };
 
-    let first_connector = if is_small_parent || fits_single_line ||
-        last_line_extendable(&parent_rewrite) ||
-        context.config.chain_indent() == IndentStyle::Visual
+    let first_connector = if is_small_parent || fits_single_line
+        || last_line_extendable(&parent_rewrite)
+        || context.config.chain_indent() == IndentStyle::Visual
     {
         ""
     } else {
@@ -445,12 +445,12 @@ fn choose_first_connector<'a>(
 ) -> &'a str {
     if subexpr_list.is_empty() {
         ""
-    } else if extend || subexpr_list.last().map_or(false, is_try) ||
-        is_extendable_parent(context, parent_str)
+    } else if extend || subexpr_list.last().map_or(false, is_try)
+        || is_extendable_parent(context, parent_str)
     {
         // 1 = ";", being conservative here.
-        if last_line_width(parent_str) + first_line_width(first_child_str) + 1 <=
-            context.config.max_width()
+        if last_line_width(parent_str) + first_line_width(first_child_str) + 1
+            <= context.config.max_width()
         {
             ""
         } else {

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -91,13 +91,13 @@ impl<'a> CommentStyle<'a> {
     pub fn line_with_same_comment_style(&self, line: &str, normalize_comments: bool) -> bool {
         match *self {
             CommentStyle::DoubleSlash | CommentStyle::TripleSlash | CommentStyle::Doc => {
-                line.trim_left().starts_with(self.line_start().trim_left()) ||
-                    comment_style(line, normalize_comments) == *self
+                line.trim_left().starts_with(self.line_start().trim_left())
+                    || comment_style(line, normalize_comments) == *self
             }
             CommentStyle::DoubleBullet | CommentStyle::SingleBullet | CommentStyle::Exclamation => {
-                line.trim_left().starts_with(self.closer().trim_left()) ||
-                    line.trim_left().starts_with(self.line_start().trim_left()) ||
-                    comment_style(line, normalize_comments) == *self
+                line.trim_left().starts_with(self.closer().trim_left())
+                    || line.trim_left().starts_with(self.line_start().trim_left())
+                    || comment_style(line, normalize_comments) == *self
             }
             CommentStyle::Custom(opener) => line.trim_left().starts_with(opener.trim_right()),
         }
@@ -121,8 +121,8 @@ fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyle {
         } else {
             CommentStyle::DoubleSlash
         }
-    } else if (orig.starts_with("///") && orig.chars().nth(3).map_or(true, |c| c != '/')) ||
-        (orig.starts_with("/**") && !orig.starts_with("/**/"))
+    } else if (orig.starts_with("///") && orig.chars().nth(3).map_or(true, |c| c != '/'))
+        || (orig.starts_with("/**") && !orig.starts_with("/**/"))
     {
         CommentStyle::TripleSlash
     } else if orig.starts_with("//!") || orig.starts_with("/*!") {
@@ -424,8 +424,8 @@ fn light_rewrite_comment(orig: &str, offset: Indent, config: &Config) -> Option<
 /// Trims comment characters and possibly a single space from the left of a string.
 /// Does not trim all whitespace.
 fn left_trim_comment_line<'a>(line: &'a str, style: &CommentStyle) -> &'a str {
-    if line.starts_with("//! ") || line.starts_with("/// ") || line.starts_with("/*! ") ||
-        line.starts_with("/** ")
+    if line.starts_with("//! ") || line.starts_with("/// ") || line.starts_with("/*! ")
+        || line.starts_with("/** ")
     {
         &line[4..]
     } else if let CommentStyle::Custom(opener) = *style {
@@ -434,14 +434,14 @@ fn left_trim_comment_line<'a>(line: &'a str, style: &CommentStyle) -> &'a str {
         } else {
             &line[opener.trim_right().len()..]
         }
-    } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!") ||
-        line.starts_with("///") || line.starts_with("** ") ||
-        line.starts_with("/*!") ||
-        (line.starts_with("/**") && !line.starts_with("/**/"))
+    } else if line.starts_with("/* ") || line.starts_with("// ") || line.starts_with("//!")
+        || line.starts_with("///") || line.starts_with("** ")
+        || line.starts_with("/*!")
+        || (line.starts_with("/**") && !line.starts_with("/**/"))
     {
         &line[3..]
-    } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//") ||
-        line.starts_with("**")
+    } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//")
+        || line.starts_with("**")
     {
         &line[2..]
     } else if line.starts_with('*') {
@@ -771,9 +771,9 @@ impl<'a> Iterator for CommentCodeSlices<'a> {
         let mut iter = CharClasses::new(subslice.char_indices());
 
         for (kind, (i, c)) in &mut iter {
-            let is_comment_connector = self.last_slice_kind == CodeCharKind::Normal &&
-                &subslice[..2] == "//" &&
-                [' ', '\t'].contains(&c);
+            let is_comment_connector = self.last_slice_kind == CodeCharKind::Normal
+                && &subslice[..2] == "//"
+                && [' ', '\t'].contains(&c);
 
             if is_comment_connector && first_whitespace.is_none() {
                 first_whitespace = Some(i);
@@ -913,8 +913,8 @@ fn remove_comment_header(comment: &str) -> &str {
         &comment[3..]
     } else if comment.starts_with("//") {
         &comment[2..]
-    } else if (comment.starts_with("/**") && !comment.starts_with("/**/")) ||
-        comment.starts_with("/*!")
+    } else if (comment.starts_with("/**") && !comment.starts_with("/**/"))
+        || comment.starts_with("/*!")
     {
         &comment[3..comment.len() - 2]
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -620,6 +620,8 @@ create_config! {
     multiline_match_arm_forces_block: bool, false,
         "Force multiline match arm bodies to be wrapped in a block";
     merge_derives: bool, true, "Merge multiple `#[derive(...)]` into a single one";
+    binop_sep: SeparatorPlace, SeparatorPlace::Front,
+        "Where to put a binary operator when a binary expression goes multiline.";
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -620,7 +620,7 @@ create_config! {
     multiline_match_arm_forces_block: bool, false,
         "Force multiline match arm bodies to be wrapped in a block";
     merge_derives: bool, true, "Merge multiple `#[derive(...)]` into a single one";
-    binop_sep: SeparatorPlace, SeparatorPlace::Front,
+    binop_separator: SeparatorPlace, SeparatorPlace::Front,
         "Where to put a binary operator when a binary expression goes multiline.";
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -101,7 +101,7 @@ pub fn format_expr(
                 "",
                 context,
                 shape,
-                context.config.binop_sep(),
+                context.config.binop_separator(),
             )
         }
         ast::ExprKind::Unary(ref op, ref subexpr) => rewrite_unary_op(context, op, subexpr, shape),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -232,7 +232,7 @@ pub fn format_expr(
             "",
             context,
             shape,
-            SeparatorPlace::Front,
+            SeparatorPlace::Back,
         ),
         ast::ExprKind::Index(ref expr, ref index) => {
             rewrite_index(&**expr, &**index, context, shape)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -513,8 +513,8 @@ where
         },
     };
     let ends_with_newline = tactic.ends_with_newline(context.config.array_layout());
-    if context.config.array_horizontal_layout_threshold() > 0 &&
-        items.len() > context.config.array_horizontal_layout_threshold()
+    if context.config.array_horizontal_layout_threshold() > 0
+        && items.len() > context.config.array_horizontal_layout_threshold()
     {
         tactic = DefinitiveListTactic::Mixed;
     }
@@ -537,8 +537,8 @@ where
     };
     let list_str = try_opt!(write_list(&items, &fmt));
 
-    let result = if context.config.array_layout() == IndentStyle::Visual ||
-        tactic == DefinitiveListTactic::Horizontal
+    let result = if context.config.array_layout() == IndentStyle::Visual
+        || tactic == DefinitiveListTactic::Horizontal
     {
         if context.config.spaces_within_square_brackets() && !list_str.is_empty() {
             format!("[ {} ]", list_str)
@@ -671,10 +671,10 @@ fn rewrite_closure(
         }
 
         // Figure out if the block is necessary.
-        let needs_block = block.rules != ast::BlockCheckMode::Default || block.stmts.len() > 1 ||
-            context.inside_macro ||
-            block_contains_comment(block, context.codemap) ||
-            prefix.contains('\n');
+        let needs_block = block.rules != ast::BlockCheckMode::Default || block.stmts.len() > 1
+            || context.inside_macro
+            || block_contains_comment(block, context.codemap)
+            || prefix.contains('\n');
 
         let no_return_type = if let ast::FunctionRetTy::Default(_) = fn_decl.output {
             true
@@ -756,8 +756,8 @@ fn rewrite_closure_block(
     let block_threshold = context.config.closure_block_indent_threshold();
     if block_threshold >= 0 {
         if let Some(block_str) = block.rewrite(context, shape) {
-            if block_str.matches('\n').count() <= block_threshold as usize &&
-                !need_block_indent(&block_str, shape)
+            if block_str.matches('\n').count() <= block_threshold as usize
+                && !need_block_indent(&block_str, shape)
             {
                 if let Some(block_str) = block_str.rewrite(context, shape) {
                     return Some(format!("{} {}", prefix, block_str));
@@ -780,8 +780,8 @@ fn and_one_line(x: Option<String>) -> Option<String> {
 fn nop_block_collapse(block_str: Option<String>, budget: usize) -> Option<String> {
     debug!("nop_block_collapse {:?} {}", block_str, budget);
     block_str.map(|block_str| {
-        if block_str.starts_with('{') && budget >= 2 &&
-            (block_str[1..].find(|c: char| !c.is_whitespace()).unwrap() == block_str.len() - 2)
+        if block_str.starts_with('{') && budget >= 2
+            && (block_str[1..].find(|c: char| !c.is_whitespace()).unwrap() == block_str.len() - 2)
         {
             "{}".to_owned()
         } else {
@@ -805,8 +805,8 @@ fn rewrite_empty_block(
     let user_str = user_str.trim();
     if user_str.starts_with('{') && user_str.ends_with('}') {
         let comment_str = user_str[1..user_str.len() - 1].trim();
-        if block.stmts.is_empty() && !comment_str.contains('\n') &&
-            !comment_str.starts_with("//") && comment_str.len() + 4 <= shape.width
+        if block.stmts.is_empty() && !comment_str.contains('\n') && !comment_str.starts_with("//")
+            && comment_str.len() + 4 <= shape.width
         {
             return Some(format!("{{ {} }}", comment_str));
         }
@@ -1118,9 +1118,9 @@ impl<'a> ControlFlow<'a> {
         let fixed_cost = self.keyword.len() + "  {  } else {  }".len();
 
         if let ast::ExprKind::Block(ref else_node) = else_block.node {
-            if !is_simple_block(self.block, context.codemap) ||
-                !is_simple_block(else_node, context.codemap) ||
-                pat_expr_str.contains('\n')
+            if !is_simple_block(self.block, context.codemap)
+                || !is_simple_block(else_node, context.codemap)
+                || pat_expr_str.contains('\n')
             {
                 return None;
             }
@@ -1216,9 +1216,9 @@ impl<'a> ControlFlow<'a> {
             .max_width()
             .checked_sub(constr_shape.used_width() + offset + brace_overhead)
             .unwrap_or(0);
-        let force_newline_brace = context.config.control_style() == Style::Rfc &&
-            (pat_expr_string.contains('\n') || pat_expr_string.len() > one_line_budget) &&
-            !last_line_extendable(&pat_expr_string);
+        let force_newline_brace = context.config.control_style() == Style::Rfc
+            && (pat_expr_string.contains('\n') || pat_expr_string.len() > one_line_budget)
+            && !last_line_extendable(&pat_expr_string);
 
         // Try to format if-else on single line.
         if self.allow_single_line && context.config.single_line_if_else_max_width() > 0 {
@@ -1259,8 +1259,8 @@ impl<'a> ControlFlow<'a> {
 
         let block_sep = if self.cond.is_none() && between_kwd_cond_comment.is_some() {
             ""
-        } else if context.config.control_brace_style() == ControlBraceStyle::AlwaysNextLine ||
-            force_newline_brace
+        } else if context.config.control_brace_style() == ControlBraceStyle::AlwaysNextLine
+            || force_newline_brace
         {
             alt_block_sep
         } else {
@@ -1443,8 +1443,8 @@ fn block_contains_comment(block: &ast::Block, codemap: &CodeMap) -> bool {
 // FIXME: incorrectly returns false when comment is contained completely within
 // the expression.
 pub fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
-    (block.stmts.len() == 1 && stmt_is_expr(&block.stmts[0]) &&
-        !block_contains_comment(block, codemap))
+    (block.stmts.len() == 1 && stmt_is_expr(&block.stmts[0])
+        && !block_contains_comment(block, codemap))
 }
 
 /// Checks whether a block contains at most one statement or expression, and no comments.
@@ -1739,8 +1739,8 @@ fn flatten_arm_body<'a>(context: &'a RewriteContext, body: &'a ast::Expr) -> (bo
         {
             if let ast::StmtKind::Expr(ref expr) = block.stmts[0].node {
                 (
-                    !context.config.multiline_match_arm_forces_block() &&
-                        expr.can_be_overflowed(context, 1),
+                    !context.config.multiline_match_arm_forces_block()
+                        && expr.can_be_overflowed(context, 1),
                     &**expr,
                 )
             } else {
@@ -1748,8 +1748,8 @@ fn flatten_arm_body<'a>(context: &'a RewriteContext, body: &'a ast::Expr) -> (bo
             }
         }
         _ => (
-            !context.config.multiline_match_arm_forces_block() &&
-                body.can_be_overflowed(context, 1),
+            !context.config.multiline_match_arm_forces_block()
+                && body.can_be_overflowed(context, 1),
             &*body,
         ),
     }
@@ -1841,9 +1841,9 @@ fn rewrite_match_body(
 
         match rewrite {
             Some(ref body_str)
-                if !forbid_same_line &&
-                    (is_block ||
-                        (!body_str.contains('\n') && body_str.len() <= body_shape.width)) =>
+                if !forbid_same_line
+                    && (is_block
+                        || (!body_str.contains('\n') && body_str.len() <= body_shape.width)) =>
             {
                 return combine_orig_body(body_str);
             }
@@ -1989,8 +1989,8 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
         }
     }
 
-    if !context.config.force_format_strings() &&
-        !string_requires_rewrite(context, span, &string_lit, shape)
+    if !context.config.force_format_strings()
+        && !string_requires_rewrite(context, span, &string_lit, shape)
     {
         return Some(string_lit);
     }
@@ -2370,8 +2370,8 @@ where
             ast::ExprKind::Closure(..) => {
                 // If the argument consists of multiple closures, we do not overflow
                 // the last closure.
-                if args.len() > 1 &&
-                    args.iter()
+                if args.len() > 1
+                    && args.iter()
                         .rev()
                         .skip(1)
                         .filter_map(|arg| arg.to_expr())
@@ -2410,8 +2410,8 @@ where
 pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_len: usize) -> bool {
     match expr.node {
         ast::ExprKind::Match(..) => {
-            (context.use_block_indent() && args_len == 1) ||
-                (context.config.fn_call_style() == IndentStyle::Visual && args_len > 1)
+            (context.use_block_indent() && args_len == 1)
+                || (context.config.fn_call_style() == IndentStyle::Visual && args_len > 1)
         }
         ast::ExprKind::If(..) |
         ast::ExprKind::IfLet(..) |
@@ -2422,8 +2422,8 @@ pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_l
             context.config.combine_control_expr() && context.use_block_indent() && args_len == 1
         }
         ast::ExprKind::Block(..) | ast::ExprKind::Closure(..) => {
-            context.use_block_indent() ||
-                context.config.fn_call_style() == IndentStyle::Visual && args_len > 1
+            context.use_block_indent()
+                || context.config.fn_call_style() == IndentStyle::Visual && args_len > 1
         }
         ast::ExprKind::Array(..) |
         ast::ExprKind::Call(..) |
@@ -2447,9 +2447,9 @@ pub fn wrap_args_with_parens(
     shape: Shape,
     nested_shape: Shape,
 ) -> String {
-    if !context.use_block_indent() ||
-        (context.inside_macro && !args_str.contains('\n') &&
-            args_str.len() + paren_overhead(context) <= shape.width) || is_extendable
+    if !context.use_block_indent()
+        || (context.inside_macro && !args_str.contains('\n')
+            && args_str.len() + paren_overhead(context) <= shape.width) || is_extendable
     {
         if context.config.spaces_within_parens() && !args_str.is_empty() {
             format!("( {} )", args_str)
@@ -2492,8 +2492,8 @@ fn rewrite_paren(context: &RewriteContext, subexpr: &ast::Expr, shape: Shape) ->
     let subexpr_str = try_opt!(subexpr.rewrite(context, sub_shape));
     debug!("rewrite_paren, subexpr_str: `{:?}`", subexpr_str);
 
-    if subexpr_str.contains('\n') ||
-        first_line_width(&subexpr_str) + total_paren_overhead <= shape.width
+    if subexpr_str.contains('\n')
+        || first_line_width(&subexpr_str) + total_paren_overhead <= shape.width
     {
         Some(paren_wrapper(&subexpr_str))
     } else {
@@ -2603,8 +2603,8 @@ fn rewrite_struct_lit<'a>(
 
     let one_line_width = h_shape.map_or(0, |shape| shape.width);
     let body_lo = context.codemap.span_after(span, "{");
-    let fields_str = if struct_lit_can_be_aligned(fields, &base) &&
-        context.config.struct_field_align_threshold() > 0
+    let fields_str = if struct_lit_can_be_aligned(fields, &base)
+        && context.config.struct_field_align_threshold() > 0
     {
         try_opt!(rewrite_with_alignment(
             fields,
@@ -2678,10 +2678,10 @@ pub fn wrap_struct_field(
     nested_shape: Shape,
     one_line_width: usize,
 ) -> String {
-    if context.config.struct_lit_style() == IndentStyle::Block &&
-        (fields_str.contains('\n') ||
-            context.config.struct_lit_multiline_style() == MultilineStyle::ForceMulti ||
-            fields_str.len() > one_line_width)
+    if context.config.struct_lit_style() == IndentStyle::Block
+        && (fields_str.contains('\n')
+            || context.config.struct_lit_multiline_style() == MultilineStyle::ForceMulti
+            || fields_str.len() > one_line_width)
     {
         format!(
             "\n{}{}\n{}",
@@ -2992,8 +2992,8 @@ fn prefer_next_line(orig_rhs: &str, next_line_rhs: &str) -> bool {
         src.chars().filter(|&x| x == '\n').count()
     }
 
-    !next_line_rhs.contains('\n') ||
-        count_line_breaks(orig_rhs) > count_line_breaks(next_line_rhs) + 1
+    !next_line_rhs.contains('\n')
+        || count_line_breaks(orig_rhs) > count_line_breaks(next_line_rhs) + 1
 }
 
 fn rewrite_expr_addrof(

--- a/src/file_lines.rs
+++ b/src/file_lines.rs
@@ -51,8 +51,8 @@ impl Range {
         if self.is_empty() || other.is_empty() {
             false
         } else {
-            (self.lo <= other.hi && other.hi <= self.hi) ||
-                (other.lo <= self.hi && self.hi <= other.hi)
+            (self.lo <= other.hi && other.hi <= self.hi)
+                || (other.lo <= self.hi && self.hi <= other.hi)
         }
     }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -132,8 +132,8 @@ fn rewrite_view_path_prefix(
     context: &RewriteContext,
     shape: Shape,
 ) -> Option<String> {
-    let path_str = if path.segments.last().unwrap().identifier.to_string() == "self" &&
-        path.segments.len() > 1
+    let path_str = if path.segments.last().unwrap().identifier.to_string() == "self"
+        && path.segments.len() > 1
     {
         let path = &ast::Path {
             span: path.span,
@@ -503,8 +503,8 @@ fn rewrite_use_list(
         IndentStyle::Visual => Shape::legacy(remaining_width, nested_indent),
     };
 
-    let ends_with_newline = context.config.imports_indent() == IndentStyle::Block &&
-        tactic != DefinitiveListTactic::Horizontal;
+    let ends_with_newline = context.config.imports_indent() == IndentStyle::Block
+        && tactic != DefinitiveListTactic::Horizontal;
 
     let fmt = ListFormatting {
         tactic: tactic,

--- a/src/items.rs
+++ b/src/items.rs
@@ -228,8 +228,8 @@ impl<'a> FmtVisitor<'a> {
         let context = self.get_context();
 
         let block_snippet = self.snippet(mk_sp(block.span.lo(), block.span.hi()));
-        let has_body = !block_snippet[1..block_snippet.len() - 1].trim().is_empty() ||
-            !context.config.fn_empty_single_line();
+        let has_body = !block_snippet[1..block_snippet.len() - 1].trim().is_empty()
+            || !context.config.fn_empty_single_line();
         let mut newline_brace = newline_for_brace(self.config, &generics.where_clause, has_body);
 
         let (mut result, force_newline_brace) = try_opt!(rewrite_fn_base(
@@ -251,8 +251,8 @@ impl<'a> FmtVisitor<'a> {
 
         if force_newline_brace {
             newline_brace = true;
-        } else if self.config.fn_brace_style() != BraceStyle::AlwaysNextLine &&
-            !result.contains('\n')
+        } else if self.config.fn_brace_style() != BraceStyle::AlwaysNextLine
+            && !result.contains('\n')
         {
             newline_brace = false;
         }
@@ -313,8 +313,8 @@ impl<'a> FmtVisitor<'a> {
 
         let codemap = self.get_context().codemap;
 
-        if self.config.fn_empty_single_line() && is_empty_block(block, codemap) &&
-            self.block_indent.width() + fn_str.len() + 2 <= self.config.max_width()
+        if self.config.fn_empty_single_line() && is_empty_block(block, codemap)
+            && self.block_indent.width() + fn_str.len() + 2 <= self.config.max_width()
         {
             return Some(format!("{}{{}}", fn_str));
         }
@@ -503,9 +503,9 @@ impl<'a> FmtVisitor<'a> {
             },
         };
 
-        let attrs_extendable = attrs_str.is_empty() ||
-            (context.config.attributes_on_same_line_as_variant() &&
-                is_attributes_extendable(&attrs_str));
+        let attrs_extendable = attrs_str.is_empty()
+            || (context.config.attributes_on_same_line_as_variant()
+                && is_attributes_extendable(&attrs_str));
         combine_strs_with_missing_comments(
             &context,
             &attrs_str,
@@ -650,9 +650,9 @@ fn is_impl_single_line(
     let open_pos = try_opt!(snippet.find_uncommented("{")) + 1;
 
     Some(
-        context.config.impl_empty_single_line() && items.is_empty() && !result.contains('\n') &&
-            result.len() + where_clause_str.len() <= context.config.max_width() &&
-            !contains_comment(&snippet[open_pos..]),
+        context.config.impl_empty_single_line() && items.is_empty() && !result.contains('\n')
+            && result.len() + where_clause_str.len() <= context.config.max_width()
+            && !contains_comment(&snippet[open_pos..]),
     )
 }
 
@@ -895,8 +895,8 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         ));
         // If the trait, generics, and trait bound cannot fit on the same line,
         // put the trait bounds on an indented new line
-        if offset.width() + last_line_width(&result) + trait_bound_str.len() >
-            context.config.comment_width()
+        if offset.width() + last_line_width(&result) + trait_bound_str.len()
+            > context.config.comment_width()
         {
             result.push('\n');
             let trait_indent = offset.block_only().block_indent(context.config);
@@ -906,11 +906,11 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
 
         let has_body = !trait_items.is_empty();
 
-        let where_density = if (context.config.where_density() == Density::Compressed &&
-            (!result.contains('\n') || context.config.fn_args_layout() == IndentStyle::Block)) ||
-            (context.config.fn_args_layout() == IndentStyle::Block && result.is_empty()) ||
-            (context.config.where_density() == Density::CompressedIfEmpty && !has_body &&
-                !result.contains('\n'))
+        let where_density = if (context.config.where_density() == Density::Compressed
+            && (!result.contains('\n') || context.config.fn_args_layout() == IndentStyle::Block))
+            || (context.config.fn_args_layout() == IndentStyle::Block && result.is_empty())
+            || (context.config.where_density() == Density::CompressedIfEmpty && !has_body
+                && !result.contains('\n'))
         {
             Density::Compressed
         } else {
@@ -937,9 +937,9 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         ));
         // If the where clause cannot fit on the same line,
         // put the where clause on a new line
-        if !where_clause_str.contains('\n') &&
-            last_line_width(&result) + where_clause_str.len() + offset.width() >
-                context.config.comment_width()
+        if !where_clause_str.contains('\n')
+            && last_line_width(&result) + where_clause_str.len() + offset.width()
+                > context.config.comment_width()
         {
             result.push('\n');
             let width = offset.block_indent + context.config.tab_spaces() - 1;
@@ -980,8 +980,8 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
                 result.push_str(&offset.to_string(context.config));
             }
             BraceStyle::PreferSameLine => result.push(' '),
-            BraceStyle::SameLineWhere => if !where_clause_str.is_empty() &&
-                (!trait_items.is_empty() || result.contains('\n'))
+            BraceStyle::SameLineWhere => if !where_clause_str.is_empty()
+                && (!trait_items.is_empty() || result.contains('\n'))
             {
                 result.push('\n');
                 result.push_str(&offset.to_string(context.config));
@@ -1061,9 +1061,9 @@ pub fn format_struct_struct(
         None => {
             // 3 = ` {}`, 2 = ` {`.
             let overhead = if fields.is_empty() { 3 } else { 2 };
-            if (context.config.item_brace_style() == BraceStyle::AlwaysNextLine &&
-                !fields.is_empty()) ||
-                context.config.max_width() < overhead + result.len()
+            if (context.config.item_brace_style() == BraceStyle::AlwaysNextLine
+                && !fields.is_empty())
+                || context.config.max_width() < overhead + result.len()
             {
                 format!("\n{}{{", offset.block_only().to_string(context.config))
             } else {
@@ -1074,8 +1074,8 @@ pub fn format_struct_struct(
     // 1 = `}`
     let overhead = if fields.is_empty() { 1 } else { 0 };
     let total_width = result.len() + generics_str.len() + overhead;
-    if !generics_str.is_empty() && !generics_str.contains('\n') &&
-        total_width > context.config.max_width()
+    if !generics_str.is_empty() && !generics_str.contains('\n')
+        && total_width > context.config.max_width()
     {
         result.push('\n');
         result.push_str(&offset.to_string(context.config));
@@ -1224,10 +1224,10 @@ fn format_tuple_struct(
         result.push_str(&body);
     }
 
-    if !where_clause_str.is_empty() && !where_clause_str.contains('\n') &&
-        (result.contains('\n') ||
-            offset.block_indent + result.len() + where_clause_str.len() + 1 >
-                context.config.max_width())
+    if !where_clause_str.is_empty() && !where_clause_str.contains('\n')
+        && (result.contains('\n')
+            || offset.block_indent + result.len() + where_clause_str.len() + 1
+                > context.config.max_width())
     {
         // We need to put the where clause on a new line, but we didn't
         // know that earlier, so the where clause will not be indented properly.
@@ -1368,8 +1368,9 @@ pub fn rewrite_struct_field(
     let prefix = try_opt!(rewrite_struct_field_prefix(context, field));
 
     let attrs_str = try_opt!(field.attrs.rewrite(context, shape));
-    let attrs_extendable = attrs_str.is_empty() ||
-        (context.config.attributes_on_same_line_as_field() && is_attributes_extendable(&attrs_str));
+    let attrs_extendable = attrs_str.is_empty()
+        || (context.config.attributes_on_same_line_as_field()
+            && is_attributes_extendable(&attrs_str));
     let missing_span = if field.attrs.is_empty() {
         mk_sp(field.span.lo(), field.span.lo())
     } else {
@@ -2154,8 +2155,9 @@ fn rewrite_args(
         arg_items.extend(more_items);
     }
 
-    let fits_in_one_line = !generics_str_contains_newline &&
-        (arg_items.is_empty() || arg_items.len() == 1 && arg_item_strs[0].len() <= one_line_budget);
+    let fits_in_one_line = !generics_str_contains_newline
+        && (arg_items.is_empty()
+            || arg_items.len() == 1 && arg_item_strs[0].len() <= one_line_budget);
 
     for (item, arg) in arg_items.iter_mut().zip(arg_item_strs) {
         item.item = Some(arg);
@@ -2419,8 +2421,8 @@ pub fn wrap_generics_with_angle_brackets(
     list_str: &str,
     list_offset: Indent,
 ) -> String {
-    if context.config.generics_indent() == IndentStyle::Block &&
-        (list_str.contains('\n') || list_str.ends_with(','))
+    if context.config.generics_indent() == IndentStyle::Block
+        && (list_str.contains('\n') || list_str.ends_with(','))
     {
         format!(
             "<\n{}{}\n{}>",
@@ -2528,9 +2530,9 @@ fn rewrite_where_clause_rfc_style(
     let newline_after_where = comment_separator(&comment_after, clause_shape);
 
     // 6 = `where `
-    let clause_sep = if where_clause_option.compress_where && comment_before.is_empty() &&
-        comment_after.is_empty() && !preds_str.contains('\n') &&
-        6 + preds_str.len() <= shape.width
+    let clause_sep = if where_clause_option.compress_where && comment_before.is_empty()
+        && comment_after.is_empty() && !preds_str.contains('\n')
+        && 6 + preds_str.len() <= shape.width
     {
         String::from(" ")
     } else {
@@ -2643,8 +2645,8 @@ fn rewrite_where_clause(
     } else {
         terminator.len()
     };
-    if density == Density::Tall || preds_str.contains('\n') ||
-        shape.indent.width() + " where ".len() + preds_str.len() + end_length > shape.width
+    if density == Density::Tall || preds_str.contains('\n')
+        || shape.indent.width() + " where ".len() + preds_str.len() + end_length > shape.width
     {
         Some(format!(
             "\n{}where {}",
@@ -2715,11 +2717,12 @@ fn format_generics(
             option,
         ));
         result.push_str(&where_clause_str);
-        force_same_line_brace || brace_style == BraceStyle::PreferSameLine ||
-            (generics.where_clause.predicates.is_empty() && trimmed_last_line_width(&result) == 1)
+        force_same_line_brace || brace_style == BraceStyle::PreferSameLine
+            || (generics.where_clause.predicates.is_empty()
+                && trimmed_last_line_width(&result) == 1)
     } else {
-        force_same_line_brace || trimmed_last_line_width(&result) == 1 ||
-            brace_style != BraceStyle::AlwaysNextLine
+        force_same_line_brace || trimmed_last_line_width(&result) == 1
+            || brace_style != BraceStyle::AlwaysNextLine
     };
     let total_used_width = last_line_used_width(&result, used_width);
     let remaining_budget = context.budget(total_used_width);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -786,8 +786,8 @@ fn format_lines(text: &mut StringBuffer, name: &str, config: &Config, report: &m
                 }
 
                 // Check for any line width errors we couldn't correct.
-                let report_error_on_line_overflow = config.error_on_line_overflow() &&
-                    (config.error_on_line_overflow_comments() || !is_comment);
+                let report_error_on_line_overflow = config.error_on_line_overflow()
+                    && (config.error_on_line_overflow_comments() || !is_comment);
                 if report_error_on_line_overflow && line_len > config.max_width() {
                     errors.push(FormattingError {
                         line: cur_line,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -118,18 +118,18 @@ impl ListItem {
     }
 
     pub fn is_different_group(&self) -> bool {
-        self.inner_as_ref().contains('\n') || self.pre_comment.is_some() ||
-            self.post_comment
+        self.inner_as_ref().contains('\n') || self.pre_comment.is_some()
+            || self.post_comment
                 .as_ref()
                 .map_or(false, |s| s.contains('\n'))
     }
 
     pub fn is_multiline(&self) -> bool {
-        self.inner_as_ref().contains('\n') ||
-            self.pre_comment
+        self.inner_as_ref().contains('\n')
+            || self.pre_comment
                 .as_ref()
-                .map_or(false, |s| s.contains('\n')) ||
-            self.post_comment
+                .map_or(false, |s| s.contains('\n'))
+            || self.post_comment
                 .as_ref()
                 .map_or(false, |s| s.contains('\n'))
     }
@@ -137,8 +137,8 @@ impl ListItem {
     pub fn has_comment(&self) -> bool {
         self.pre_comment
             .as_ref()
-            .map_or(false, |comment| comment.starts_with("//")) ||
-            self.post_comment
+            .map_or(false, |comment| comment.starts_with("//"))
+            || self.post_comment
                 .as_ref()
                 .map_or(false, |comment| comment.starts_with("//"))
     }
@@ -243,8 +243,8 @@ where
     let total_sep_len = sep.len() * sep_count.checked_sub(1).unwrap_or(0);
     let real_total = total_width + total_sep_len;
 
-    if real_total <= limit && !pre_line_comments &&
-        !items.into_iter().any(|item| item.as_ref().is_multiline())
+    if real_total <= limit && !pre_line_comments
+        && !items.into_iter().any(|item| item.as_ref().is_multiline())
     {
         DefinitiveListTactic::Horizontal
     } else {
@@ -346,8 +346,8 @@ where
 
             if tactic == DefinitiveListTactic::Vertical {
                 // We cannot keep pre-comments on the same line if the comment if normalized.
-                let keep_comment = if formatting.config.normalize_comments() ||
-                    item.pre_comment_style == ListItemCommentStyle::DifferentLine
+                let keep_comment = if formatting.config.normalize_comments()
+                    || item.pre_comment_style == ListItemCommentStyle::DifferentLine
                 {
                     false
                 } else {
@@ -416,9 +416,9 @@ where
                 let comment_shape = Shape::legacy(width, offset);
 
                 // Use block-style only for the last item or multiline comments.
-                let block_style = !formatting.ends_with_newline && last ||
-                    comment.trim().contains('\n') ||
-                    comment.trim().len() > width;
+                let block_style = !formatting.ends_with_newline && last
+                    || comment.trim().contains('\n')
+                    || comment.trim().len() > width;
 
                 rewrite_comment(comment, block_style, comment_shape, formatting.config)
             };
@@ -428,8 +428,8 @@ where
             if !formatted_comment.starts_with('\n') {
                 let mut comment_alignment =
                     post_comment_alignment(item_max_width, inner_item.len());
-                if first_line_width(&formatted_comment) + last_line_width(&result) +
-                    comment_alignment + 1 > formatting.config.max_width()
+                if first_line_width(&formatted_comment) + last_line_width(&result)
+                    + comment_alignment + 1 > formatting.config.max_width()
                 {
                     item_max_width = None;
                     formatted_comment = try_opt!(rewrite_post_comment(&mut item_max_width));
@@ -452,8 +452,8 @@ where
             item_max_width = None;
         }
 
-        if formatting.preserve_newline && !last && tactic == DefinitiveListTactic::Vertical &&
-            item.new_lines
+        if formatting.preserve_newline && !last && tactic == DefinitiveListTactic::Vertical
+            && item.new_lines
         {
             item_max_width = None;
             result.push('\n');
@@ -478,9 +478,9 @@ where
     for item in items.clone().into_iter().skip(i) {
         let item = item.as_ref();
         let inner_item_width = item.inner_as_ref().len();
-        if !first &&
-            (item.is_different_group() || !item.post_comment.is_some() ||
-                inner_item_width + overhead > max_budget)
+        if !first
+            && (item.is_different_group() || !item.post_comment.is_some()
+                || inner_item_width + overhead > max_budget)
         {
             return max_width;
         }
@@ -714,9 +714,9 @@ where
 }
 
 fn total_item_width(item: &ListItem) -> usize {
-    comment_len(item.pre_comment.as_ref().map(|x| &(*x)[..])) +
-        comment_len(item.post_comment.as_ref().map(|x| &(*x)[..])) +
-        item.item.as_ref().map_or(0, |str| str.len())
+    comment_len(item.pre_comment.as_ref().map(|x| &(*x)[..]))
+        + comment_len(item.post_comment.as_ref().map(|x| &(*x)[..]))
+        + item.item.as_ref().map_or(0, |str| str.len())
 }
 
 fn comment_len(comment: Option<&str>) -> usize {
@@ -800,8 +800,8 @@ pub fn struct_lit_formatting<'a>(
     context: &'a RewriteContext,
     force_no_trailing_comma: bool,
 ) -> ListFormatting<'a> {
-    let ends_with_newline = context.config.struct_lit_style() != IndentStyle::Visual &&
-        tactic == DefinitiveListTactic::Vertical;
+    let ends_with_newline = context.config.struct_lit_style() != IndentStyle::Visual
+        && tactic == DefinitiveListTactic::Vertical;
     ListFormatting {
         tactic: tactic,
         separator: ",",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -230,8 +230,8 @@ pub fn rewrite_macro(
                 let nested_shape = mac_shape.block_indent(context.config.tab_spaces());
                 let lhs = try_opt!(arg_vec[0].rewrite(context, nested_shape));
                 let rhs = try_opt!(arg_vec[1].rewrite(context, nested_shape));
-                if !lhs.contains('\n') && !rhs.contains('\n') &&
-                    lhs.len() + rhs.len() + total_overhead <= shape.width
+                if !lhs.contains('\n') && !rhs.contains('\n')
+                    && lhs.len() + rhs.len() + total_overhead <= shape.width
                 {
                     Some(format!("{}{}{}; {}{}", macro_name, lbr, lhs, rhs, rbr))
                 } else {
@@ -373,13 +373,13 @@ fn indent_macro_snippet(
     );
 
     Some(
-        String::from(first_line) + "\n" +
-            &trimmed_lines
+        String::from(first_line) + "\n"
+            + &trimmed_lines
                 .iter()
                 .map(|&(line, prefix_space_width)| match prefix_space_width {
                     Some(original_indent_width) => {
-                        let new_indent_width = indent.width() +
-                            original_indent_width
+                        let new_indent_width = indent.width()
+                            + original_indent_width
                                 .checked_sub(min_prefix_space_width)
                                 .unwrap_or(0);
                         let new_indent = Indent::from_width(context.config, new_indent_width);

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -145,8 +145,8 @@ impl<'a> FmtVisitor<'a> {
 
                 let subslice_num_lines = subslice.chars().filter(|c| *c == '\n').count();
 
-                if rewrite_next_comment &&
-                    !self.config.file_lines().intersects_range(
+                if rewrite_next_comment
+                    && !self.config.file_lines().intersects_range(
                         file_name,
                         cur_line,
                         cur_line + subslice_num_lines,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -18,7 +18,7 @@ use comment::FindUncommented;
 use expr::{can_be_overflowed_expr, rewrite_call_inner, rewrite_pair, rewrite_unary_prefix,
            wrap_struct_field};
 use lists::{itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
-            struct_lit_tactic, write_list, DefinitiveListTactic, SeparatorTactic};
+            struct_lit_tactic, write_list, DefinitiveListTactic, SeparatorPlace, SeparatorTactic};
 use rewrite::{Rewrite, RewriteContext};
 use types::{rewrite_path, PathContext};
 use utils::{format_mutability, mk_sp, wrap_str};
@@ -59,8 +59,26 @@ impl Rewrite for Pat {
                 None
             },
             PatKind::Range(ref lhs, ref rhs, ref end_kind) => match *end_kind {
-                RangeEnd::Included => rewrite_pair(&**lhs, &**rhs, "", "...", "", context, shape),
-                RangeEnd::Excluded => rewrite_pair(&**lhs, &**rhs, "", "..", "", context, shape),
+                RangeEnd::Included => rewrite_pair(
+                    &**lhs,
+                    &**rhs,
+                    "",
+                    "...",
+                    "",
+                    context,
+                    shape,
+                    SeparatorPlace::Front,
+                ),
+                RangeEnd::Excluded => rewrite_pair(
+                    &**lhs,
+                    &**rhs,
+                    "",
+                    "..",
+                    "",
+                    context,
+                    shape,
+                    SeparatorPlace::Front,
+                ),
             },
             PatKind::Ref(ref pat, mutability) => {
                 let prefix = format!("&{}", format_mutability(mutability));

--- a/src/string.rs
+++ b/src/string.rs
@@ -82,8 +82,8 @@ pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> 
                     // If we can't break at whitespace or punctuation, grow the string instead.
                     if cur_end < cur_start + MIN_STRING {
                         cur_end = cur_start + max_chars;
-                        while !(punctuation.contains(graphemes[cur_end - 1]) ||
-                            graphemes[cur_end - 1].trim().is_empty())
+                        while !(punctuation.contains(graphemes[cur_end - 1])
+                            || graphemes[cur_end - 1].trim().is_empty())
                         {
                             if cur_end >= graphemes.len() {
                                 let line = &graphemes[cur_start..].join("");

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -44,8 +44,8 @@ impl Summary {
     }
 
     pub fn has_no_errors(&self) -> bool {
-        !(self.has_operational_errors || self.has_parsing_errors || self.has_formatting_errors ||
-            self.has_diff)
+        !(self.has_operational_errors || self.has_parsing_errors || self.has_formatting_errors
+            || self.has_diff)
     }
 
     pub fn add(&mut self, other: Summary) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -208,8 +208,8 @@ fn rewrite_segment(
     let params = if let Some(ref params) = segment.parameters {
         match **params {
             ast::PathParameters::AngleBracketed(ref data)
-                if !data.lifetimes.is_empty() || !data.types.is_empty() ||
-                    !data.bindings.is_empty() =>
+                if !data.lifetimes.is_empty() || !data.types.is_empty()
+                    || !data.bindings.is_empty() =>
             {
                 let param_list = data.lifetimes
                     .iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -738,7 +738,16 @@ impl Rewrite for ast::Ty {
                 let use_spaces = context.config.spaces_within_square_brackets();
                 let lbr = if use_spaces { "[ " } else { "[" };
                 let rbr = if use_spaces { " ]" } else { "]" };
-                rewrite_pair(&**ty, &**repeats, lbr, "; ", rbr, context, shape)
+                rewrite_pair(
+                    &**ty,
+                    &**repeats,
+                    lbr,
+                    "; ",
+                    rbr,
+                    context,
+                    shape,
+                    SeparatorPlace::Back,
+                )
             }
             ast::TyKind::Infer => if shape.width >= 1 {
                 Some("_".to_owned())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -165,8 +165,8 @@ pub fn trimmed_last_line_width(s: &str) -> usize {
 #[inline]
 pub fn last_line_extendable(s: &str) -> bool {
     s.lines().last().map_or(false, |s| {
-        s.ends_with("\"#") ||
-            s.trim()
+        s.ends_with("\"#")
+            || s.trim()
                 .chars()
                 .all(|c| c == ')' || c == ']' || c == '}' || c == '?')
     })

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -53,8 +53,8 @@ impl AlignedItem for ast::StructField {
         } else {
             mk_sp(self.attrs.last().unwrap().span.hi(), self.span.lo())
         };
-        let attrs_extendable = context.config.attributes_on_same_line_as_field() &&
-            is_attributes_extendable(&attrs_str);
+        let attrs_extendable = context.config.attributes_on_same_line_as_field()
+            && is_attributes_extendable(&attrs_str);
         rewrite_struct_field_prefix(context, self).and_then(|field_str| {
             combine_strs_with_missing_comments(
                 context,
@@ -184,8 +184,8 @@ pub fn rewrite_with_alignment<T: AlignedItem>(
             one_line_width,
         ));
         Some(
-            result + spaces + "\n" +
-                &shape
+            result + spaces + "\n"
+                + &shape
                     .indent
                     .block_indent(context.config)
                     .to_string(context.config) + &rest_str,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -722,8 +722,8 @@ impl<'a> FmtVisitor<'a> {
         // Decide whether this is an inline mod or an external mod.
         let local_file_name = self.codemap.span_to_filename(s);
         let inner_span = source!(self, m.inner);
-        let is_internal = !(inner_span.lo().0 == 0 && inner_span.hi().0 == 0) &&
-            local_file_name == self.codemap.span_to_filename(inner_span);
+        let is_internal = !(inner_span.lo().0 == 0 && inner_span.hi().0 == 0)
+            && local_file_name == self.codemap.span_to_filename(inner_span);
 
         self.buffer.push_str(&*utils::format_visibility(vis));
         self.buffer.push_str("mod ");
@@ -883,8 +883,8 @@ impl<'a> Rewrite for [ast::Attribute] {
                 // This particular horror show is to preserve line breaks in between doc
                 // comments. An alternative would be to force such line breaks to start
                 // with the usual doc comment token.
-                let (multi_line_before, multi_line_after) = if a.is_sugared_doc ||
-                    is_prev_sugared_doc
+                let (multi_line_before, multi_line_after) = if a.is_sugared_doc
+                    || is_prev_sugared_doc
                 {
                     // Look at before and after comment and see if there are any empty lines.
                     let comment_begin = comment.chars().position(|c| c == '/');

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -94,8 +94,8 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
     pub fn eq_expr(&self, left: &Expr, right: &Expr) -> bool {
         match (&left.node, &right.node) {
             (&ExprBinary(l_op, ref ll, ref lr), &ExprBinary(r_op, ref rl, ref rr)) => {
-                l_op.node == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr) ||
-                    swap_binop(l_op.node, ll, lr).map_or(false, |(l_op, ll, lr)| {
+                l_op.node == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
+                    || swap_binop(l_op.node, ll, lr).map_or(false, |(l_op, ll, lr)| {
                         l_op == r_op.node && self.eq_expr(ll, rl) && self.eq_expr(lr, rr)
                     })
             }

--- a/tests/target/configs-control_style-rfc.rs
+++ b/tests/target/configs-control_style-rfc.rs
@@ -4,10 +4,9 @@
 fn main() {
     loop {
         if foo {
-            if ((right_paddle_speed < 0.) &&
-                (right_paddle.position().y - paddle_size.y / 2. > 5.)) ||
-                ((right_paddle_speed > 0.) &&
-                    (right_paddle.position().y + paddle_size.y / 2. < game_height as f32 - 5.))
+            if ((right_paddle_speed < 0.) && (right_paddle.position().y - paddle_size.y / 2. > 5.))
+                || ((right_paddle_speed > 0.)
+                    && (right_paddle.position().y + paddle_size.y / 2. < game_height as f32 - 5.))
             {
                 foo
             }
@@ -26,10 +25,10 @@ fn issue1656() {
         {
             match rewrite {
                 Some(ref body_str)
-                    if (!body_str.contains('\n') && body_str.len() <= arm_shape.width) ||
-                        !context.config.wrap_match_arms() ||
-                        (extend && first_line_width(body_str) <= arm_shape.width) ||
-                        is_block =>
+                    if (!body_str.contains('\n') && body_str.len() <= arm_shape.width)
+                        || !context.config.wrap_match_arms()
+                        || (extend && first_line_width(body_str) <= arm_shape.width)
+                        || is_block =>
                 {
                     return None;
                 }

--- a/tests/target/expr-block.rs
+++ b/tests/target/expr-block.rs
@@ -197,8 +197,8 @@ fn issue_1450() {
 }
 
 fn foo() {
-    if real_total <= limit && !pre_line_comments &&
-        !items.into_iter().any(|item| item.as_ref().is_multiline())
+    if real_total <= limit && !pre_line_comments
+        && !items.into_iter().any(|item| item.as_ref().is_multiline())
     {
         DefinitiveListTactic::Horizontal
     }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -13,17 +13,17 @@ fn foo() -> bool {
     let is_internalxxxx =
         self.codemap.span_to_filename(s) == self.codemap.span_to_filename(m.inner);
 
-    let some_val = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * bbbb /
-        (bbbbbb - function_call(x, *very_long_pointer, y)) + 1000;
+    let some_val = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * bbbb
+        / (bbbbbb - function_call(x, *very_long_pointer, y)) + 1000;
 
     some_ridiculously_loooooooooooooooooooooong_function(
         10000 * 30000000000 + 40000 / 1002200000000 - 50000 * sqrt(-1),
         trivial_value,
     );
-    (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-        a +
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-        aaaaa)))))))));
+    (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + a
+        + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + aaaaa)))))))));
 
     {
         for _ in 0..10 {}
@@ -78,8 +78,8 @@ fn foo() -> bool {
         something_else();
     } else {
         // Check subformatting
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
 }
 
@@ -249,18 +249,18 @@ fn arrays() {
 }
 
 fn returns() {
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
-        return;
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        && return;
 
-    return aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+    return aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 }
 
 fn addrof() {
-    &mut (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
-    &(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
+    &mut (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
+    &(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
 }
 
 fn casts() {

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -32,8 +32,8 @@ fn main() {
 	} else if different_cond() {
 		something_else();
 	} else {
-		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			+ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	}
 
 	unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong

--- a/tests/target/issue-1239.rs
+++ b/tests/target/issue-1239.rs
@@ -1,11 +1,10 @@
 fn foo() {
-    let with_alignment = if condition__uses_alignment_for_first_if__0 ||
-        condition__uses_alignment_for_first_if__1 ||
-        condition__uses_alignment_for_first_if__2
+    let with_alignment = if condition__uses_alignment_for_first_if__0
+        || condition__uses_alignment_for_first_if__1
+        || condition__uses_alignment_for_first_if__2
     {
-    } else if condition__no_alignment_for_later_else__0 ||
-        condition__no_alignment_for_later_else__1 ||
-        condition__no_alignment_for_later_else__2
+    } else if condition__no_alignment_for_later_else__0 || condition__no_alignment_for_later_else__1
+        || condition__no_alignment_for_later_else__2
     {
     };
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -324,9 +324,9 @@ fn guards() {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             if foooooooooooooo && barrrrrrrrrrrr => {}
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            if fooooooooooooooooooooo &&
-                (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
-                    cccccccccccccccccccccccccccccccccccccccc) => {}
+            if fooooooooooooooooooooo
+                && (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+                    || cccccccccccccccccccccccccccccccccccccccc) => {}
     }
 }
 

--- a/tests/target/type-ascription.rs
+++ b/tests/target/type-ascription.rs
@@ -5,8 +5,8 @@ fn main() {
     let xxxxxxxxxxxxxxx =
         yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 
-    let z = funk(yyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzz, wwwwww)
-        : AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+    let z = funk(yyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzz, wwwwww):
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 
     x: u32 - 1u32 / 10f32: u32
 }

--- a/tests/target/type-ascription.rs
+++ b/tests/target/type-ascription.rs
@@ -5,8 +5,8 @@ fn main() {
     let xxxxxxxxxxxxxxx =
         yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 
-    let z = funk(yyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzz, wwwwww):
-        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+    let z = funk(yyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzz, wwwwww)
+        : AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
 
     x: u32 - 1u32 / 10f32: u32
 }


### PR DESCRIPTION
This PR implements a config option for controlling the placement of binary operators, and change the default to put binary operators in front so that it follows the style specified in RFC.

cc https://github.com/rust-lang-nursery/fmt-rfcs/issues/18.
cc https://github.com/rust-lang-nursery/fmt-rfcs/pull/91.