### PR TITLE
Format attributes on block expressions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -12,7 +12,7 @@ use std::cmp::min;
 use std::borrow::Cow;
 use std::iter::{repeat, ExactSizeIterator};
 
-use syntax::{ast, ptr};
+use syntax::{self, ast, ptr};
 use syntax::codemap::{BytePos, CodeMap, Span};
 use syntax::parse::classify;
 
@@ -114,16 +114,24 @@ pub fn format_expr(
             match expr_type {
                 ExprType::Statement => {
                     if is_unsafe_block(block) {
-                        block.rewrite(context, shape)
-                    } else if let rw @ Some(_) = rewrite_empty_block(context, block, shape) {
+                        rewrite_block(block, Some(&expr.attrs), context, shape)
+                    } else if let rw @ Some(_) =
+                        rewrite_empty_block(context, block, Some(&expr.attrs), "", shape)
+                    {
                         // Rewrite block without trying to put it in a single line.
                         rw
                     } else {
                         let prefix = block_prefix(context, block, shape)?;
-                        rewrite_block_with_visitor(context, &prefix, block, shape)
+                        rewrite_block_with_visitor(
+                            context,
+                            &prefix,
+                            block,
+                            Some(&expr.attrs),
+                            shape,
+                        )
                     }
                 }
-                ExprType::SubExpression => block.rewrite(context, shape),
+                ExprType::SubExpression => rewrite_block(block, Some(&expr.attrs), context, shape),
             }
         }
         ast::ExprKind::Match(ref cond, ref arms) => {
@@ -286,7 +294,9 @@ pub fn format_expr(
             Some(context.snippet(expr.span))
         }
         ast::ExprKind::Catch(ref block) => {
-            if let rw @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape) {
+            if let rw @ Some(_) =
+                rewrite_single_line_block(context, "do catch ", block, Some(&expr.attrs), shape)
+            {
                 rw
             } else {
                 // 9 = `do catch `
@@ -294,7 +304,12 @@ pub fn format_expr(
                 Some(format!(
                     "{}{}",
                     "do catch ",
-                    block.rewrite(context, Shape::legacy(budget, shape.indent))?
+                    rewrite_block(
+                        block,
+                        Some(&expr.attrs),
+                        context,
+                        Shape::legacy(budget, shape.indent)
+                    )?
                 ))
             }
         }
@@ -340,7 +355,7 @@ where
     let lhs_result = lhs.rewrite(context, lhs_shape)
         .map(|lhs_str| format!("{}{}", prefix, lhs_str))?;
 
-    // Try to the both lhs and rhs on the same line.
+    // Try to put both lhs and rhs on the same line.
     let rhs_orig_result = shape
         .offset_left(last_line_width(&lhs_result) + infix.len())
         .and_then(|s| s.sub_width(suffix.len()))
@@ -626,7 +641,8 @@ fn rewrite_closure(
     if let ast::ExprKind::Block(ref block) = body.node {
         // The body of the closure is an empty block.
         if block.stmts.is_empty() && !block_contains_comment(block, context.codemap) {
-            return Some(format!("{} {{}}", prefix));
+            return body.rewrite(context, shape)
+                .map(|s| format!("{} {}", prefix, s));
         }
 
         // Figure out if the block is necessary.
@@ -650,7 +666,7 @@ fn rewrite_closure(
         }
 
         // Either we require a block, or tried without and failed.
-        rewrite_closure_block(block, &prefix, context, body_shape)
+        rewrite_closure_block(body, &prefix, context, body_shape)
     } else {
         rewrite_closure_expr(body, &prefix, context, body_shape).or_else(|| {
             // The closure originally had a non-block expression, but we can't fit on
@@ -679,7 +695,14 @@ fn rewrite_closure_with_block(
         rules: ast::BlockCheckMode::Default,
         span: body.span,
     };
-    rewrite_closure_block(&block, prefix, context, shape)
+    let expr = ast::Expr {
+        id: ast::NodeId::new(0),
+        node: ast::ExprKind::Block(ptr::P(block)),
+        span: body.span,
+        attrs: syntax::util::ThinVec::new(),
+    };
+
+    rewrite_closure_block(&expr, prefix, context, shape)
 }
 
 // Rewrite closure with a single expression without wrapping its body with block.
@@ -705,16 +728,21 @@ fn rewrite_closure_expr(
 
 // Rewrite closure whose body is block.
 fn rewrite_closure_block(
-    block: &ast::Block,
+    body: &ast::Expr,
     prefix: &str,
     context: &RewriteContext,
     shape: Shape,
 ) -> Option<String> {
+    if let ast::ExprKind::Block(_) = body.node {
+    } else {
+        unreachable!()
+    };
+
     // Start with visual indent, then fall back to block indent if the
     // closure is large.
     let block_threshold = context.config.closure_block_indent_threshold();
     if block_threshold >= 0 {
-        if let Some(block_str) = block.rewrite(context, shape) {
+        if let Some(block_str) = body.rewrite(context, shape) {
             if block_str.matches('\n').count() <= block_threshold as usize
                 && !need_block_indent(&block_str, shape)
             {
@@ -726,7 +754,7 @@ fn rewrite_closure_block(
     // The body of the closure is big enough to be block indented, that
     // means we must re-format.
     let block_shape = shape.block();
-    let block_str = block.rewrite(context, block_shape)?;
+    let block_str = body.rewrite(context, block_shape)?;
     Some(format!("{} {}", prefix, block_str))
 }
 
@@ -750,11 +778,17 @@ fn nop_block_collapse(block_str: Option<String>, budget: usize) -> Option<String
 fn rewrite_empty_block(
     context: &RewriteContext,
     block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    prefix: &str,
     shape: Shape,
 ) -> Option<String> {
+    if attrs.map_or(false, |a| !inner_attributes(a).is_empty()) {
+        return None;
+    }
+
     if block.stmts.is_empty() && !block_contains_comment(block, context.codemap) && shape.width >= 2
     {
-        return Some("{}".to_owned());
+        return Some(format!("{}{{}}", prefix));
     }
 
     // If a block contains only a single-line comment, then leave it on one line.
@@ -765,7 +799,7 @@ fn rewrite_empty_block(
         if block.stmts.is_empty() && !comment_str.contains('\n') && !comment_str.starts_with("//")
             && comment_str.len() + 4 <= shape.width
         {
-            return Some(format!("{{ {} }}", comment_str));
+            return Some(format!("{}{{ {} }}", prefix, comment_str));
         }
     }
 
@@ -804,9 +838,10 @@ fn rewrite_single_line_block(
     context: &RewriteContext,
     prefix: &str,
     block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
     shape: Shape,
 ) -> Option<String> {
-    if is_simple_block(block, context.codemap) {
+    if is_simple_block(block, attrs, context.codemap) {
         let expr_shape = Shape::legacy(shape.width - prefix.len(), shape.indent);
         let expr_str = block.stmts[0].rewrite(context, expr_shape)?;
         let result = format!("{}{{ {} }}", prefix, expr_str);
@@ -821,9 +856,10 @@ fn rewrite_block_with_visitor(
     context: &RewriteContext,
     prefix: &str,
     block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
     shape: Shape,
 ) -> Option<String> {
-    if let rw @ Some(_) = rewrite_empty_block(context, block, shape) {
+    if let rw @ Some(_) = rewrite_empty_block(context, block, attrs, prefix, shape) {
         return rw;
     }
 
@@ -839,31 +875,36 @@ fn rewrite_block_with_visitor(
         ast::BlockCheckMode::Default => visitor.last_pos = block.span.lo(),
     }
 
-    visitor.visit_block(block, None);
+    let inner_attrs = attrs.map(inner_attributes);
+    visitor.visit_block(block, inner_attrs.as_ref().map(|a| &**a));
     Some(format!("{}{}", prefix, visitor.buffer))
 }
 
-impl Rewrite for ast::Block {
-    fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        // shape.width is used only for the single line case: either the empty block `{}`,
-        // or an unsafe expression `unsafe { e }`.
-        if let rw @ Some(_) = rewrite_empty_block(context, self, shape) {
-            return rw;
-        }
 
-        let prefix = block_prefix(context, self, shape)?;
+fn rewrite_block(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    context: &RewriteContext,
+    shape: Shape,
+) -> Option<String> {
+    let prefix = block_prefix(context, block, shape)?;
 
-        let result = rewrite_block_with_visitor(context, &prefix, self, shape);
-        if let Some(ref result_str) = result {
-            if result_str.lines().count() <= 3 {
-                if let rw @ Some(_) = rewrite_single_line_block(context, &prefix, self, shape) {
-                    return rw;
-                }
+    // shape.width is used only for the single line case: either the empty block `{}`,
+    // or an unsafe expression `unsafe { e }`.
+    if let rw @ Some(_) = rewrite_empty_block(context, block, attrs, &prefix, shape) {
+        return rw;
+    }
+
+    let result = rewrite_block_with_visitor(context, &prefix, block, attrs, shape);
+    if let Some(ref result_str) = result {
+        if result_str.lines().count() <= 3 {
+            if let rw @ Some(_) = rewrite_single_line_block(context, &prefix, block, attrs, shape) {
+                return rw;
             }
         }
-
-        result
     }
+
+    result
 }
 
 impl Rewrite for ast::Stmt {
@@ -1073,8 +1114,8 @@ impl<'a> ControlFlow<'a> {
         let fixed_cost = self.keyword.len() + "  {  } else {  }".len();
 
         if let ast::ExprKind::Block(ref else_node) = else_block.node {
-            if !is_simple_block(self.block, context.codemap)
-                || !is_simple_block(else_node, context.codemap)
+            if !is_simple_block(self.block, None, context.codemap)
+                || !is_simple_block(else_node, None, context.codemap)
                 || pat_expr_str.contains('\n')
             {
                 return None;
@@ -1275,7 +1316,8 @@ impl<'a> Rewrite for ControlFlow<'a> {
         };
         let mut block_context = context.clone();
         block_context.is_if_else_block = self.else_block.is_some();
-        let block_str = rewrite_block_with_visitor(&block_context, "", self.block, block_shape)?;
+        let block_str =
+            rewrite_block_with_visitor(&block_context, "", self.block, None, block_shape)?;
 
         let mut result = format!("{}{}", cond_str, block_str);
 
@@ -1386,22 +1428,39 @@ fn block_contains_comment(block: &ast::Block, codemap: &CodeMap) -> bool {
     contains_comment(&snippet)
 }
 
-// Checks that a block contains no statements, an expression and no comments.
+// Checks that a block contains no statements, an expression and no comments or
+// attributes.
 // FIXME: incorrectly returns false when comment is contained completely within
 // the expression.
-pub fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
+pub fn is_simple_block(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    codemap: &CodeMap,
+) -> bool {
     (block.stmts.len() == 1 && stmt_is_expr(&block.stmts[0])
-        && !block_contains_comment(block, codemap))
+        && !block_contains_comment(block, codemap) && attrs.map_or(true, |a| a.is_empty()))
 }
 
-/// Checks whether a block contains at most one statement or expression, and no comments.
-pub fn is_simple_block_stmt(block: &ast::Block, codemap: &CodeMap) -> bool {
+/// Checks whether a block contains at most one statement or expression, and no
+/// comments or attributes.
+pub fn is_simple_block_stmt(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    codemap: &CodeMap,
+) -> bool {
     block.stmts.len() <= 1 && !block_contains_comment(block, codemap)
+        && attrs.map_or(true, |a| a.is_empty())
 }
 
-/// Checks whether a block contains no statements, expressions, or comments.
-pub fn is_empty_block(block: &ast::Block, codemap: &CodeMap) -> bool {
+/// Checks whether a block contains no statements, expressions, comments, or
+/// inner attributes.
+pub fn is_empty_block(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    codemap: &CodeMap,
+) -> bool {
     block.stmts.is_empty() && !block_contains_comment(block, codemap)
+        && attrs.map_or(true, |a| inner_attributes(a).is_empty())
 }
 
 pub fn stmt_is_expr(stmt: &ast::Stmt) -> bool {
@@ -1666,7 +1725,8 @@ fn rewrite_match_pattern(
 fn flatten_arm_body<'a>(context: &'a RewriteContext, body: &'a ast::Expr) -> (bool, &'a ast::Expr) {
     match body.node {
         ast::ExprKind::Block(ref block)
-            if !is_unsafe_block(block) && is_simple_block(block, context.codemap) =>
+            if !is_unsafe_block(block)
+                && is_simple_block(block, Some(&body.attrs), context.codemap) =>
         {
             if let ast::StmtKind::Expr(ref expr) = block.stmts[0].node {
                 (
@@ -1700,7 +1760,10 @@ fn rewrite_match_body(
     let alt_block_sep = String::from("\n") + &shape.indent.block_only().to_string(context.config);
     let alt_block_sep = alt_block_sep.as_str();
     let (is_block, is_empty_block) = if let ast::ExprKind::Block(ref block) = body.node {
-        (true, is_empty_block(block, context.codemap))
+        (
+            true,
+            is_empty_block(block, Some(&body.attrs), context.codemap),
+        )
     } else {
         (false, false)
     };

--- a/src/items.rs
+++ b/src/items.rs
@@ -298,11 +298,12 @@ impl<'a> FmtVisitor<'a> {
         fn_sig: &FnSig,
         span: Span,
         block: &ast::Block,
+        inner_attrs: Option<&[ast::Attribute]>,
     ) -> Option<String> {
         let context = self.get_context();
 
-        let has_body =
-            !is_empty_block(block, self.codemap) || !context.config.fn_empty_single_line();
+        let has_body = !is_empty_block(block, inner_attrs, self.codemap)
+            || !context.config.fn_empty_single_line();
         let mut newline_brace =
             newline_for_brace(self.config, &fn_sig.generics.where_clause, has_body);
 
@@ -330,7 +331,8 @@ impl<'a> FmtVisitor<'a> {
             result.push(' ');
         }
 
-        self.single_line_fn(&result, block).or_else(|| Some(result))
+        self.single_line_fn(&result, block, inner_attrs)
+            .or_else(|| Some(result))
     }
 
     pub fn rewrite_required_fn(
@@ -360,20 +362,25 @@ impl<'a> FmtVisitor<'a> {
         Some(result)
     }
 
-    fn single_line_fn(&self, fn_str: &str, block: &ast::Block) -> Option<String> {
-        if fn_str.contains('\n') {
+    fn single_line_fn(
+        &self,
+        fn_str: &str,
+        block: &ast::Block,
+        inner_attrs: Option<&[ast::Attribute]>,
+    ) -> Option<String> {
+        if fn_str.contains('\n') || inner_attrs.map_or(false, |a| !a.is_empty()) {
             return None;
         }
 
         let codemap = self.get_context().codemap;
 
-        if self.config.fn_empty_single_line() && is_empty_block(block, codemap)
+        if self.config.fn_empty_single_line() && is_empty_block(block, None, codemap)
             && self.block_indent.width() + fn_str.len() + 2 <= self.config.max_width()
         {
             return Some(format!("{}{{}}", fn_str));
         }
 
-        if self.config.fn_single_line() && is_simple_block_stmt(block, codemap) {
+        if self.config.fn_single_line() && is_simple_block_stmt(block, None, codemap) {
             let rewrite = {
                 if let Some(stmt) = block.stmts.first() {
                     match stmt_expr(stmt) {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -246,6 +246,7 @@ impl<'a> FmtVisitor<'a> {
                     &FnSig::from_fn_kind(&fk, fd, defaultness),
                     mk_sp(s.lo(), b.span.lo()),
                     b,
+                    inner_attrs,
                 )
             }
             visit::FnKind::Method(ident, _, _, b) => {
@@ -256,6 +257,7 @@ impl<'a> FmtVisitor<'a> {
                     &FnSig::from_fn_kind(&fk, fd, defaultness),
                     mk_sp(s.lo(), b.span.lo()),
                     b,
+                    inner_attrs,
                 )
             }
             visit::FnKind::Closure(_) => unreachable!(),
@@ -410,6 +412,7 @@ impl<'a> FmtVisitor<'a> {
                 // FIXME(#78): format impl definitions.
             }
             ast::ItemKind::Fn(ref decl, unsafety, constness, abi, ref generics, ref body) => {
+                let inner_attrs = inner_attributes(&item.attrs);
                 self.visit_fn(
                     visit::FnKind::ItemFn(
                         item.ident,
@@ -424,7 +427,7 @@ impl<'a> FmtVisitor<'a> {
                     item.span,
                     item.id,
                     ast::Defaultness::Final,
-                    Some(&item.attrs),
+                    Some(&inner_attrs),
                 )
             }
             ast::ItemKind::Ty(ref ty, ref generics) => {
@@ -494,13 +497,14 @@ impl<'a> FmtVisitor<'a> {
                 self.push_rewrite(ti.span, rewrite);
             }
             ast::TraitItemKind::Method(ref sig, Some(ref body)) => {
+                let inner_attrs = inner_attributes(&ti.attrs);
                 self.visit_fn(
                     visit::FnKind::Method(ti.ident, sig, None, body),
                     &sig.decl,
                     ti.span,
                     ti.id,
                     ast::Defaultness::Final,
-                    Some(&ti.attrs),
+                    Some(&inner_attrs),
                 );
             }
             ast::TraitItemKind::Type(ref type_param_bounds, ref type_default) => {
@@ -529,13 +533,14 @@ impl<'a> FmtVisitor<'a> {
 
         match ii.node {
             ast::ImplItemKind::Method(ref sig, ref body) => {
+                let inner_attrs = inner_attributes(&ii.attrs);
                 self.visit_fn(
                     visit::FnKind::Method(ii.ident, sig, Some(&ii.vis), body),
                     &sig.decl,
                     ii.span,
                     ii.id,
                     ii.defaultness,
-                    Some(&ii.attrs),
+                    Some(&inner_attrs),
                 );
             }
             ast::ImplItemKind::Const(ref ty, ref expr) => {

--- a/tests/target/attrib-block-expr.rs
+++ b/tests/target/attrib-block-expr.rs
@@ -1,0 +1,58 @@
+fn issue_2073() {
+    let x = {
+        #![my_attr]
+        do_something()
+    };
+
+    let x = #[my_attr]
+    {
+        do_something()
+    };
+
+    let x = #[my_attr]
+    {};
+
+    {
+        #![just_an_attribute]
+    };
+
+    let z = #[attr1]
+    #[attr2]
+    {
+        body()
+    };
+
+    x = |y| {
+        #![inner]
+    };
+
+    x = |y| #[outer]
+    {};
+
+    x = |y| {
+        //! ynot
+    };
+
+    x = |y| #[outer]
+    unsafe {};
+
+    let x = unsafe {
+        #![my_attr]
+        do_something()
+    };
+
+    let x = #[my_attr]
+    unsafe {
+        do_something()
+    };
+
+    // This is a dumb but possible case
+    let x = #[my_attr]
+    unsafe {};
+
+    x = |y| #[outer]
+    #[outer2]
+    unsafe {
+        //! Comment
+    };
+}


### PR DESCRIPTION
Addresses https://github.com/rust-lang-nursery/rustfmt/issues/2073, also catching extra corner cases like empty blocks. Basically the fix was to pass attributes around and reuse the existing rewriting machinery.

It would be kind of nice to put single outer attributes on the same line as the thing they modify, like
```rust
let blah = #[attr] {
    // ...
}
```
However, it might have to account for doc comments, and I didn't play around with it. Plus this is already a very niche case except for doing fine-grained `#[rustfmt_skip]`, so probably no one will ever care.