### PR TITLE
Recover from failing to format variants even where there is no comment 

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -452,9 +452,7 @@ impl<'a> FmtVisitor<'a> {
         let variant_list = self.format_variant_list(enum_def, body_start, span.hi() - BytePos(1));
         match variant_list {
             Some(ref body_str) => self.buffer.push_str(body_str),
-            None => if contains_comment(&enum_snippet[brace_pos..]) {
-                self.format_missing_no_indent(span.hi() - BytePos(1))
-            },
+            None => self.format_missing_no_indent(span.hi() - BytePos(1)),
         }
         self.block_indent = self.block_indent.block_unindent(self.config);
 

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -165,3 +165,10 @@ enum State {
     TimedOut,
     Disconnected,
 }
+
+// #2190
+#[derive(Debug, Fail)]
+enum AnError {
+    #[fail(display = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    UnexpectedSingleToken { token: syn::Token },
+}

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -215,3 +215,10 @@ enum State {
     TimedOut,
     Disconnected,
 }
+
+// #2190
+#[derive(Debug, Fail)]
+enum AnError {
+    #[fail(display = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    UnexpectedSingleToken { token: syn::Token },
+}


### PR DESCRIPTION
Closes #2190.