### PR TITLE
Refactoring: use Cow and etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = "0.2.6"
 dependencies = [
  "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -117,22 +117,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -141,13 +141,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0a515461b6c8c08419850ced27bc29e86166dcdcde8fbe76f8b1f0589bb49472"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac17257442c2ed77dbc9fd555cf83c58b0c7f7d0e8f2ae08c0ac05c72842e1f6"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
@@ -256,10 +256,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
-"checksum serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cf823e706be268e73e7747b147aa31c8f633ab4ba31f115efb57e5047c3a76dd"
-"checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
-"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
+"checksum serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb6a7637a47663ee073391a139ed07851f27ed2532c2abc88c6bf27a16cdf34"
+"checksum serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "812ff66056fd9a9a5b7c119714243b0862cf98340e7d4b5ee05a932c40d5ea6c"
+"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
 "checksum strings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da75d8bf2c4d210d63dd09581a041b036001f9f6e03d9b151dbff810fb7ba26a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -294,7 +294,7 @@ pub fn format_expr(
                 Some(format!(
                     "{}{}",
                     "do catch ",
-                    try_opt!(block.rewrite(&context, Shape::legacy(budget, shape.indent)))
+                    try_opt!(block.rewrite(context, Shape::legacy(budget, shape.indent)))
                 ))
             }
         }
@@ -3004,17 +3004,17 @@ impl<'a> ToExpr for ast::StructField {
 
 impl<'a> ToExpr for MacroArg {
     fn to_expr(&self) -> Option<&ast::Expr> {
-        match self {
-            &MacroArg::Expr(ref expr) => Some(expr),
+        match *self {
+            MacroArg::Expr(ref expr) => Some(expr),
             _ => None,
         }
     }
 
     fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        match self {
-            &MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
-            &MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
-            &MacroArg::Pat(..) => false,
+        match *self {
+            MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
+            MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
+            MacroArg::Pat(..) => false,
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::cmp::{min, Ordering};
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::iter::{repeat, ExactSizeIterator};
 
@@ -1364,10 +1365,10 @@ impl<'a> Rewrite for ControlFlow<'a> {
     }
 }
 
-fn rewrite_label(label: Option<ast::SpannedIdent>) -> String {
+fn rewrite_label(label: Option<ast::SpannedIdent>) -> Cow<'static, str> {
     match label {
-        Some(ident) => format!("{}: ", ident.node),
-        None => "".to_owned(),
+        Some(ident) => Cow::from(format!("{}: ", ident.node)),
+        None => Cow::from(""),
     }
 }
 
@@ -1926,7 +1927,11 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
                 string_lit
                     .lines()
                     .map(|line| {
-                        new_indent.to_string(context.config) + line.trim_left()
+                        format!(
+                            "{}{}",
+                            new_indent.to_string(context.config),
+                            line.trim_left()
+                        )
                     })
                     .collect::<Vec<_>>()
                     .join("\n")

--- a/src/items.rs
+++ b/src/items.rs
@@ -330,7 +330,7 @@ impl<'a> FmtVisitor<'a> {
                                 ""
                             };
 
-                            format_expr(&e, ExprType::Statement, &self.get_context(), self.shape())
+                            format_expr(e, ExprType::Statement, &self.get_context(), self.shape())
                                 .map(|s| s + suffix)
                                 .or_else(|| Some(self.snippet(e.span)))
                         }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -114,7 +114,7 @@ pub struct ListItem {
 
 impl ListItem {
     pub fn inner_as_ref(&self) -> &str {
-        self.item.as_ref().map_or("", |s| &*s)
+        self.item.as_ref().map_or("", |s| s)
     }
 
     pub fn is_different_group(&self) -> bool {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -289,7 +289,7 @@ where
             inner_item.as_ref()
         };
         let mut item_last_line_width = item_last_line.len() + item_sep_len;
-        if item_last_line.starts_with(indent_str) {
+        if item_last_line.starts_with(&**indent_str) {
             item_last_line_width -= indent_str.len();
         }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -104,7 +104,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
     parse_macro_arg!(ty, Ty, parse_ty);
     parse_macro_arg!(pat, Pat, parse_pat);
 
-    return None;
+    None
 }
 
 pub fn rewrite_macro(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -383,7 +383,7 @@ fn indent_macro_snippet(
                                 .checked_sub(min_prefix_space_width)
                                 .unwrap_or(0);
                         let new_indent = Indent::from_width(context.config, new_indent_width);
-                        new_indent.to_string(context.config) + line.trim()
+                        format!("{}{}", new_indent.to_string(context.config), line.trim())
                     }
                     None => String::new(),
                 })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,11 +89,11 @@ pub fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
-pub fn format_abi(abi: abi::Abi, explicit_abi: bool) -> String {
+pub fn format_abi(abi: abi::Abi, explicit_abi: bool) -> Cow<'static, str> {
     if abi == abi::Abi::C && !explicit_abi {
-        "extern ".into()
+        Cow::from("extern ")
     } else {
-        format!("extern {} ", abi)
+        Cow::from(format!("extern {} ", abi))
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -340,7 +340,7 @@ impl<'a> FmtVisitor<'a> {
         }
 
         match item.node {
-            ast::ItemKind::Use(ref vp) => self.format_import(&item, vp),
+            ast::ItemKind::Use(ref vp) => self.format_import(item, vp),
             ast::ItemKind::Impl(..) => {
                 let snippet = self.snippet(item.span);
                 let where_span_end = snippet
@@ -381,7 +381,7 @@ impl<'a> FmtVisitor<'a> {
             }
             ast::ItemKind::Mod(ref module) => {
                 self.format_missing_with_indent(source!(self, item.span).lo());
-                self.format_mod(module, &item.vis, item.span, item.ident, &attrs);
+                self.format_mod(module, &item.vis, item.span, item.ident, attrs);
             }
             ast::ItemKind::Mac(ref mac) => {
                 self.visit_mac(mac, Some(item.ident), MacroPosition::Item);


### PR DESCRIPTION
This PR changes the return type of some functions from `String` to `Cow<'static, str>` to avoid unnecessary allocation.