### PR TITLE
Fix broken tests under CRLF environment.

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -31,8 +31,8 @@ use types::join_bounds;
 use utils::{colon_spaces, contains_skip, end_typaram, first_line_width, format_abi,
             format_constness, format_defaultness, format_mutability, format_unsafety,
             format_visibility, is_attributes_extendable, last_line_contains_single_line_comment,
-            last_line_used_width, last_line_width, mk_sp, semicolon_for_expr, stmt_expr,
-            trim_newlines, trimmed_last_line_width};
+            last_line_used_width, last_line_width, mk_sp, semicolon_for_expr, starts_with_newline,
+            stmt_expr, trim_newlines, trimmed_last_line_width};
 use vertical::rewrite_with_alignment;
 use visitor::FmtVisitor;
 
@@ -1940,7 +1940,7 @@ fn rewrite_fn_base(
             // Try to preserve the layout of the original snippet.
             let original_starts_with_newline = snippet
                 .find(|c| c != ' ')
-                .map_or(false, |i| snippet[i..].starts_with('\n'));
+                .map_or(false, |i| starts_with_newline(&snippet[i..]));
             let original_ends_with_newline = snippet
                 .rfind(|c| c != ' ')
                 .map_or(false, |i| snippet[i..].ends_with('\n'));

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -17,7 +17,7 @@ use comment::{find_comment_end, rewrite_comment, FindUncommented};
 use config::{Config, IndentStyle};
 use rewrite::RewriteContext;
 use shape::{Indent, Shape};
-use utils::{first_line_width, last_line_width, mk_sp};
+use utils::{first_line_width, last_line_width, mk_sp, starts_with_newline};
 
 /// Formatting tactic for lists. This will be cast down to a
 /// `DefinitiveListTactic` depending on the number and length of the items and
@@ -425,7 +425,7 @@ where
 
             let mut formatted_comment = try_opt!(rewrite_post_comment(&mut item_max_width));
 
-            if !formatted_comment.starts_with('\n') {
+            if !starts_with_newline(&formatted_comment) {
                 let mut comment_alignment =
                     post_comment_alignment(item_max_width, inner_item.len());
                 if first_line_width(&formatted_comment) + last_line_width(&result)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -493,3 +493,7 @@ pub fn isatty() -> bool {
         kernel32::GetConsoleMode(handle, &mut out) != 0
     }
 }
+
+pub fn starts_with_newline(s: &str) -> bool {
+    s.starts_with('\n') || s.starts_with("\r\n")
+}


### PR DESCRIPTION
Fixes #617 ... for now.

The problem was that some codes are assuming the newline in the input code is always '\n'. Especially, str.starts_with('\n') was breaking danger because it always fail in CRLF environment.
I'm still feeling uncomfortable that so many codes seems to not consider CRLF env, but fortunately str.ends_with('\n') and str.contains('\n') both work properly under CRLF env. At least, no tests are broken in Windows anymore.

Need to push #2028 beforehand to check if the tests are really fixed under Windows.