### PR TITLE
[not ready] Implement match_arm_forces_newline option (#2039)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1229,6 +1229,48 @@ struct Dolor<T>
 }
 ```
 
+## `match_arm_forces_newline`
+
+Consistently put match arms (block based or not) in a newline.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+
+#### `false` (default):
+
+```rust
+match x {
+    // a non-empty block
+    X0 => {
+        f();
+    }
+    // an empty block
+    X1 => {}
+    // a non-block
+    X2 => println!("ok"),
+}
+```
+
+#### `true`:
+
+```rust
+match x {
+    // a non-empty block
+    X0 => {
+        f();
+    }
+    // an empty block
+    X1 =>
+        {}
+    // a non-block
+    X2 => {
+        println!("ok")
+    }
+}
+```
+
+See also: [`wrap_match_arms`](#wrap_match_arms).
+
 ## `match_block_trailing_comma`
 
 Put a trailing comma after a block based match arm (non-block arms are not affected)

--- a/src/config.rs
+++ b/src/config.rs
@@ -597,6 +597,8 @@ create_config! {
                                   the same line with the pattern of arms";
     match_block_trailing_comma: bool, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
+    match_arm_forces_newline: bool, false,
+        "Force match arm bodies to be in a new lines";
     indent_match_arms: bool, true, "Indent match arms instead of keeping them at the same \
                                     indentation level as the match keyword";
     match_pattern_separator_break_point: SeparatorPlace, SeparatorPlace::Back,

--- a/tests/source/configs-match_arm_forces_newline-true.rs
+++ b/tests/source/configs-match_arm_forces_newline-true.rs
@@ -1,0 +1,20 @@
+// rustfmt-match_arm_forces_newline: true
+// rustfmt-wrap_match_arms: false
+
+// match_arm_forces_newline puts all match arms bodies in a newline and indents
+// them.
+
+fn main() {
+    match x() {
+        // a short non-empty block
+        X0 => { f(); }
+        // a long non-empty block
+        X1 => { some.really.long.expression.fooooooooooooooooooooooooooooooooooooooooo().baaaaarrrrrrrrrrrrrrrrrrrrrrrrrr(); }
+        // an empty block
+        X2 => {}
+        // a short non-block
+        X3 => println!("ok"),
+        // a long non-block
+        X4 => foo.bar.baz.test.x.y.z.a.s.d.fasdfasdf.asfads.fasd.fasdfasdf.dfasfdsaf(),
+    }
+}

--- a/tests/target/configs-match_arm_forces_newline-true.rs
+++ b/tests/target/configs-match_arm_forces_newline-true.rs
@@ -1,0 +1,44 @@
+// rustfmt-match_arm_forces_newline: true
+// rustfmt-wrap_match_arms: false
+
+// match_arm_forces_newline puts all match arms bodies in a newline and indents
+// them.
+
+fn main() {
+    match x() {
+        // a short non-empty block
+        X0 => {
+            f();
+        }
+        // a long non-empty block
+        X1 => {
+            some.really
+                .long
+                .expression
+                .fooooooooooooooooooooooooooooooooooooooooo()
+                .baaaaarrrrrrrrrrrrrrrrrrrrrrrrrr();
+        }
+        // an empty block
+        X2 =>
+            {}
+        // a short non-block
+        X3 =>
+            println!("ok"),
+        // a long non-block
+        X4 =>
+            foo.bar
+                .baz
+                .test
+                .x
+                .y
+                .z
+                .a
+                .s
+                .d
+                .fasdfasdf
+                .asfads
+                .fasd
+                .fasdfasdf
+                .dfasfdsaf(),
+    }
+}


### PR DESCRIPTION
This is an attempt at implementing #2039. I don't quite understand `rewrite_match_body` function yet, I just played around with some parameters until it indented as I wanted.