### PR TITLE
Fix missing trailing newline in --write-mode=diff.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -108,7 +108,7 @@ name = "rustfmt-nightly"
 version = "0.2.15"
 dependencies = [
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -253,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "415f627ab054041c3eb748c2e1da0ef751989f5f0c386b63a098e545854a98ba"
-"checksum diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0a515461b6c8c08419850ced27bc29e86166dcdcde8fbe76f8b1f0589bb49472"
+"checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"

--- a/src/checkstyle.rs
+++ b/src/checkstyle.rs
@@ -33,7 +33,7 @@ where
 {
     if mode == WriteMode::Checkstyle {
         let mut xml_tail = String::new();
-        xml_tail.push_str("</checkstyle>");
+        xml_tail.push_str("</checkstyle>\n");
         write!(out, "{}", xml_tail)?;
     }
     Ok(())

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -234,4 +234,20 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn diff_trailing_newline() {
+        let src = "one\ntwo\nthree\nfour\nfive";
+        let dest = "one\ntwo\nthree\nfour\nfive\n";
+        let diff = make_diff(src, dest, 1);
+        assert_eq!(
+            diff,
+            vec![
+                Mismatch {
+                    line_number: 5,
+                    lines: vec![Context("five".into()), Expected("".into())],
+                },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
This was a bug in the `diff` crate which has been fixed in 0.1.11. This PR
simply bumps `diff` to that version.

Fixes #1753.

    $ xxd main.rs
    00000000: 666e 206d 6169 6e28 2920 7b7d            fn main() {}
    $ cargo run --bin rustfmt -- main.rs --write-mode=diff
    $ echo $?
    0
    $ git checkout issue-1753
    Switched to branch 'issue-1753'
    $ cargo run --bin rustfmt -- main.rs --write-mode=diff
    Diff in /Users/utkarsh/dev/git/rustfmt/main.rs at line 1:
     fn main() {}⏎
    +⏎
    $ echo $?
    4

cc @afshinm @octaltree