### PR TITLE
Fix config warnings leaking into stdout

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -361,7 +361,7 @@ macro_rules! create_config {
                             self.$i.1 = true;
                             self.$i.2 = val;
                         } else {
-                            println!("Warning: can't set `{} = {:?}`, unstable features are only \
+                            eprintln!("Warning: can't set `{} = {:?}`, unstable features are only \
                                       available in nightly channel.", stringify!($i), val);
                         }
                     }


### PR DESCRIPTION
Warnings on stdout can really hurt Rls as it's a stdin-stdout server, see https://github.com/rust-lang-nursery/rls/issues/616. This PR routes the config warnings to stderr instead. Feel free to fix another way and close this PR.