### PR TITLE
Support for `..=` syntax

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -232,7 +232,7 @@ pub fn format_expr(
         ast::ExprKind::Range(ref lhs, ref rhs, limits) => {
             let delim = match limits {
                 ast::RangeLimits::HalfOpen => "..",
-                ast::RangeLimits::Closed => "...",
+                ast::RangeLimits::Closed => "..=",
             };
 
             fn needs_space_before_range(context: &RewriteContext, lhs: &ast::Expr) -> bool {

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd};
+use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
 use syntax::codemap::{self, BytePos, Span};
 use syntax::ptr;
 
@@ -58,31 +58,23 @@ impl Rewrite for Pat {
             } else {
                 None
             },
-            PatKind::Range(ref lhs, ref rhs, ref end_kind) => match *end_kind {
-                RangeEnd::Excluded => rewrite_pair(
+            PatKind::Range(ref lhs, ref rhs, ref end_kind) => {
+                let infix = match *end_kind {
+                    RangeEnd::Included(RangeSyntax::DotDotDot) => "...",
+                    RangeEnd::Included(RangeSyntax::DotDotEq) => "..=",
+                    RangeEnd::Excluded => "..",
+                };
+                rewrite_pair(
                     &**lhs,
                     &**rhs,
                     "",
-                    "..",
+                    infix,
                     "",
                     context,
                     shape,
                     SeparatorPlace::Front,
-                ),
-                // FIXME: Change _ to RangeEnd::Included(RangeSyntax::DotDotDot)
-                // and add RangeEnd::Included(RangeSyntax::DotDotEq)
-                // once rust PR #44709 gets merged
-                _ => rewrite_pair(
-                    &**lhs,
-                    &**rhs,
-                    "",
-                    "...",
-                    "",
-                    context,
-                    shape,
-                    SeparatorPlace::Front,
-                ),
-            },
+                )
+            }
             PatKind::Ref(ref pat, mutability) => {
                 let prefix = format!("&{}", format_mutability(mutability));
                 rewrite_unary_prefix(context, &prefix, &**pat, shape)

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -250,17 +250,17 @@ fn issue767() {
 
 fn ranges() {
     let x = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa .. bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-    let y = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ... bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-    let z = ... x ;
+    let y = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ..= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+    let z = ..= x ;
 
     // #1766
     let x = [0. ..10.0];
-    let x = [0. ...10.0];
+    let x = [0. ..=10.0];
 
-    a ... b
+    a ..= b
 
-    // the expr below won't compile for some reason...
-    // let a = 0 ... ;
+    // the expr below won't compile because inclusive ranges need a defined end
+    // let a = 0 ..= ;
 }
 
 fn if_else() {

--- a/tests/source/spaces-around-ranges.rs
+++ b/tests/source/spaces-around-ranges.rs
@@ -4,12 +4,12 @@ fn bar(v: &[u8]) {}
 
 fn foo() {
     let a = vec![0; 20];
-    for j in 0...20 {
+    for j in 0..=20 {
         for i in 0..3 {
             bar(a[i..j]);
             bar(a[i..]);
             bar(a[..j]);
-            bar(a[...(j + 1)]);
+            bar(a[..=(j + 1)]);
         }
     }
 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -316,17 +316,17 @@ fn issue767() {
 fn ranges() {
     let x = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
     let y =
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-    let z = ...x;
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+    let z = ..=x;
 
     // #1766
     let x = [0. ..10.0];
-    let x = [0. ...10.0];
+    let x = [0. ..=10.0];
 
-    a...b
+    a..=b
 
-    // the expr below won't compile for some reason...
-    // let a = 0 ... ;
+    // the expr below won't compile because inclusive ranges need a defined end
+    // let a = 0 ..= ;
 }
 
 fn if_else() {

--- a/tests/target/spaces-around-ranges.rs
+++ b/tests/target/spaces-around-ranges.rs
@@ -4,12 +4,12 @@ fn bar(v: &[u8]) {}
 
 fn foo() {
     let a = vec![0; 20];
-    for j in 0 ... 20 {
+    for j in 0 ..= 20 {
         for i in 0 .. 3 {
             bar(a[i .. j]);
             bar(a[i ..]);
             bar(a[.. j]);
-            bar(a[... (j + 1)]);
+            bar(a[..= (j + 1)]);
         }
     }
 }


### PR DESCRIPTION
As promised, here is full support for the new `..=` syntax. Here is the tracking issue https://github.com/rust-lang/rust/issues/28237

I've updated the tests that used `...` in expressions: `let x = a...b;`, as that syntax is deprecated now, but I didn't add any new tests for `..=` in patterns: `match x { 0..=10 => true, _ => false }` (it should be exactly the same as `...`).