### PR TITLE
Fix make_diff with zero context requested

### DIFF
--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -47,7 +47,7 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
     for result in diff::lines(expected, actual) {
         match result {
             diff::Result::Left(str) => {
-                if lines_since_mismatch >= context_size {
+                if lines_since_mismatch >= context_size && lines_since_mismatch > 0 {
                     results.push(mismatch);
                     mismatch = Mismatch::new(line_number - context_queue.len() as u32);
                 }
@@ -60,7 +60,7 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
                 lines_since_mismatch = 0;
             }
             diff::Result::Right(str) => {
-                if lines_since_mismatch >= context_size {
+                if lines_since_mismatch >= context_size && lines_since_mismatch > 0 {
                     results.push(mismatch);
                     mismatch = Mismatch::new(line_number - context_queue.len() as u32);
                 }
@@ -80,7 +80,7 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
 
                 if lines_since_mismatch < context_size {
                     mismatch.lines.push(DiffLine::Context(str.to_owned()));
-                } else {
+                } else if context_size > 0 {
                     context_queue.push_back(str);
                 }
 

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -169,7 +169,7 @@ mod test {
     use super::DiffLine::*;
 
     #[test]
-    fn simple_diff() {
+    fn diff_simple() {
         let src = "one\ntwo\nthree\nfour\nfive\n";
         let dest= "one\ntwo\ntrois\nfour\nfive\n";
         let diff = make_diff(src, dest, 1);
@@ -179,6 +179,18 @@ mod test {
                                              Resulting("three".into()),
                                              Expected("trois".into()),
                                              Context("four".into()),
+                                         ] }]);
+    }
+
+    #[test]
+    fn diff_zerocontext() {
+        let src = "one\ntwo\nthree\nfour\nfive\n";
+        let dest= "one\ntwo\ntrois\nfour\nfive\n";
+        let diff = make_diff(src, dest, 0);
+        assert_eq!(diff, vec![Mismatch { line_number: 3,
+                                         lines: vec![
+                                             Resulting("three".into()),
+                                             Expected("trois".into()),
                                          ] }]);
     }
 }

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -183,6 +183,26 @@ mod test {
     }
 
     #[test]
+    fn diff_simple2() {
+        let src = "one\ntwo\nthree\nfour\nfive\nsix\nseven\n";
+        let dest= "one\ntwo\ntrois\nfour\ncinq\nsix\nseven\n";
+        let diff = make_diff(src, dest, 1);
+        assert_eq!(diff, vec![Mismatch { line_number: 2,
+                                         lines: vec![
+                                             Context("two".into()),
+                                             Resulting("three".into()),
+                                             Expected("trois".into()),
+                                             Context("four".into()),
+                                         ] },
+                              Mismatch { line_number: 5,
+                                         lines: vec![
+                                             Resulting("five".into()),
+                                             Expected("cinq".into()),
+                                             Context("six".into()),
+                                         ] }]);
+    }
+
+    #[test]
     fn diff_zerocontext() {
         let src = "one\ntwo\nthree\nfour\nfive\n";
         let dest= "one\ntwo\ntrois\nfour\nfive\n";

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -162,3 +162,23 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{make_diff,Mismatch};
+    use super::DiffLine::*;
+
+    #[test]
+    fn simple_diff() {
+        let src = "one\ntwo\nthree\nfour\nfive\n";
+        let dest= "one\ntwo\ntrois\nfour\nfive\n";
+        let diff = make_diff(src, dest, 1);
+        assert_eq!(diff, vec![Mismatch { line_number: 2,
+                                         lines: vec![
+                                             Context("two".into()),
+                                             Resulting("three".into()),
+                                             Expected("trois".into()),
+                                             Context("four".into()),
+                                         ] }]);
+    }
+}

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -165,52 +165,72 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{make_diff,Mismatch};
+    use super::{make_diff, Mismatch};
     use super::DiffLine::*;
 
     #[test]
     fn diff_simple() {
         let src = "one\ntwo\nthree\nfour\nfive\n";
-        let dest= "one\ntwo\ntrois\nfour\nfive\n";
+        let dest = "one\ntwo\ntrois\nfour\nfive\n";
         let diff = make_diff(src, dest, 1);
-        assert_eq!(diff, vec![Mismatch { line_number: 2,
-                                         lines: vec![
-                                             Context("two".into()),
-                                             Resulting("three".into()),
-                                             Expected("trois".into()),
-                                             Context("four".into()),
-                                         ] }]);
+        assert_eq!(
+            diff,
+            vec![
+                Mismatch {
+                    line_number: 2,
+                    lines: vec![
+                        Context("two".into()),
+                        Resulting("three".into()),
+                        Expected("trois".into()),
+                        Context("four".into()),
+                    ],
+                },
+            ]
+        );
     }
 
     #[test]
     fn diff_simple2() {
         let src = "one\ntwo\nthree\nfour\nfive\nsix\nseven\n";
-        let dest= "one\ntwo\ntrois\nfour\ncinq\nsix\nseven\n";
+        let dest = "one\ntwo\ntrois\nfour\ncinq\nsix\nseven\n";
         let diff = make_diff(src, dest, 1);
-        assert_eq!(diff, vec![Mismatch { line_number: 2,
-                                         lines: vec![
-                                             Context("two".into()),
-                                             Resulting("three".into()),
-                                             Expected("trois".into()),
-                                             Context("four".into()),
-                                         ] },
-                              Mismatch { line_number: 5,
-                                         lines: vec![
-                                             Resulting("five".into()),
-                                             Expected("cinq".into()),
-                                             Context("six".into()),
-                                         ] }]);
+        assert_eq!(
+            diff,
+            vec![
+                Mismatch {
+                    line_number: 2,
+                    lines: vec![
+                        Context("two".into()),
+                        Resulting("three".into()),
+                        Expected("trois".into()),
+                        Context("four".into()),
+                    ],
+                },
+                Mismatch {
+                    line_number: 5,
+                    lines: vec![
+                        Resulting("five".into()),
+                        Expected("cinq".into()),
+                        Context("six".into()),
+                    ],
+                },
+            ]
+        );
     }
 
     #[test]
     fn diff_zerocontext() {
         let src = "one\ntwo\nthree\nfour\nfive\n";
-        let dest= "one\ntwo\ntrois\nfour\nfive\n";
+        let dest = "one\ntwo\ntrois\nfour\nfive\n";
         let diff = make_diff(src, dest, 0);
-        assert_eq!(diff, vec![Mismatch { line_number: 3,
-                                         lines: vec![
-                                             Resulting("three".into()),
-                                             Expected("trois".into()),
-                                         ] }]);
+        assert_eq!(
+            diff,
+            vec![
+                Mismatch {
+                    line_number: 3,
+                    lines: vec![Resulting("three".into()), Expected("trois".into())],
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
While working on #1173, I found that calling `make_diff` with `context_size` of `0` didn't work properly (or at least not as I expected!): it sometimes includes a `Context` line (I think in the first `Mismatch`) and splits a contiguous chunk of changed lines into separate `Mismatch`es.

I'm not completely convinced about what it does with `context_size>0` and two changes closer than that together; it splits it into two `Mismatch` items after the context lines between them.  The Unix diff command merges them together.  In any case, I don't think I've changed how that behaves.