### PR TITLE
Fix rustfmt failing to format closure block body with comment

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -899,9 +899,6 @@ fn rewrite_cond(context: &RewriteContext, expr: &ast::Expr, shape: Shape) -> Opt
             };
             cond.rewrite(context, cond_shape)
         }
-        ast::ExprKind::Block(ref block) if block.stmts.len() == 1 => {
-            stmt_expr(&block.stmts[0]).and_then(|e| rewrite_cond(context, e, shape))
-        }
         _ => to_control_flow(expr, ExprType::SubExpression).and_then(|control_flow| {
             let alt_block_sep =
                 String::from("\n") + &shape.indent.block_only().to_string(context.config);
@@ -2219,7 +2216,7 @@ fn rewrite_last_closure(
 ) -> Option<String> {
     if let ast::ExprKind::Closure(capture, ref fn_decl, ref body, _) = expr.node {
         let body = match body.node {
-            ast::ExprKind::Block(ref block) if block.stmts.len() == 1 => {
+            ast::ExprKind::Block(ref block) if is_simple_block(block, context.codemap) => {
                 stmt_expr(&block.stmts[0]).unwrap_or(body)
             }
             _ => body,

--- a/tests/source/closure.rs
+++ b/tests/source/closure.rs
@@ -41,7 +41,16 @@ fn main() {
     let closure_with_return_type = |aaaaaaaaaaaaaaaaaaaaaaarg1, aaaaaaaaaaaaaaaaaaaaaaarg2| -> Strong { "sup".to_owned() };
 
     |arg1, arg2, _, _, arg3, arg4| { let temp = arg4 + arg3;
-                                     arg2 * arg1 - temp }
+                                     arg2 * arg1 - temp };
+
+    let block_body_with_comment = args.iter()
+        .map(|a| {
+            // Emitting only dep-info is possible only for final crate type, as
+            // as others may emit required metadata for dependent crate types
+            if a.starts_with("--emit") && is_final_crate_type && !self.workspace_mode {
+                "--emit=dep-info"
+            } else { a }
+        });
 }
 
 fn issue311() {

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -60,7 +60,17 @@ fn main() {
     |arg1, arg2, _, _, arg3, arg4| {
         let temp = arg4 + arg3;
         arg2 * arg1 - temp
-    }
+    };
+
+    let block_body_with_comment = args.iter().map(|a| {
+        // Emitting only dep-info is possible only for final crate type, as
+        // as others may emit required metadata for dependent crate types
+        if a.starts_with("--emit") && is_final_crate_type && !self.workspace_mode {
+            "--emit=dep-info"
+        } else {
+            a
+        }
+    });
 }
 
 fn issue311() {


### PR DESCRIPTION
An example taken from [rls/src/build/cargo.rs](https://github.com/rust-lang-nursery/rls/blob/75f97194ff7a265184fd0212086ad9e94b44096a/src/build/cargo.rs#L385-L393):
```rust
            let modified = args.iter()
                .map(|a| {
                    // Emitting only dep-info is possible only for final crate type, as
                    // as others may emit required metadata for dependent crate types
                    if a.starts_with("--emit") && is_final_crate_type && !self.workspace_mode {
                        "--emit=dep-info"
                    } else { a }
                })
                .collect::<Vec<_>>();
```
rustfmt fails to format the above snippet. This PR fixes it.