### PR TITLE
Fix format for `spaces_around_ranges` example

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1503,8 +1503,6 @@ struct Foo {
 }
 ```
 
-```
-
 ## `spaces_around_ranges`
 
 Put spaces around the .. and ... range operators


### PR DESCRIPTION
A duplicate codeblock end marker broke the formatting of this example.