### PR TITLE
[WIP] keep match arms within the max width

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1807,6 +1807,11 @@ fn rewrite_match_body(
         }
         (None, Some(ref next_line_str)) => combine_next_line_body(next_line_str),
         (None, None) => None,
+        (Some(ref orig_str), Some(ref next_line_str))
+            if first_line_width(orig_str) > orig_budget =>
+        {
+            combine_next_line_body(next_line_str)
+        }
         (Some(ref orig_str), _) => combine_orig_body(orig_str),
     }
 }

--- a/tests/source/issue-2021-1.rs
+++ b/tests/source/issue-2021-1.rs
@@ -1,0 +1,8 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val =
+            match *cv {
+                ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => bug!("MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)", cv),
+            };
+    }
+}

--- a/tests/source/issue-2021-2.rs
+++ b/tests/source/issue-2021-2.rs
@@ -1,0 +1,8 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val =
+            match *cv {
+                ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => eprintln!("MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)", cv),
+            };
+    }
+}

--- a/tests/source/issue-2021-3.rs
+++ b/tests/source/issue-2021-3.rs
@@ -1,0 +1,8 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val =
+            match *cv {
+                ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => println!("MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)", cv),
+            };
+    }
+}

--- a/tests/target/issue-2021-1.rs
+++ b/tests/target/issue-2021-1.rs
@@ -1,0 +1,10 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val = match *cv {
+            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => bug!(
+                "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
+                cv
+            ),
+        };
+    }
+}

--- a/tests/target/issue-2021-2.rs
+++ b/tests/target/issue-2021-2.rs
@@ -1,0 +1,12 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val = match *cv {
+            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => {
+                eprintln!(
+                    "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
+                    cv
+                )
+            }
+        };
+    }
+}

--- a/tests/target/issue-2021-3.rs
+++ b/tests/target/issue-2021-3.rs
@@ -1,0 +1,12 @@
+impl<'tcx> Const<'tcx> {
+    pub fn from_constval<'a>() -> Const<'tcx> {
+        let val = match *cv {
+            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => {
+                println!(
+                    "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
+                    cv
+                )
+            }
+        };
+    }
+}


### PR DESCRIPTION
closes #2021

This formats the snippet in #2021 as:

``` rust
// tests/target/issue-2021-1.rs
impl<'tcx> Const<'tcx> {
    pub fn from_constval<'a>() -> Const<'tcx> {
        let val = match *cv {
            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => bug!(
                "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
                cv
            ),
        };
    }
}
```

which doesn't quite match the ideal formatting described by @topecongiro but at least is within the
width limits.

Increasing the length of the macro name does produce a surrounding block:

``` rust
// tests/target/issue-2021-2.rs
impl<'tcx> Const<'tcx> {
    pub fn from_constval<'a>() -> Const<'tcx> {
        let val = match *cv {
            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => {
                eprintln!(
                    "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
                    cv
                )
            }
        };
    }
}
```

Though perhaps the arguments of the macro shouldn't be broken into separate lines?

One issue that this PR has is that for some length of the macro name the idempotence property is
lost. For example, formatting the code below

``` rust
// tests/source/issue-2021-3.rs
impl<'tcx> Const<'tcx> {
    pub fn from_constval<'a>() -> Const<'tcx> {
        let val =
            match *cv {
                ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => println!("MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)", cv),
            };
    }
}
```

produces:

``` rust
// tests/target/issue-2021-3.rs
impl<'tcx> Const<'tcx> {
    pub fn from_constval<'a>() -> Const<'tcx> {
        let val = match *cv {
            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => {
                println!(
                    "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
                    cv
                )
            }
        };
    }
}
```

but formatting the code again produces:

``` rust
impl<'tcx> Const<'tcx> {
    pub fn from_constval<'a>() -> Const<'tcx> {
        let val = match *cv {
            ConstVal::Variant(_) | ConstVal::Aggregate(..) | ConstVal::Unevaluated(..) => println!(
                    "MIR must not use `{:?}` (aggregates are expanded to MIR rvalues)",
                    cv
                ),
        };
    }
}
```

I haven't been able to nail down the exact source of this behavior. But my closest guess is that
it's some sort of bug (?) in `rewrite_macro`; AFAICT when formatting `tests/source/issue-2021-3.rs`
and `tests/target/issue-2021-3.rs` that method is fed the exact same arguments (i.e. same AST and
shape), *except* for the original span of the macro, yet it produces a different output in each
case. I think this discrepancy may arise from the fact that we flatten the RHS of the match arm
before formatting / rewriting; AFAICT this flattening doesn't modify the original span of the macro.

Any hints about where to look next would be appreciated!