### PR TITLE
Add rudimentary timing of parsing and formatting phases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,11 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +125,7 @@ dependencies = [
  "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -205,6 +211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "395993cac4e3599c7c1b70a6a92d3b3f55f4443df9f0b5294e362285ad7c9ecb"
@@ -276,6 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ log = "0.3"
 env_logger = "0.4"
 getopts = "0.2"
 derive-new = "0.5"
+time = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ log = "0.3"
 env_logger = "0.4"
 getopts = "0.2"
 derive-new = "0.5"
-time = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ extern crate serde_json;
 extern crate strings;
 extern crate syntax;
 extern crate term;
-extern crate time;
 extern crate unicode_segmentation;
 
 use std::collections::HashMap;
@@ -33,6 +32,7 @@ use std::io::{self, stdout, Write};
 use std::iter::repeat;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::time::Duration;
 
 use errors::{DiagnosticBuilder, Handler};
 use errors::emitter::{ColorConfig, EmitterWriter};
@@ -557,10 +557,14 @@ pub fn format_input<T: Write>(
     summary.mark_format_time();
 
     if config.verbose() {
+        fn duration_to_f32(d: Duration) -> f32 {
+            d.as_secs() as f32 + d.subsec_nanos() as f32 / 1_000_000_000f32
+        }
+
         println!(
-            "Spent {} in the parsing phase, and {} in the formatting phase",
-            summary.get_parse_time().unwrap(),
-            summary.get_format_time().unwrap(),
+            "Spent {0:.3} secs in the parsing phase, and {1:.3} secs in the formatting phase",
+            duration_to_f32(summary.get_parse_time().unwrap()),
+            duration_to_f32(summary.get_format_time().unwrap()),
         );
     }
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,3 +1,6 @@
+use time::{precise_time_ns, Duration};
+use std::default::Default;
+
 #[must_use]
 #[derive(Debug, Default, Clone)]
 pub struct Summary {
@@ -12,9 +15,42 @@ pub struct Summary {
 
     // Formatted code differs from existing code (write-mode diff only).
     pub has_diff: bool,
+
+    // Keeps track of time spent in parsing and formatting steps.
+    timer: Timer,
 }
 
 impl Summary {
+    pub fn mark_parse_time(&mut self) {
+        self.timer = self.timer.done_parsing();
+    }
+
+    pub fn mark_format_time(&mut self) {
+        self.timer = self.timer.done_formatting();
+    }
+
+    /// Returns the time it took to parse the source files in nanoseconds.
+    pub fn get_parse_time(&self) -> Option<Duration> {
+        match self.timer {
+            Timer::DoneParsing(init, parse_time) | Timer::DoneFormatting(init, parse_time, _) => {
+                // This should never underflow since `precise_time_ns()` guarantees monotonicity.
+                Some(Duration::nanoseconds((parse_time - init) as i64))
+            }
+            Timer::Initialized(..) => None,
+        }
+    }
+
+    /// Returns the time it took to go from the parsed AST to the formatted output. Parsing time is
+    /// not included.
+    pub fn get_format_time(&self) -> Option<Duration> {
+        match self.timer {
+            Timer::DoneFormatting(_init, parse_time, format_time) => {
+                Some(Duration::nanoseconds((format_time - parse_time) as i64))
+            }
+            Timer::DoneParsing(..) | Timer::Initialized(..) => None,
+        }
+    }
+
     pub fn has_operational_errors(&self) -> bool {
         self.has_operational_errors
     }
@@ -63,5 +99,36 @@ impl Summary {
     3 = Code is valid, but it is impossible to format it properly
     4 = Formatted code differs from existing code (write-mode diff only)"#;
         println!("{}", exit_codes);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Timer {
+    Initialized(u64),
+    DoneParsing(u64, u64),
+    DoneFormatting(u64, u64, u64),
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Timer::Initialized(precise_time_ns())
+    }
+}
+
+impl Timer {
+    fn done_parsing(self) -> Self {
+        match self {
+            Timer::Initialized(init_time) => Timer::DoneParsing(init_time, precise_time_ns()),
+            _ => panic!("Timer can only transition to DoneParsing from Initialized state"),
+        }
+    }
+
+    fn done_formatting(self) -> Self {
+        match self {
+            Timer::DoneParsing(init_time, parse_time) => {
+                Timer::DoneFormatting(init_time, parse_time, precise_time_ns())
+            }
+            _ => panic!("Timer can only transition to DoneFormatting from DoneParsing state"),
+        }
     }
 }


### PR DESCRIPTION
I was interested to see how much time is spent parsing vs formatting. This adds a timer to `Summary` to measure these things.

When run on rustfmt itself, using `$ cargo run --release --bin rustfmt -- --verbose src/lib.rs`, I get the following results on my machine:
```
Spent PT0.109887983S in the parsing phase, and PT0.414788861S in the formatting phase
```
In this case, formatting takes about 4x as long as parsing. This suggests that it should be worthwhile to look into trimming the fat from rustfmt.

cc https://github.com/rust-lang-nursery/rustfmt/issues/338