### PR TITLE
Fix broken build after use_nested_groups lands on nightly

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -328,7 +328,7 @@ impl<'a> FmtVisitor<'a> {
         }
 
         match item.node {
-            ast::ItemKind::Use(ref vp) => self.format_import(item, vp),
+            ast::ItemKind::Use(ref tree) => self.format_import(item, tree),
             ast::ItemKind::Impl(..) => {
                 let snippet = self.snippet(item.span);
                 let where_span_end = snippet


### PR DESCRIPTION
Rustfmt will be broken after rust-lang/rust#45846 (support for the `use_nested_groups` feature) lands on nightly. That PR completly changes the AST for `use` declarations, so imports formatting will break.

This PR fixes rustfmt to keep the old behavior with the new AST, and adds _partial_ support for the new features introduced in the rustc PR: some of them will work, some will behave unexpectedly and some will just panic with `unimplemented!`.