### PR TITLE
[Travis] Fix python/travis-cargo on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_script:
     pip install 'travis-cargo<0.2'
   else
     pip install 'travis-cargo<0.2' --user
+    export PATH="$(python -m site --user-base)/bin:$PATH"
   fi
-- export PATH="$(python -m site --user-base)/bin:$PATH"
 
 script:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ addons:
 before_script:
 - |
   if [ $TRAVIS_OS_NAME = 'osx' ]; then
-    brew install python3
-    virtualenv env -p python3
-    source env/bin/activate
-    pip install 'travis-cargo<0.2'
+    brew install python3 &&
+    virtualenv env -p python3 &&
+    source env/bin/activate &&
+    pip install 'travis-cargo<0.2' &&
   else
-    pip install 'travis-cargo<0.2' --user
+    pip install 'travis-cargo<0.2' --user &&
     export PATH="$(python -m site --user-base)/bin:$PATH"
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,15 @@ addons:
 
 before_script:
 - |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
+  if [ $TRAVIS_OS_NAME = 'osx' ]; then
+    brew install python3
+    virtualenv env -p python3
+    source env/bin/activate
+    pip install 'travis-cargo<0.2'
+  else
+    pip install 'travis-cargo<0.2' --user
+  fi
+- export PATH="$(python -m site --user-base)/bin:$PATH"
 
 script:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
     brew install python3 &&
     virtualenv env -p python3 &&
     source env/bin/activate &&
-    pip install 'travis-cargo<0.2' &&
+    pip install 'travis-cargo<0.2'
   else
     pip install 'travis-cargo<0.2' --user &&
     export PATH="$(python -m site --user-base)/bin:$PATH"


### PR DESCRIPTION
Builds on macOS are failing, e.g. https://travis-ci.org/rust-lang-nursery/rustfmt/jobs/310698549, due to `pip` not working.

This PR

- ensures that python is installed on macOS (travis-ci/travis-ci#2312)
- does `pip install --user` on linux but without `--user` on macOS, which has python in virtualenv
- sets up PATH in a os-agnostic manner (huonw/travis-cargo#71)