### PR TITLE
Add absolute_comment_width setting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -618,6 +618,8 @@ create_config! {
     wrap_comments: bool, false, false, "Break comments to fit on the line";
     comment_width: usize, 80, false,
         "Maximum length of comments. No effect unless wrap_comments = true";
+    absolute_comment_width: bool, false, false,
+        "Treat column_width as a fixed column number to wrap at";
     normalize_comments: bool, false, false, "Convert /* */ comments to // comments where possible";
     wrap_match_arms: bool, true, false, "Wrap the body of arms in blocks when it does not fit on \
                                   the same line with the pattern of arms";

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -173,17 +173,17 @@ impl<'a> FmtVisitor<'a> {
                         self.buffer.push_str(" ");
                     }
 
-                    let comment_width = if self.config.absolute_comment_width() {
-                        self.config
-                            .comment_width()
-                            .checked_sub(self.block_indent.width())
-                            .unwrap_or(0)
-                    } else {
-                        ::std::cmp::min(
-                            self.config.comment_width(),
-                            self.config.max_width() - self.block_indent.width(),
-                        )
-                    };
+                    let comment_width = ::std::cmp::min(
+                        if self.config.absolute_comment_width() {
+                            self.config
+                                .comment_width()
+                                .checked_sub(self.block_indent.width())
+                                .unwrap_or(0)
+                        } else {
+                            self.config.comment_width()
+                        },
+                        self.config.max_width() - self.block_indent.width(),
+                    );
                     let comment_indent = Indent::from_width(self.config, self.buffer.cur_offset());
 
                     self.buffer.push_str(&rewrite_comment(

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -173,10 +173,17 @@ impl<'a> FmtVisitor<'a> {
                         self.buffer.push_str(" ");
                     }
 
-                    let comment_width = ::std::cmp::min(
-                        self.config.comment_width(),
-                        self.config.max_width() - self.block_indent.width(),
-                    );
+                    let comment_width = if self.config.absolute_comment_width() {
+                        self.config
+                            .comment_width()
+                            .checked_sub(self.block_indent.width())
+                            .unwrap_or(0)
+                    } else {
+                        ::std::cmp::min(
+                            self.config.comment_width(),
+                            self.config.max_width() - self.block_indent.width(),
+                        )
+                    };
                     let comment_indent = Indent::from_width(self.config, self.buffer.cur_offset());
 
                     self.buffer.push_str(&rewrite_comment(

--- a/tests/source/configs-absolute_comment_width.rs
+++ b/tests/source/configs-absolute_comment_width.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 72
+// rustfmt-absolute_comment_width: true
+impl MyStruct {
+    fn my_fun() {
+        if foo {
+            // Please wrap this comment at column number 72 exactly, rather than column 84
+        }
+
+        fn bar() {
+            //! Please wrap this comment at column number 72 exactly, rather than column 84
+        }
+    }
+}

--- a/tests/target/configs-absolute_comment_width.rs
+++ b/tests/target/configs-absolute_comment_width.rs
@@ -1,0 +1,16 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 72
+// rustfmt-absolute_comment_width: true
+impl MyStruct {
+    fn my_fun() {
+        if foo {
+            // Please wrap this comment at column number 72 exactly,
+            // rather than column 84
+        }
+
+        fn bar() {
+            //! Please wrap this comment at column number 72 exactly,
+            //! rather than column 84
+        }
+    }
+}


### PR DESCRIPTION
Some coding standards, such as PEP8, require wrapping block comments at a certain column number rather than a certain length from the start of the comment, which improves readability on narrow displays. Here is an option to make `comment_width` behave as a fixed column number rather than a relative width.