### PR TITLE
Assignment whose lhs has 100 chars

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2635,7 +2635,11 @@ pub fn rewrite_assign_rhs<S: Into<String>, R: Rewrite>(
         0
     };
     // 1 = space between operator and rhs.
-    let orig_shape = shape.offset_left(last_line_width + 1)?;
+    let orig_shape = shape.offset_left(last_line_width + 1).unwrap_or(Shape {
+        width: 0,
+        offset: shape.offset + last_line_width + 1,
+        ..shape
+    });
     let rhs = choose_rhs(context, ex, orig_shape, ex.rewrite(context, orig_shape))?;
     Some(lhs + &rhs)
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -955,7 +955,9 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
 
         // FIXME(#2055): rustfmt fails to format when there are comments between trait bounds.
         if !type_param_bounds.is_empty() {
-            let ident_hi = context.codemap.span_after(item.span, &format!("{}", item.ident));
+            let ident_hi = context
+                .codemap
+                .span_after(item.span, &format!("{}", item.ident));
             let bound_hi = type_param_bounds.last().unwrap().span().hi();
             let snippet = context.snippet(mk_sp(ident_hi, bound_hi));
             if contains_comment(&snippet) {

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -45,6 +45,11 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
  + 2 + 3 {
     }
 
+    if let ast::ItemKind::Trait(_, unsafety, ref generics, ref type_param_bounds, ref trait_items) = item.node
+    {
+        // nothing
+    }
+
     let test = if true { 5 } else { 3 };
 
     if cond() {

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -70,6 +70,12 @@ fn foo() -> bool {
     ) = 1 + 2 + 3
     {}
 
+    if let ast::ItemKind::Trait(_, unsafety, ref generics, ref type_param_bounds, ref trait_items) =
+        item.node
+    {
+        // nothing
+    }
+
     let test = if true { 5 } else { 3 };
 
     if cond() {


### PR DESCRIPTION
rustfmt fails to format assignment if it uses exactly 100 (or `max_width`) chars up to `=`:
```rust
// From src/items.rs
fn bar() {
    if let ast::ItemKind::Trait(_, unsafety, ref generics, ref type_param_bounds, ref trait_items) = item {
    //                                                                                             ^ 100 chars
        abcdefg;
    }
}
```

This PR fixes it.