### PR TITLE
Optimize snippet()

### DIFF
--- a/src/bin/rustfmt-format-diff.rs
+++ b/src/bin/rustfmt-format-diff.rs
@@ -120,7 +120,7 @@ fn run(opts: &getopts::Options) -> Result<(), FormatDiffError> {
 
     let filter = matches
         .opt_str("f")
-        .unwrap_or_else(|| DEFAULT_PATTERN.into());
+        .unwrap_or_else(|| DEFAULT_PATTERN.to_owned());
 
     let skip_prefix = matches
         .opt_str("p")
@@ -247,19 +247,19 @@ fn scan_simple_git_diff() {
         &ranges,
         &[
             Range {
-                file: "src/ir/item.rs".into(),
+                file: "src/ir/item.rs".to_owned(),
                 range: [148, 158],
             },
             Range {
-                file: "src/ir/item.rs".into(),
+                file: "src/ir/item.rs".to_owned(),
                 range: [160, 170],
             },
             Range {
-                file: "src/ir/traversal.rs".into(),
+                file: "src/ir/traversal.rs".to_owned(),
                 range: [9, 16],
             },
             Range {
-                file: "src/ir/traversal.rs".into(),
+                file: "src/ir/traversal.rs".to_owned(),
                 range: [35, 43],
             }
         ]

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -918,7 +918,7 @@ pub fn recover_comment_removed(
     let snippet = context.snippet(span);
     if snippet != new && changed_comment_content(&snippet, &new) {
         // We missed some comments. Keep the original text.
-        Some(snippet.into())
+        Some(snippet.to_owned())
     } else {
         Some(new)
     }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -918,7 +918,7 @@ pub fn recover_comment_removed(
     let snippet = context.snippet(span);
     if snippet != new && changed_comment_content(&snippet, &new) {
         // We missed some comments. Keep the original text.
-        Some(snippet)
+        Some(snippet.into())
     } else {
         Some(new)
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -58,7 +58,7 @@ pub fn format_expr(
     skip_out_of_file_lines_range!(context, expr.span);
 
     if contains_skip(&*expr.attrs) {
-        return Some(context.snippet(expr.span()));
+        return Some(context.snippet(expr.span()).into());
     }
 
     let expr_rw = match expr.node {
@@ -168,7 +168,7 @@ pub fn format_expr(
         ast::ExprKind::Mac(ref mac) => {
             rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|| {
                 wrap_str(
-                    context.snippet(expr.span),
+                    context.snippet(expr.span).into(),
                     context.config.max_width(),
                     shape,
                 )
@@ -274,7 +274,7 @@ pub fn format_expr(
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
         ast::ExprKind::InPlace(..) | ast::ExprKind::InlineAsm(..) => {
-            Some(context.snippet(expr.span))
+            Some(context.snippet(expr.span).into())
         }
         ast::ExprKind::Catch(ref block) => {
             if let rw @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape) {
@@ -1308,7 +1308,7 @@ fn rewrite_match(
             Some(format!("match {} {{}}", cond_str))
         } else {
             // Empty match with comments or inner attributes? We are not going to bother, sorry ;)
-            Some(context.snippet(span))
+            Some(context.snippet(span).into())
         }
     } else {
         Some(format!(
@@ -1767,7 +1767,11 @@ fn can_extend_match_arm_body(body: &ast::Expr) -> bool {
 pub fn rewrite_literal(context: &RewriteContext, l: &ast::Lit, shape: Shape) -> Option<String> {
     match l.node {
         ast::LitKind::Str(_, ast::StrStyle::Cooked) => rewrite_string_lit(context, l.span, shape),
-        _ => wrap_str(context.snippet(l.span), context.config.max_width(), shape),
+        _ => wrap_str(
+            context.snippet(l.span).into(),
+            context.config.max_width(),
+            shape,
+        ),
     }
 }
 
@@ -1798,7 +1802,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
             );
             return wrap_str(indented_string_lit, context.config.max_width(), shape);
         } else {
-            return wrap_str(string_lit, context.config.max_width(), shape);
+            return wrap_str(string_lit.into(), context.config.max_width(), shape);
         }
     }
 
@@ -2530,7 +2534,7 @@ pub fn rewrite_field(
     prefix_max_width: usize,
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
-        return Some(context.snippet(field.span()));
+        return Some(context.snippet(field.span()).into());
     }
     let name = &field.ident.node.to_string();
     if field.is_shorthand {
@@ -2738,7 +2742,7 @@ fn rewrite_assignment(
 ) -> Option<String> {
     let operator_str = match op {
         Some(op) => context.snippet(op.span),
-        None => "=".to_owned(),
+        None => "=",
     };
 
     // 1 = space between lhs and operator.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -629,7 +629,7 @@ pub fn rewrite_block_with_visitor(
         return rw;
     }
 
-    let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config, block.span);
+    let mut visitor = FmtVisitor::from_context(context);
     visitor.block_indent = shape.indent;
     visitor.is_if_else_block = context.is_if_else_block;
     match block.rules {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -629,7 +629,7 @@ pub fn rewrite_block_with_visitor(
         return rw;
     }
 
-    let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config);
+    let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config, block.span);
     visitor.block_indent = shape.indent;
     visitor.is_if_else_block = context.is_if_else_block;
     match block.rules {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -58,7 +58,7 @@ pub fn format_expr(
     skip_out_of_file_lines_range!(context, expr.span);
 
     if contains_skip(&*expr.attrs) {
-        return Some(context.snippet(expr.span()).into());
+        return Some(context.snippet(expr.span()).to_owned());
     }
 
     let expr_rw = match expr.node {
@@ -168,7 +168,7 @@ pub fn format_expr(
         ast::ExprKind::Mac(ref mac) => {
             rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|| {
                 wrap_str(
-                    context.snippet(expr.span).into(),
+                    context.snippet(expr.span).to_owned(),
                     context.config.max_width(),
                     shape,
                 )
@@ -241,7 +241,7 @@ pub fn format_expr(
                     } else if needs_space_before_range(context, lhs) {
                         format!(" {}", delim)
                     } else {
-                        delim.into()
+                        delim.to_owned()
                     };
                     rewrite_pair(
                         &*lhs,
@@ -256,7 +256,7 @@ pub fn format_expr(
                     let sp_delim = if context.config.spaces_around_ranges() {
                         format!("{} ", delim)
                     } else {
-                        delim.into()
+                        delim.to_owned()
                     };
                     rewrite_unary_prefix(context, &sp_delim, &*rhs, shape)
                 }
@@ -264,17 +264,17 @@ pub fn format_expr(
                     let sp_delim = if context.config.spaces_around_ranges() {
                         format!(" {}", delim)
                     } else {
-                        delim.into()
+                        delim.to_owned()
                     };
                     rewrite_unary_suffix(context, &sp_delim, &*lhs, shape)
                 }
-                (None, None) => Some(delim.into()),
+                (None, None) => Some(delim.to_owned()),
             }
         }
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
         ast::ExprKind::InPlace(..) | ast::ExprKind::InlineAsm(..) => {
-            Some(context.snippet(expr.span).into())
+            Some(context.snippet(expr.span).to_owned())
         }
         ast::ExprKind::Catch(ref block) => {
             if let rw @ Some(_) = rewrite_single_line_block(context, "do catch ", block, shape) {
@@ -1308,7 +1308,7 @@ fn rewrite_match(
             Some(format!("match {} {{}}", cond_str))
         } else {
             // Empty match with comments or inner attributes? We are not going to bother, sorry ;)
-            Some(context.snippet(span).into())
+            Some(context.snippet(span).to_owned())
         }
     } else {
         Some(format!(
@@ -1768,7 +1768,7 @@ pub fn rewrite_literal(context: &RewriteContext, l: &ast::Lit, shape: Shape) -> 
     match l.node {
         ast::LitKind::Str(_, ast::StrStyle::Cooked) => rewrite_string_lit(context, l.span, shape),
         _ => wrap_str(
-            context.snippet(l.span).into(),
+            context.snippet(l.span).to_owned(),
             context.config.max_width(),
             shape,
         ),
@@ -1802,7 +1802,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
             );
             return wrap_str(indented_string_lit, context.config.max_width(), shape);
         } else {
-            return wrap_str(string_lit.into(), context.config.max_width(), shape);
+            return wrap_str(string_lit.to_owned(), context.config.max_width(), shape);
         }
     }
 
@@ -2534,7 +2534,7 @@ pub fn rewrite_field(
     prefix_max_width: usize,
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
-        return Some(context.snippet(field.span()).into());
+        return Some(context.snippet(field.span()).to_owned());
     }
     let name = &field.ident.node.to_string();
     if field.is_shorthand {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -148,7 +148,7 @@ impl Rewrite for ast::UseTree {
                     let path_str = rewrite_prefix(&self.prefix, context, prefix_shape)?;
                     Some(format!("{}::*", path_str))
                 } else {
-                    Some("*".into())
+                    Some("*".to_owned())
                 }
             }
             ast::UseTreeKind::Simple(ident) => {
@@ -184,7 +184,7 @@ fn rewrite_import(
         .and_then(|shape| match tree.kind {
             // If we have an empty nested group with no attributes, we erase it
             ast::UseTreeKind::Nested(ref items) if items.is_empty() && attrs.is_empty() => {
-                Some("".into())
+                Some("".to_owned())
             }
             _ => tree.rewrite(context, shape),
         });

--- a/src/items.rs
+++ b/src/items.rs
@@ -657,7 +657,8 @@ pub fn format_impl(
         let open_pos = snippet.find_uncommented("{")? + 1;
 
         if !items.is_empty() || contains_comment(&snippet[open_pos..]) {
-            let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config);
+            let mut visitor =
+                FmtVisitor::from_codemap(context.parse_session, context.config, item.span);
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = item.span.lo() + BytePos(open_pos as u32);
 
@@ -1055,7 +1056,8 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         let open_pos = snippet.find_uncommented("{")? + 1;
 
         if !trait_items.is_empty() || contains_comment(&snippet[open_pos..]) {
-            let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config);
+            let mut visitor =
+                FmtVisitor::from_codemap(context.parse_session, context.config, item.span);
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = item.span.lo() + BytePos(open_pos as u32);
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -382,7 +382,7 @@ impl<'a> FmtVisitor<'a> {
 
                             format_expr(e, ExprType::Statement, &self.get_context(), self.shape())
                                 .map(|s| s + suffix)
-                                .or_else(|| Some(self.snippet(e.span)))
+                                .or_else(|| Some(self.snippet(e.span).into()))
                         }
                         None => stmt.rewrite(&self.get_context(), self.shape()),
                     }
@@ -526,7 +526,7 @@ impl<'a> FmtVisitor<'a> {
         if contains_skip(&field.node.attrs) {
             let lo = field.node.attrs[0].span.lo();
             let span = mk_sp(lo, field.span.hi());
-            return Some(self.snippet(span));
+            return Some(self.snippet(span).into());
         }
 
         let context = self.get_context();
@@ -1429,7 +1429,8 @@ pub fn rewrite_struct_field(
     lhs_max_width: usize,
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
-        return Some(context.snippet(mk_sp(field.attrs[0].span.lo(), field.span.hi())));
+        let snippet = context.snippet(mk_sp(field.attrs[0].span.lo(), field.span.hi()));
+        return Some(snippet.into());
     }
 
     let type_annotation_spacing = type_annotation_spacing(context.config);

--- a/src/items.rs
+++ b/src/items.rs
@@ -382,7 +382,7 @@ impl<'a> FmtVisitor<'a> {
 
                             format_expr(e, ExprType::Statement, &self.get_context(), self.shape())
                                 .map(|s| s + suffix)
-                                .or_else(|| Some(self.snippet(e.span).into()))
+                                .or_else(|| Some(self.snippet(e.span).to_owned()))
                         }
                         None => stmt.rewrite(&self.get_context(), self.shape()),
                     }
@@ -526,7 +526,7 @@ impl<'a> FmtVisitor<'a> {
         if contains_skip(&field.node.attrs) {
             let lo = field.node.attrs[0].span.lo();
             let span = mk_sp(lo, field.span.hi());
-            return Some(self.snippet(span).into());
+            return Some(self.snippet(span).to_owned());
         }
 
         let context = self.get_context();
@@ -1428,7 +1428,7 @@ pub fn rewrite_struct_field(
 ) -> Option<String> {
     if contains_skip(&field.attrs) {
         let snippet = context.snippet(mk_sp(field.attrs[0].span.lo(), field.span.hi()));
-        return Some(snippet.into());
+        return Some(snippet.to_owned());
     }
 
     let type_annotation_spacing = type_annotation_spacing(context.config);

--- a/src/items.rs
+++ b/src/items.rs
@@ -657,8 +657,7 @@ pub fn format_impl(
         let open_pos = snippet.find_uncommented("{")? + 1;
 
         if !items.is_empty() || contains_comment(&snippet[open_pos..]) {
-            let mut visitor =
-                FmtVisitor::from_codemap(context.parse_session, context.config, item.span);
+            let mut visitor = FmtVisitor::from_context(context);
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = item.span.lo() + BytePos(open_pos as u32);
 
@@ -1056,8 +1055,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         let open_pos = snippet.find_uncommented("{")? + 1;
 
         if !trait_items.is_empty() || contains_comment(&snippet[open_pos..]) {
-            let mut visitor =
-                FmtVisitor::from_codemap(context.parse_session, context.config, item.span);
+            let mut visitor = FmtVisitor::from_context(context);
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = item.span.lo() + BytePos(open_pos as u32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use config::Config;
 use filemap::FileMap;
 use issues::{BadIssueSeeker, Issue};
 use utils::use_colored_tty;
-use visitor::FmtVisitor;
+use visitor::{FmtVisitor, SnippetProvider};
 
 pub use self::summary::Summary;
 
@@ -317,8 +317,13 @@ where
         if config.verbose() {
             println!("Formatting {}", path_str);
         }
-        let mut visitor = FmtVisitor::from_codemap(parse_session, config, module.inner);
-        let filemap = visitor.codemap.lookup_char_pos(module.inner.lo()).file;
+        let filemap = parse_session
+            .codemap()
+            .lookup_char_pos(module.inner.lo())
+            .file;
+        let big_snippet = filemap.src.as_ref().unwrap();
+        let snippet_provider = SnippetProvider::new(filemap.start_pos, big_snippet);
+        let mut visitor = FmtVisitor::from_codemap(parse_session, config, &snippet_provider);
         // Format inner attributes if available.
         if !krate.attrs.is_empty() && path == main_file {
             visitor.skip_empty_lines(filemap.end_pos);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ where
         if config.verbose() {
             println!("Formatting {}", path_str);
         }
-        let mut visitor = FmtVisitor::from_codemap(parse_session, config);
+        let mut visitor = FmtVisitor::from_codemap(parse_session, config, module.inner);
         let filemap = visitor.codemap.lookup_char_pos(module.inner.lo()).file;
         // Format inner attributes if available.
         if !krate.attrs.is_empty() && path == main_file {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -162,7 +162,7 @@ pub fn rewrite_macro(
         loop {
             match parse_macro_arg(&mut parser) {
                 Some(arg) => arg_vec.push(arg),
-                None => return Some(context.snippet(mac.span)),
+                None => return Some(context.snippet(mac.span).into()),
             }
 
             match parser.token {
@@ -182,13 +182,13 @@ pub fn rewrite_macro(
                                         break;
                                     }
                                 }
-                                None => return Some(context.snippet(mac.span)),
+                                None => return Some(context.snippet(mac.span).into()),
                             }
                         }
                     }
-                    return Some(context.snippet(mac.span));
+                    return Some(context.snippet(mac.span).into());
                 }
-                _ => return Some(context.snippet(mac.span)),
+                _ => return Some(context.snippet(mac.span).into()),
             }
 
             parser.bump();
@@ -271,7 +271,7 @@ pub fn rewrite_macro(
         }
         MacroStyle::Braces => {
             // Skip macro invocations with braces, for now.
-            indent_macro_snippet(context, &context.snippet(mac.span), shape.indent)
+            indent_macro_snippet(context, context.snippet(mac.span), shape.indent)
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -162,7 +162,7 @@ pub fn rewrite_macro(
         loop {
             match parse_macro_arg(&mut parser) {
                 Some(arg) => arg_vec.push(arg),
-                None => return Some(context.snippet(mac.span).into()),
+                None => return Some(context.snippet(mac.span).to_owned()),
             }
 
             match parser.token {
@@ -182,13 +182,13 @@ pub fn rewrite_macro(
                                         break;
                                     }
                                 }
-                                None => return Some(context.snippet(mac.span).into()),
+                                None => return Some(context.snippet(mac.span).to_owned()),
                             }
                         }
                     }
-                    return Some(context.snippet(mac.span).into());
+                    return Some(context.snippet(mac.span).to_owned());
                 }
-                _ => return Some(context.snippet(mac.span).into()),
+                _ => return Some(context.snippet(mac.span).to_owned()),
             }
 
             parser.bump();

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -122,7 +122,7 @@ impl Rewrite for Pat {
                 rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
             }
             // FIXME(#819) format pattern macros.
-            PatKind::Mac(..) => Some(context.snippet(self.span)),
+            PatKind::Mac(..) => Some(context.snippet(self.span).into()),
         }
     }
 }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -122,7 +122,7 @@ impl Rewrite for Pat {
                 rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
             }
             // FIXME(#819) format pattern macros.
-            PatKind::Mac(..) => Some(context.snippet(self.span).into()),
+            PatKind::Mac(..) => Some(context.snippet(self.span).to_owned()),
         }
     }
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -35,7 +35,7 @@ pub struct RewriteContext<'a> {
     pub is_if_else_block: bool,
     // When rewriting chain, veto going multi line except the last element
     pub force_one_line_chain: bool,
-    pub snippet_provider: &'a SnippetProvider,
+    pub snippet_provider: &'a SnippetProvider<'a>,
 }
 
 impl<'a> RewriteContext<'a> {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -15,6 +15,7 @@ use syntax::parse::ParseSess;
 
 use config::{Config, IndentStyle};
 use shape::Shape;
+use visitor::SnippetProvider;
 
 pub trait Rewrite {
     /// Rewrite self into shape.
@@ -34,11 +35,12 @@ pub struct RewriteContext<'a> {
     pub is_if_else_block: bool,
     // When rewriting chain, veto going multi line except the last element
     pub force_one_line_chain: bool,
+    pub snippet_provider: &'a SnippetProvider,
 }
 
 impl<'a> RewriteContext<'a> {
-    pub fn snippet(&self, span: Span) -> String {
-        self.codemap.span_to_snippet(span).unwrap()
+    pub fn snippet(&self, span: Span) -> &str {
+        self.snippet_provider.span_to_snippet(span).unwrap()
     }
 
     /// Return true if we should use block indent style for rewriting function call.

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -180,10 +180,10 @@ mod test {
                 Mismatch {
                     line_number: 2,
                     lines: vec![
-                        Context("two".into()),
-                        Resulting("three".into()),
-                        Expected("trois".into()),
-                        Context("four".into()),
+                        Context("two".to_owned()),
+                        Resulting("three".to_owned()),
+                        Expected("trois".to_owned()),
+                        Context("four".to_owned()),
                     ],
                 },
             ]
@@ -201,18 +201,18 @@ mod test {
                 Mismatch {
                     line_number: 2,
                     lines: vec![
-                        Context("two".into()),
-                        Resulting("three".into()),
-                        Expected("trois".into()),
-                        Context("four".into()),
+                        Context("two".to_owned()),
+                        Resulting("three".to_owned()),
+                        Expected("trois".to_owned()),
+                        Context("four".to_owned()),
                     ],
                 },
                 Mismatch {
                     line_number: 5,
                     lines: vec![
-                        Resulting("five".into()),
-                        Expected("cinq".into()),
-                        Context("six".into()),
+                        Resulting("five".to_owned()),
+                        Expected("cinq".to_owned()),
+                        Context("six".to_owned()),
                     ],
                 },
             ]
@@ -229,7 +229,7 @@ mod test {
             vec![
                 Mismatch {
                     line_number: 3,
-                    lines: vec![Resulting("three".into()), Expected("trois".into())],
+                    lines: vec![Resulting("three".to_owned()), Expected("trois".to_owned())],
                 },
             ]
         );
@@ -245,7 +245,7 @@ mod test {
             vec![
                 Mismatch {
                     line_number: 5,
-                    lines: vec![Context("five".into()), Expected("".into())],
+                    lines: vec![Context("five".to_owned()), Expected("".to_owned())],
                 },
             ]
         );

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -530,7 +530,11 @@ impl<'a> FmtVisitor<'a> {
         self.last_pos = source!(self, span).hi();
     }
 
-    pub fn from_codemap(parse_session: &'a ParseSess, config: &'a Config) -> FmtVisitor<'a> {
+    pub fn from_codemap(
+        parse_session: &'a ParseSess,
+        config: &'a Config,
+        span: Span,
+    ) -> FmtVisitor<'a> {
         FmtVisitor {
             parse_session: parse_session,
             codemap: parse_session.codemap(),

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::rc::Rc;
 use std::cmp;
 
 use strings::string_buffer::StringBuffer;
@@ -51,7 +50,7 @@ fn is_extern_crate(item: &ast::Item) -> bool {
 /// Creates a string slice corresponding to the specified span.
 pub struct SnippetProvider<'a> {
     /// A pointer to the content of the file we are formatting.
-    big_snippet: &'a Rc<String>,
+    big_snippet: &'a str,
     /// A position of the start of `big_snippet`, used as an offset.
     start_pos: usize,
 }
@@ -63,7 +62,7 @@ impl<'b, 'a: 'b> SnippetProvider<'a> {
         Some(&self.big_snippet[start_index..end_index])
     }
 
-    pub fn new(start_pos: BytePos, big_snippet: &'a Rc<String>) -> Self {
+    pub fn new(start_pos: BytePos, big_snippet: &'a str) -> Self {
         let start_pos = start_pos.to_usize();
         SnippetProvider {
             big_snippet,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -531,6 +531,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         self.last_pos = source!(self, span).hi();
     }
 
+    pub fn from_context(ctx: &'a RewriteContext) -> FmtVisitor<'a> {
+        FmtVisitor::from_codemap(ctx.parse_session, ctx.config, ctx.snippet_provider)
+    }
+
     pub fn from_codemap(
         parse_session: &'a ParseSess,
         config: &'a Config,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -420,7 +420,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 self.push_rewrite(item.span, rewrite);
             }
             ast::ItemKind::GlobalAsm(..) => {
-                let snippet = Some(self.snippet(item.span).into());
+                let snippet = Some(self.snippet(item.span).to_owned());
                 self.push_rewrite(item.span, snippet);
             }
             ast::ItemKind::MacroDef(..) => {
@@ -831,7 +831,7 @@ impl Rewrite for ast::Attribute {
             rewrite_comment(snippet, false, doc_shape, context.config)
         } else {
             if contains_comment(snippet) {
-                return Some(snippet.into());
+                return Some(snippet.to_owned());
             }
             // 1 = `[`
             let shape = shape.offset_left(prefix.len() + 1)?;
@@ -1043,7 +1043,7 @@ pub fn rewrite_extern_crate(context: &RewriteContext, item: &ast::Item) -> Optio
     assert!(is_extern_crate(item));
     let new_str = context.snippet(item.span);
     Some(if contains_comment(&new_str) {
-        new_str.into()
+        new_str.to_owned()
     } else {
         let no_whitespace = &new_str.split_whitespace().collect::<Vec<&str>>().join(" ");
         String::from(&*Regex::new(r"\s;").unwrap().replace(no_whitespace, ";"))

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -55,8 +55,8 @@ pub struct SnippetProvider<'a> {
     start_pos: usize,
 }
 
-impl<'b, 'a: 'b> SnippetProvider<'a> {
-    pub fn span_to_snippet(&'b self, span: Span) -> Option<&'a str> {
+impl<'a> SnippetProvider<'a> {
+    pub fn span_to_snippet(&self, span: Span) -> Option<&str> {
         let start_index = span.lo().to_usize().checked_sub(self.start_pos)?;
         let end_index = span.hi().to_usize().checked_sub(self.start_pos)?;
         Some(&self.big_snippet[start_index..end_index])


### PR DESCRIPTION
## Motivation
rustfmt makes heavy use of `snippet()` to fetch a piece of snippet from the original file. It returns `String`, even though we do not modify the returned value. It is preferable to return `&str` to avoid allocations on heap.

## Pros

We get about 15% speed up against a large code base. The following is a quick experiment result that runs `cargo fmt --all` against rustc:

### env

- OS: Linux 4.13.16
- rustc: `rustc 1.24.0-nightly (1956d5535 2017-12-03)`
- CPU: `Intel(R) Core(TM) i3-4150 CPU @ 3.50GHz`
- RAM: 8GB

### Result

| version | time [s] (an average of 10 attempts) |
| ----------|-------|
| master (0432d4db35cee640ca96460f4ebc4baad3891d6d) | 9.77 |
| PR (a5b5ef078bd835f68a1e2b8eb5f63d0797e4e0e8) | 8.47 |

## Cons

This PR introduces `unsafe` code in rustfmt (specifically in `impl SnippetProducer`):

- transmute `&Option<Rc<String>>` into `*const Rc<String>`.
- dereference `*const`.