### PR TITLE
Temporarily replace `RangeEnd::Included` with `_`

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -59,21 +59,24 @@ impl Rewrite for Pat {
                 None
             },
             PatKind::Range(ref lhs, ref rhs, ref end_kind) => match *end_kind {
-                RangeEnd::Included => rewrite_pair(
-                    &**lhs,
-                    &**rhs,
-                    "",
-                    "...",
-                    "",
-                    context,
-                    shape,
-                    SeparatorPlace::Front,
-                ),
                 RangeEnd::Excluded => rewrite_pair(
                     &**lhs,
                     &**rhs,
                     "",
                     "..",
+                    "",
+                    context,
+                    shape,
+                    SeparatorPlace::Front,
+                ),
+                // FIXME: Change _ to RangeEnd::Included(RangeSyntax::DotDotDot)
+                // and add RangeEnd::Included(RangeSyntax::DotDotEq)
+                // once rust PR #44709 gets merged
+                _ => rewrite_pair(
+                    &**lhs,
+                    &**rhs,
+                    "",
+                    "...",
                     "",
                     context,
                     shape,


### PR DESCRIPTION
Hi! I'm currently adding support for `..=` syntax as a synonym for `...`: https://github.com/rust-lang/rust/pull/44709
I made a small change in ~HIR~ the AST which prevents rustfmt from compiling, however with this workaround it will compile without errors, in both old and new versions of rustc. Once the PR gets merged, I will fix this. Basically the change in ~HIR~ the AST is the new RangeSyntax enum:

    enum RangeEnd {
       // Included,
       Included(RangeSyntax),
       Excluded,
    }

    enum RangeSyntax {
       DotDotDot, // ...
       DotDotEq,  // ..=
    }