### PR TITLE
Avoid panicking when calling 'cargo fmt --all'

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -248,7 +248,7 @@ fn get_targets(workspace_hitlist: &WorkspaceHitlist) -> Result<Vec<Target>, std:
                 hitlist.take(&member_name.to_string()).is_some()
             })
             .collect();
-        if hitlist.is_empty() {
+        if !hitlist.is_empty() {
             // Mimick cargo of only outputting one <package> spec.
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,


### PR DESCRIPTION
Closes #1963.
Due to a typo from #1931 😞 