### PR TITLE
Soft wrapping for comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -396,7 +396,7 @@ fn rewrite_comment_inner(
 /// Returns true if the given string MAY include URLs or alike.
 fn has_url(s: &str) -> bool {
     // This function may return false positive, but should get its job done in most cases.
-    s.contains("https://") || s.contains("http://")
+    s.contains("https://") || s.contains("http://") || s.contains("ftp://") || s.contains("file://")
 }
 
 /// Given the span, rewrite the missing comment inside it if available.

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -349,6 +349,12 @@ fn rewrite_comment_inner(
     Some(result)
 }
 
+/// Returns true if the given string MAY include URLs or alike.
+fn has_url(s: &str) -> bool {
+    // This function may return false positive, but should get its job done in most cases.
+    s.contains("https://") || s.contains("http://")
+}
+
 /// Given the span, rewrite the missing comment inside it if available.
 /// Note that the given span must only include comments (or leading/trailing whitespaces).
 pub fn rewrite_missing_comment(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1955,7 +1955,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     // Remove the quote characters.
     let str_lit = &string_lit[1..string_lit.len() - 1];
 
-    rewrite_string(str_lit, &StringFormat::new(shape, context.config))
+    rewrite_string(str_lit, &StringFormat::new(shape.visual_indent(0), context.config))
 }
 
 fn string_requires_rewrite(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1955,7 +1955,11 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     // Remove the quote characters.
     let str_lit = &string_lit[1..string_lit.len() - 1];
 
-    rewrite_string(str_lit, &StringFormat::new(shape.visual_indent(0), context.config))
+    rewrite_string(
+        str_lit,
+        &StringFormat::new(shape.visual_indent(0), context.config),
+        None,
+    )
 }
 
 fn string_requires_rewrite(

--- a/src/string.rs
+++ b/src/string.rs
@@ -50,7 +50,7 @@ pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> 
     let stripped_str = re.replace_all(orig, "$1");
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
-    let shape = fmt.shape.visual_indent(0);
+    let shape = fmt.shape;
     let indent = shape.indent.to_string(fmt.config);
     let punctuation = ":,;.";
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -44,7 +44,11 @@ impl<'a> StringFormat<'a> {
 }
 
 // FIXME: simplify this!
-pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> {
+pub fn rewrite_string<'a>(
+    orig: &str,
+    fmt: &StringFormat<'a>,
+    max_width: Option<usize>,
+) -> Option<String> {
     // Strip line breaks.
     let re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][[:space:]]*").unwrap();
     let stripped_str = re.replace_all(orig, "$1");
@@ -67,7 +71,7 @@ pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> 
     let ender_length = fmt.line_end.len();
     // If we cannot put at least a single character per line, the rewrite won't
     // succeed.
-    let max_chars = shape
+    let mut max_chars = shape
         .width
         .checked_sub(fmt.opener.len() + ender_length + 1)? + 1;
 
@@ -135,6 +139,10 @@ pub fn rewrite_string<'a>(orig: &str, fmt: &StringFormat<'a>) -> Option<String> 
 
         // The next line starts where the current line ends.
         cur_start = cur_end;
+
+        if let Some(new_max_chars) = max_width {
+            max_chars = new_max_chars.checked_sub(fmt.opener.len() + ender_length + 1)? + 1;
+        }
     }
 
     result.push_str(fmt.closer);
@@ -150,6 +158,6 @@ mod test {
     fn issue343() {
         let config = Default::default();
         let fmt = StringFormat::new(Shape::legacy(2, Indent::empty()), &config);
-        rewrite_string("eq_", &fmt);
+        rewrite_string("eq_", &fmt, None);
     }
 }

--- a/tests/source/soft-wrapping.rs
+++ b/tests/source/soft-wrapping.rs
@@ -1,0 +1,9 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 80
+// Soft wrapping for comments.
+
+// #535, soft wrapping for comments
+// Compare the lowest `f32` of both inputs for greater than or equal. The
+// lowest 32 bits of the result will be `0xffffffff` if `a.extract(0)` is
+// ggreater than or equal `b.extract(0)`, or `0` otherwise. The upper 96 bits off
+// the result are the upper 96 bits of `a`.

--- a/tests/target/soft-wrapping.rs
+++ b/tests/target/soft-wrapping.rs
@@ -1,0 +1,9 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 80
+// Soft wrapping for comments.
+
+// #535, soft wrapping for comments
+// Compare the lowest `f32` of both inputs for greater than or equal. The
+// lowest 32 bits of the result will be `0xffffffff` if `a.extract(0)` is
+// ggreater than or equal `b.extract(0)`, or `0` otherwise. The upper 96 bits
+// off the result are the upper 96 bits of `a`.


### PR DESCRIPTION
This PR is a first step to implementing soft wrapping for comments (cc #535).

Note that this PR does **NOT** implement soft wrapping for doc comments (`///` or `//!`). Currently each line of doc comments are rewritten on its own due to how it's implemented in AST (a vector of `ast::Attribute`). Fixing this will be in a different PR, hopefully.