### PR TITLE
Use cargo_metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.3.2"
+source = "git+https://github.com/topecongiro/cargo_metadata#1f5bbc43efdad3dfc1d622174b976982cf1f8bf8"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +86,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -104,9 +166,15 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustfmt-nightly"
 version = "0.2.16"
 dependencies = [
+ "cargo_metadata 0.3.2 (git+https://github.com/topecongiro/cargo_metadata)",
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -124,6 +192,20 @@ dependencies = [
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -252,10 +334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
+"checksum cargo_metadata 0.3.2 (git+https://github.com/topecongiro/cargo_metadata)" = "<none>"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "415f627ab054041c3eb748c2e1da0ef751989f5f0c386b63a098e545854a98ba"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -267,6 +356,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bee2bc909ab2d8d60dab26e8cad85b25d795b14603a0dcb627b78b9d30b6454b"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6eda663e865517ee783b0891a3f6eb3a253e0b0dabb46418969ee9635beadd9e"
 "checksum serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "652bc323d694dc925829725ec6c890156d8e70ae5202919869cb00fe2eff3788"
 "checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ log = "0.3"
 env_logger = "0.4"
 getopts = "0.2"
 derive-new = "0.5"
+cargo_metadata = { git = "https://github.com/topecongiro/cargo_metadata" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.11"

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -13,6 +13,7 @@
 #![cfg(not(test))]
 #![deny(warnings)]
 
+extern crate cargo_metadata;
 extern crate getopts;
 extern crate serde_json as json;
 

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -359,6 +359,7 @@ fn format_files(
     } else {
         std::process::Stdio::inherit()
     };
+
     if verbosity == Verbosity::Verbose {
         print!("rustfmt");
         for a in fmt_args {
@@ -369,6 +370,7 @@ fn format_files(
         }
         println!();
     }
+
     let mut command = Command::new("rustfmt")
         .stdout(stdout)
         .args(files)
@@ -381,6 +383,7 @@ fn format_files(
             ),
             _ => e,
         })?;
+
     command.wait()
 }
 

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -52,13 +52,16 @@ fn execute() -> i32 {
     opts.optflag("", "all", "format all packages (only usable in workspaces)");
 
     // If there is any invalid argument passed to `cargo fmt`, return without formatting.
-    if let Some(arg) = env::args()
-        .skip(2)
-        .take_while(|a| a != "--")
-        .find(|a| !a.starts_with('-'))
-    {
-        print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`.", arg));
-        return failure;
+    let mut is_package_arg = false;
+    for arg in env::args().skip(2).take_while(|a| a != "--") {
+        if arg.starts_with("-") {
+            is_package_arg = arg.starts_with("--package");
+        } else if !is_package_arg {
+            print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`.", arg));
+            return failure;
+        } else {
+            is_package_arg = false;
+        }
     }
 
     let matches = match opts.parse(env::args().skip(1).take_while(|a| a != "--")) {

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -137,10 +137,9 @@ fn format_crate(
     // Currently only bin and lib files get formatted
     let files: Vec<_> = targets
         .into_iter()
-        .filter(|t| t.kind.should_format())
         .inspect(|t| {
             if verbosity == Verbosity::Verbose {
-                println!("[{:?}] {:?}", t.kind, t.path)
+                println!("[{}] {:?}", t.kind, t.path)
             }
         })
         .map(|t| t.path)
@@ -154,53 +153,13 @@ fn get_fmt_args() -> Vec<String> {
     env::args().skip_while(|a| a != "--").skip(1).collect()
 }
 
-#[derive(Debug)]
-enum TargetKind {
-    Lib,         // dylib, staticlib, lib
-    Bin,         // bin
-    Example,     // example file
-    Test,        // test file
-    Bench,       // bench file
-    CustomBuild, // build script
-    ProcMacro,   // a proc macro implementation
-    Other,       // plugin,...
-}
-
-impl TargetKind {
-    fn should_format(&self) -> bool {
-        match *self {
-            TargetKind::Lib
-            | TargetKind::Bin
-            | TargetKind::Example
-            | TargetKind::Test
-            | TargetKind::Bench
-            | TargetKind::CustomBuild
-            | TargetKind::ProcMacro => true,
-            _ => false,
-        }
-    }
-
-    fn from_str(s: &str) -> Self {
-        match s {
-            "bin" => TargetKind::Bin,
-            "lib" | "dylib" | "staticlib" | "cdylib" | "rlib" => TargetKind::Lib,
-            "test" => TargetKind::Test,
-            "example" => TargetKind::Example,
-            "bench" => TargetKind::Bench,
-            "custom-build" => TargetKind::CustomBuild,
-            "proc-macro" => TargetKind::ProcMacro,
-            _ => TargetKind::Other,
-        }
-    }
-}
-
 /// Target uses a `path` field for equality and hashing.
 #[derive(Debug)]
 pub struct Target {
     /// A path to the main source file of the target.
     path: PathBuf,
     /// A kind of target (e.g. lib, bin, example, ...).
-    kind: TargetKind,
+    kind: String,
 }
 
 impl Target {
@@ -210,7 +169,7 @@ impl Target {
 
         Target {
             path: canonicalized,
-            kind: TargetKind::from_str(&target.kind[0]),
+            kind: target.kind[0].clone(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -364,7 +364,7 @@ macro_rules! create_config {
                             self.$i.2 = val;
                         } else {
                             println!("Warning: can't set some features as unstable \
-                                    features are only available in nightly channel.");
+                                      features are only available in nightly channel.");
                         }
                     }
                 }


### PR DESCRIPTION
This PR replaces the direct calls of `cargo metadata` with `cargo_metadata` crate. Also, this PR fixes some bugs related to `cargo fmt`.

Closes #1201.
Closes #2182.
Closes #2189.