### PR TITLE
Add crates.io version shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rustfmt [![Build Status](https://travis-ci.org/rust-lang-nursery/rustfmt.svg)](https://travis-ci.org/rust-lang-nursery/rustfmt) [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt?svg=true)](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt)
+# rustfmt [![Build Status](https://travis-ci.org/rust-lang-nursery/rustfmt.svg)](https://travis-ci.org/rust-lang-nursery/rustfmt) [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt?svg=true)](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt) [![crates.io](https://img.shields.io/crates/v/rustfmt-nightly.svg)](https://crates.io/crates/rustfmt-nightly)
 
 A tool for formatting Rust code according to style guidelines.
 


### PR DESCRIPTION
Would make it easier to see what the version is and to get to https://crates.io/crates/rustfmt-nightly from https://github.com/rust-lang-nursery/rustfmt