### PR TITLE
Updating `where_density = "Vertical"` example

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2228,10 +2228,12 @@ Density of a where clause.
 ```rust
 trait Lorem {
     fn ipsum<Dolor>(dolor: Dolor) -> Sit
-        where Dolor: Eq;
+    where
+        Dolor: Eq;
 
     fn ipsum<Dolor>(dolor: Dolor) -> Sit
-        where Dolor: Eq
+    where
+        Dolor: Eq,
     {
         // body
     }


### PR DESCRIPTION
The example for `where_density = "Vertical"` in Configurations.md does not match the current output from rustfmt. This corrects that.

You can view the live change [here](https://github.com/davidalber/rustfmt/blob/fix-where-density-examples/Configurations.md#vertical-default-1) and compare with the current format [here](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#vertical-default-1). The `where_density = "Tall"` example, which this change makes "Vertical" identical to, is [here](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#tall).

Fixes #2133.