### PR TITLE
Run recover_comment_removed() only if the text changed after format

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -826,7 +826,7 @@ pub fn recover_comment_removed(
     shape: Shape,
 ) -> Option<String> {
     let snippet = context.snippet(span);
-    if changed_comment_content(&snippet, &new) {
+    if snippet != new && changed_comment_content(&snippet, &new) {
         // We missed some comments
         // Keep previous formatting if it satisfies the constrains
         wrap_str(snippet, context.config.max_width(), shape)

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -18,7 +18,7 @@ use {Indent, Shape};
 use config::Config;
 use rewrite::RewriteContext;
 use string::{rewrite_string, StringFormat};
-use utils::{first_line_width, last_line_width, wrap_str};
+use utils::{first_line_width, last_line_width};
 
 fn is_custom_comment(comment: &str) -> bool {
     if !comment.starts_with("//") {
@@ -823,13 +823,11 @@ pub fn recover_comment_removed(
     new: String,
     span: Span,
     context: &RewriteContext,
-    shape: Shape,
 ) -> Option<String> {
     let snippet = context.snippet(span);
     if snippet != new && changed_comment_content(&snippet, &new) {
-        // We missed some comments
-        // Keep previous formatting if it satisfies the constrains
-        wrap_str(snippet, context.config.max_width(), shape)
+        // We missed some comments. Keep the original text.
+        Some(snippet)
     } else {
         Some(new)
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -328,7 +328,7 @@ pub fn format_expr(
 
     expr_rw
         .and_then(|expr_str| {
-            recover_comment_removed(expr_str, expr.span, context, shape)
+            recover_comment_removed(expr_str, expr.span, context)
         })
         .and_then(|expr_str| {
             let attrs = outer_attributes(&expr.attrs);
@@ -920,9 +920,7 @@ impl Rewrite for ast::Stmt {
             }
             ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
         };
-        result.and_then(|res| {
-            recover_comment_removed(res, self.span(), context, shape)
-        })
+        result.and_then(|res| recover_comment_removed(res, self.span(), context))
     }
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -1488,9 +1488,7 @@ pub fn rewrite_static(
             lhs,
             expr,
             Shape::legacy(remaining_width, offset.block_only()),
-        ).and_then(|res| {
-            recover_comment_removed(res, span, context, Shape::indented(offset, context.config))
-        })
+        ).and_then(|res| recover_comment_removed(res, span, context))
             .map(|s| if s.ends_with(';') { s } else { s + ";" })
     } else {
         Some(format!("{}{};", prefix, ty_str))


### PR DESCRIPTION
One of the most time consuming function in rustfmt is `recover_comment_removed()`. E.g. it takes up roughly 20% of the execution time when running rustfmt against librustc.
This PR attempts to avoid expensive recover procedure whenever possible by comparing the equality of original text and formatted text.

cc #338