### PR TITLE
Add a test for issue 1211, showing it's no longer an issue.

### DIFF
--- a/tests/source/issue-1211.rs
+++ b/tests/source/issue-1211.rs
@@ -1,0 +1,15 @@
+fn main() {
+    for iface in &ifaces {
+        match iface.addr {
+            get_if_addrs::IfAddr::V4(ref addr) => {
+                match addr.broadcast {
+                    Some(ip) => {
+                        sock.send_to(&buf, (ip, 8765)).expect("foobar");
+                    }
+                    _ => ()
+                }
+            }
+            _ => ()
+        };
+    }
+}

--- a/tests/target/issue-1211.rs
+++ b/tests/target/issue-1211.rs
@@ -1,0 +1,13 @@
+fn main() {
+    for iface in &ifaces {
+        match iface.addr {
+            get_if_addrs::IfAddr::V4(ref addr) => match addr.broadcast {
+                Some(ip) => {
+                    sock.send_to(&buf, (ip, 8765)).expect("foobar");
+                }
+                _ => (),
+            },
+            _ => (),
+        };
+    }
+}


### PR DESCRIPTION
Since rustfmt has moved away from syntex the overflow seen in https://github.com/rust-lang-nursery/rustfmt/issues/1211 is no longer a problem. This commit adds a test to verify that.

Closes #1211.