### PR TITLE
Handle chain with a single long child with a small parent 

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -126,7 +126,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
 
     let first_child_shape = if extend {
         let overhead = last_line_width(&parent_rewrite);
-        let offset = trimmed_last_line_width(&parent_rewrite);
+        let offset = trimmed_last_line_width(&parent_rewrite) + prefix_try_num;
         match context.config.chain_indent() {
             IndentStyle::Visual => parent_shape.offset_left(overhead)?,
             IndentStyle::Block => parent_shape.block().offset_left(offset)?,
@@ -166,9 +166,16 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     let all_in_one_line = !parent_rewrite_contains_newline
         && rewrites.iter().all(|s| !s.contains('\n'))
         && almost_total < one_line_budget;
-    let last_shape = match context.config.chain_indent() {
-        IndentStyle::Visual => other_child_shape.sub_width(shape.rhs_overhead(context.config))?,
-        IndentStyle::Block => other_child_shape,
+    let last_shape = {
+        let last_shape = if rewrites.len() == 0 {
+            first_child_shape
+        } else {
+            other_child_shape
+        };
+        match context.config.chain_indent() {
+            IndentStyle::Visual => last_shape.sub_width(shape.rhs_overhead(context.config))?,
+            IndentStyle::Block => last_shape,
+        }
     };
     let last_shape = last_shape.sub_width(suffix_try_num)?;
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -2142,7 +2142,9 @@ fn rewrite_args(
     generics_str_contains_newline: bool,
 ) -> Option<String> {
     let mut arg_item_strs = args.iter()
-        .map(|arg| arg.rewrite(context, Shape::legacy(multi_line_budget, arg_indent)))
+        .map(|arg| {
+            arg.rewrite(context, Shape::legacy(multi_line_budget, arg_indent))
+        })
         .collect::<Option<Vec<_>>>()?;
 
     // Account for sugary self.
@@ -2841,15 +2843,17 @@ impl Rewrite for ast::ForeignItem {
         let span = mk_sp(self.span.lo(), self.span.hi() - BytePos(1));
 
         let item_str = match self.node {
-            ast::ForeignItemKind::Fn(ref fn_decl, ref generics) => rewrite_fn_base(
-                context,
-                shape.indent,
-                self.ident,
-                &FnSig::new(fn_decl, generics, self.vis.clone()),
-                span,
-                false,
-                false,
-            ).map(|(s, _)| format!("{};", s)),
+            ast::ForeignItemKind::Fn(ref fn_decl, ref generics) => {
+                rewrite_fn_base(
+                    context,
+                    shape.indent,
+                    self.ident,
+                    &FnSig::new(fn_decl, generics, self.vis.clone()),
+                    span,
+                    false,
+                    false,
+                ).map(|(s, _)| format!("{};", s))
+            }
             ast::ForeignItemKind::Static(ref ty, is_mutable) => {
                 // FIXME(#21): we're dropping potential comments in between the
                 // function keywords here.

--- a/tests/source/chains.rs
+++ b/tests/source/chains.rs
@@ -170,3 +170,19 @@ impl Settings {
         let mut file = File::create(&settings_path).chain_err(|| ErrorKind::WriteError(settings_path.clone()))?;
     }
 }
+
+fn issue2126() {
+    {
+        {
+            {
+                {
+                    {
+                        let x = self.span_from(sub_span.expect("No span found for struct arant variant"));
+                        self.sspanpan_from_span(sub_span.expect("No span found for struct variant"));
+                        let x = self.spanpan_from_span(sub_span.expect("No span found for struct variant"))?;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -193,3 +193,25 @@ impl Settings {
             .chain_err(|| ErrorKind::WriteError(settings_path.clone()))?;
     }
 }
+
+fn issue2126() {
+    {
+        {
+            {
+                {
+                    {
+                        let x = self.span_from(
+                            sub_span.expect("No span found for struct arant variant"),
+                        );
+                        self.sspanpan_from_span(
+                            sub_span.expect("No span found for struct variant"),
+                        );
+                        let x = self.spanpan_from_span(
+                            sub_span.expect("No span found for struct variant"),
+                        )?;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #2126.

I was wondering if we should allow first child on the next line if there is an offset:
```rust
// Don't do this
self
    .span_from(sub_span.expect("No span found for struct arant variant"));

// But this is fine?
let x = self
    .span_from(sub_span.expect("No span found for struct arant variant")); 
```