### PR TITLE
Remove trailing white spaces from skipped items 

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -20,7 +20,8 @@ use spanned::Spanned;
 use chains::rewrite_chain;
 use codemap::{LineRangeUtils, SpanUtils};
 use comment::{combine_strs_with_missing_comments, contains_comment, recover_comment_removed,
-              rewrite_comment, rewrite_missing_comment, FindUncommented};
+              remove_trailing_white_spaces, rewrite_comment, rewrite_missing_comment,
+              FindUncommented};
 use config::{Config, ControlBraceStyle, IndentStyle, MultilineStyle, Style};
 use items::{span_hi_for_arg, span_lo_for_arg};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
@@ -60,7 +61,7 @@ pub fn format_expr(
     skip_out_of_file_lines_range!(context, expr.span);
 
     if contains_skip(&*expr.attrs) {
-        return Some(context.snippet(expr.span()));
+        return Some(remove_trailing_white_spaces(&context.snippet(expr.span())));
     }
 
     let expr_rw = match expr.node {
@@ -2592,7 +2593,7 @@ pub fn rewrite_field(
     prefix_max_width: usize,
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
-        return Some(context.snippet(field.span()));
+        return Some(remove_trailing_white_spaces(&context.snippet(field.span())));
     }
     let name = &field.ident.node.to_string();
     if field.is_shorthand {

--- a/src/items.rs
+++ b/src/items.rs
@@ -21,7 +21,8 @@ use syntax::visit;
 use spanned::Spanned;
 use codemap::{LineRangeUtils, SpanUtils};
 use comment::{combine_strs_with_missing_comments, contains_comment, recover_comment_removed,
-              recover_missing_comment_in_span, rewrite_missing_comment, FindUncommented};
+              recover_missing_comment_in_span, remove_trailing_white_spaces,
+              rewrite_missing_comment, FindUncommented};
 use config::{BraceStyle, Config, Density, IndentStyle, ReturnIndent, Style};
 use expr::{format_expr, is_empty_block, is_simple_block_stmt, rewrite_assign_rhs,
            rewrite_call_inner, ExprType};
@@ -59,7 +60,7 @@ impl Rewrite for ast::Local {
         skip_out_of_file_lines_range!(context, self.span);
 
         if contains_skip(&self.attrs) {
-            return None;
+            return Some(remove_trailing_white_spaces(&context.snippet(self.span())));
         }
 
         let attrs_str = self.attrs.rewrite(context, shape)?;
@@ -507,7 +508,7 @@ impl<'a> FmtVisitor<'a> {
         if contains_skip(&field.node.attrs) {
             let lo = field.node.attrs[0].span.lo();
             let span = mk_sp(lo, field.span.hi());
-            return Some(self.snippet(span));
+            return Some(remove_trailing_white_spaces(&self.snippet(span)));
         }
 
         let context = self.get_context();
@@ -1375,7 +1376,7 @@ pub fn rewrite_struct_field(
     lhs_max_width: usize,
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
-        return Some(context.snippet(mk_sp(field.attrs[0].span.lo(), field.span.hi())));
+        return Some(remove_trailing_white_spaces(&context.snippet(field.span())));
     }
 
     let type_annotation_spacing = type_annotation_spacing(context.config);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -580,7 +580,7 @@ impl<'a> FmtVisitor<'a> {
 
     pub fn push_rewrite(&mut self, span: Span, rewrite: Option<String>) {
         self.format_missing_with_indent(source!(self, span).lo());
-        let result = rewrite.unwrap_or_else(|| self.snippet(span));
+        let result = rewrite.unwrap_or_else(|| remove_trailing_white_spaces(&self.snippet(span)));
         self.buffer.push_str(&result);
         self.last_pos = source!(self, span).hi();
     }

--- a/tests/source/skip.rs
+++ b/tests/source/skip.rs
@@ -71,3 +71,30 @@ fn skip_on_statements() {
 )]
 fn
 main() {}
+
+// Remove trailing whitespaces from skipped items.
+enum Foo {
+    #[rustfmt_skip]
+    Foo(
+        u32,
+        u32,  
+    ),
+}
+struct Bar {
+    #[rustfmt_skip]
+    field: 
+    u32,
+}
+fn foo() {
+    #[rustfmt_skip]
+    fn name() {
+        
+    }
+    #[rustfmt_skip]
+    let x =   
+        3;
+    #[rustfmt_skip]
+    foo(  
+        x,
+    )  
+}

--- a/tests/target/file-lines-4.rs
+++ b/tests/target/file-lines-4.rs
@@ -11,7 +11,7 @@ fn floaters() {
     let y = if cond {
                 val1
             } else {
-                val2	
+                val2
             }
                 .method_call();
                                                                                               // aaaaaaaaaaaaa
@@ -25,6 +25,6 @@ fn floaters() {
                                         }]
                                .clone());
             }
-        }    
+        }
     }
 }

--- a/tests/target/file-lines-5.rs
+++ b/tests/target/file-lines-5.rs
@@ -12,6 +12,6 @@ mod foo {
     }
     // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     fn baz() {
-        let j = 15;     
+        let j = 15;
     }
 }

--- a/tests/target/file-lines-6.rs
+++ b/tests/target/file-lines-6.rs
@@ -13,6 +13,6 @@ mod foo {
 
     fn baz() {
 ///
-        let j = 15;     
+        let j = 15;
     }
 }

--- a/tests/target/skip.rs
+++ b/tests/target/skip.rs
@@ -71,3 +71,30 @@ fn skip_on_statements() {
 )]
 fn
 main() {}
+
+// Remove trailing whitespaces from skipped items.
+enum Foo {
+    #[rustfmt_skip]
+    Foo(
+        u32,
+        u32,
+    ),
+}
+struct Bar {
+    #[rustfmt_skip]
+    field:
+    u32,
+}
+fn foo() {
+    #[rustfmt_skip]
+    fn name() {
+
+    }
+    #[rustfmt_skip]
+    let x =
+        3;
+    #[rustfmt_skip]
+    foo(
+        x,
+    )
+}


### PR DESCRIPTION
Closes #2037.

This PR changes rustfmt to remove trailing white spaces from skipped items. With `file_lines` option, this might be a problem, as it removes trailing white spaces from lines that are not specified (https://github.com/topecongiro/rustfmt/commit/b59992de2125fa11d62256ec482ba6d624271eeb). I am not sure if this is acceptable or not.
If this is not desired, I will add commits to fix it.