### PR TITLE
get_targets: Fix inverted is_empty test

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -248,7 +248,7 @@ fn get_targets(workspace_hitlist: &WorkspaceHitlist) -> Result<Vec<Target>, std:
                 hitlist.take(&member_name.to_string()).is_some()
             })
             .collect();
-        if hitlist.is_empty() {
+        if !hitlist.is_empty() {
             // Mimick cargo of only outputting one <package> spec.
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,


### PR DESCRIPTION
This test was mistakenly inverted by commit 4b79055a158e388e4b47026958da0f57e07dd940 (#1931).

```
$ cargo fmt --all
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /checkout/src/libcore/option.rs:335:20
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
