### PR TITLE
Updating good starting issues link

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -65,7 +65,7 @@ example, the `issue-1111.rs` test file is configured by the file
 
 ## Hack!
 
-Here are some [good starting issues](https://github.com/rust-lang-nursery/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy).
+Here are some [good starting issues](https://github.com/rust-lang-nursery/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue).
 
 If you've found areas which need polish and don't have issues, please submit a
 PR, don't feel there needs to be an issue.


### PR DESCRIPTION
_This is a little speculative._

The [current "good starting issues" link](https://github.com/rust-lang-nursery/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy) in [Contributing.md](https://github.com/rust-lang-nursery/rustfmt/blob/master/Contributing.md) searches for issues labeled with "easy". There are currently no issues -- opened or closed -- with this label.

I arrived here via https://www.rustaceans.org/findwork/starters/rustfmt, which is looking for issues labeled with "good-first-issue". Here's the speculation: I'm guessing that at some point in the past the "easy" label in this repository was updated to "good-first-issue". This PR was created, in case that's correct.

The PR changes the link to [this](https://github.com/rust-lang-nursery/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue), which you can see in the [source branch Contributing.md](https://github.com/davidalber/rustfmt/blob/starting-issue-link/Contributing.md).