### PR TITLE
Change return type of rewrite_call_inner() to Option<String>

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1211,17 +1211,15 @@ fn format_tuple_struct(
         result.push(')');
     } else {
         // 3 = `();`
-        let body = try_opt!(
-            rewrite_call_inner(
-                context,
-                "",
-                &fields.iter().map(|field| field).collect::<Vec<_>>()[..],
-                span,
-                Shape::legacy(context.budget(last_line_width(&result) + 3), offset),
-                context.config.fn_call_width(),
-                false,
-            ).ok()
-        );
+        let body = try_opt!(rewrite_call_inner(
+            context,
+            "",
+            &fields.iter().map(|field| field).collect::<Vec<_>>()[..],
+            span,
+            Shape::legacy(context.budget(last_line_width(&result) + 3), offset),
+            context.config.fn_call_width(),
+            false,
+        ));
         result.push_str(&body);
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -202,7 +202,7 @@ pub fn rewrite_macro(
         MacroStyle::Parens => {
             // Format macro invocation as function call, forcing no trailing
             // comma because not all macros support them.
-            let rw = rewrite_call_inner(
+            rewrite_call_inner(
                 context,
                 &macro_name,
                 &arg_vec.iter().map(|e| &*e).collect::<Vec<_>>()[..],
@@ -210,8 +210,7 @@ pub fn rewrite_macro(
                 shape,
                 context.config.fn_call_width(),
                 trailing_comma,
-            );
-            rw.ok().map(|rw| match position {
+            ).map(|rw| match position {
                 MacroPosition::Item => format!("{};", rw),
                 _ => rw,
             })

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -351,7 +351,7 @@ fn rewrite_tuple_pat(
         shape,
         shape.width,
         add_comma,
-    ).ok()
+    )
 }
 
 fn count_wildcard_suffix_len(


### PR DESCRIPTION
Since we entirely removed binary search from `rewrite_call()`, there is no need to return `Result<String, Ordering>` any more.