### PR TITLE
default --dump-default-config path to rustfmt.toml

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -129,7 +129,7 @@ fn make_opts() -> Options {
         "",
         "dump-default-config",
         "Dumps the default configuration to a file and exits. PATH defaults to rustfmt.toml if \
-        omitted.",
+         omitted.",
         "PATH",
         HasArg::Maybe,
         Occur::Optional,


### PR DESCRIPTION
closes #1988