### PR TITLE
Adding an example for `combine_control_expr = false`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -354,6 +354,57 @@ fn example() {
 #### `false`:
 
 ```rust
+fn example() {
+    // If
+    foo!(
+        if x {
+            foo();
+        } else {
+            bar();
+        }
+    );
+
+    // IfLet
+    foo!(
+        if let Some(..) = x {
+            foo();
+        } else {
+            bar();
+        }
+    );
+
+    // While
+    foo!(
+        while x {
+            foo();
+            bar();
+        }
+    );
+
+    // WhileLet
+    foo!(
+        while let Some(..) = x {
+            foo();
+            bar();
+        }
+    );
+
+    // ForLoop
+    foo!(
+        for x in y {
+            foo();
+            bar();
+        }
+    );
+
+    // Loop
+    foo!(
+        loop {
+            foo();
+            bar();
+        }
+    );
+}
 ```
 
 ## `comment_width`


### PR DESCRIPTION
A live version of the new example is [here](https://github.com/davidalber/rustfmt/blob/add-combine-control-expr-example/Configurations.md#false-2). The existing `combine_control_expr = true` example is [here](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#true-default-2), in case that's useful for comparison in any way.

Fixes #2132.