### PR TITLE
Return a more verbose error when formatting a file fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,14 @@ where
         }
         visitor.format_separate_mod(module, &*filemap);
 
-        has_diff |= after_file(path_str, &mut visitor.buffer)?;
+        has_diff |= match after_file(path_str, &mut visitor.buffer) {
+            Ok(result) => result,
+            Err(e) => {
+                // Create a new error with path_str to help users see which files failed
+                let mut err_msg = path_str.to_string() + &": ".to_string() + &e.to_string();
+                return Err(io::Error::new(e.kind(), err_msg));
+            }
+        };
 
         result.push((path_str.to_owned(), visitor.buffer));
     }


### PR DESCRIPTION
Expands the error message returned if the after_file function fails to also include path_str. This allows users to better identify files that are not being formatted. Attempts help address https://github.com/rust-lang-nursery/rustfmt/issues/1880, though doesn't provide the stats on how many files were and were not formatted.

Wasn't sure how to test or if a test is sane here, but please advise if anyone looking at this has any ideas how to do so.