### PR TITLE
add `required-version` option to rustfmt.toml

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -195,7 +195,13 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
                 }
             }
 
-            Ok(run(Input::Text(input), &config))
+            let mut error_summary = Summary::default();
+            if config.version_meets_requirement(&mut error_summary) {
+                error_summary.add(run(Input::Text(input), &config));
+            }
+
+            Ok(error_summary)
+
         }
         Operation::Format {
             files,
@@ -245,6 +251,10 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
                             }
                         }
                         config = config_tmp;
+                    }
+
+                    if !config.version_meets_requirement(&mut error_summary) {
+                        break
                     }
 
                     options.clone().apply_to(&mut config);

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -201,7 +201,6 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
             }
 
             Ok(error_summary)
-
         }
         Operation::Format {
             files,
@@ -254,7 +253,7 @@ fn execute(opts: &Options) -> FmtResult<Summary> {
                     }
 
                     if !config.version_meets_requirement(&mut error_summary) {
-                        break
+                        break;
                     }
 
                     options.clone().apply_to(&mut config);

--- a/src/config.rs
+++ b/src/config.rs
@@ -640,7 +640,7 @@ create_config! {
     merge_derives: bool, true, "Merge multiple `#[derive(...)]` into a single one";
     binop_separator: SeparatorPlace, SeparatorPlace::Front,
         "Where to put a binary operator when a binary expression goes multiline.";
-    required_version: String, "".to_owned(),
+    required_version: String, env!("CARGO_PKG_VERSION").to_owned(),
         "Require a specific version of rustfmt."
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use file_lines::FileLines;
 use lists::{ListTactic, SeparatorPlace, SeparatorTactic};
+use Summary;
 
 macro_rules! configuration_option_enum{
     ($e:ident: $( $x:ident ),+ $(,)*) => {
@@ -272,6 +273,23 @@ macro_rules! create_config {
         }
 
         impl Config {
+            pub fn version_meets_requirement(&self, error_summary: &mut Summary) -> bool {
+                if self.was_set().required_version() {
+                    let version = env!("CARGO_PKG_VERSION");
+                    let required_version = self.required_version();
+                    if version != required_version {
+                        println!(
+                            "Error: rustfmt version ({}) doesn't match the required version ({})",
+                            version,
+                            required_version,
+                        );
+                        error_summary.add_formatting_error();
+                        return false;
+                    }
+                }
+
+                true
+            }
 
             $(
             pub fn $i(&self) -> $ty {
@@ -622,6 +640,8 @@ create_config! {
     merge_derives: bool, true, "Merge multiple `#[derive(...)]` into a single one";
     binop_separator: SeparatorPlace, SeparatorPlace::Front,
         "Where to put a binary operator when a binary expression goes multiline.";
+    required_version: String, "".to_owned(),
+        "Require a specific version of rustfmt."
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This option specifies the rustfmt version that *must* be used to format the code. Trying to use a
different version raises an error.

closes #1505