### PR TITLE
unstable_features without CFG_RELEASE_CHANNEL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,11 +21,21 @@ use file_lines::FileLines;
 use lists::{ListTactic, SeparatorPlace, SeparatorTactic};
 use Summary;
 
+/// Check if we're in a nightly build.
+///
+/// The environment variable `CFG_RELEASE_CHANNEL` is set during the rustc bootstrap
+/// to "stable", "beta", or "nightly" depending on what toolchain is being built.
+/// If we are being built as part of the stable or beta toolchains, we want
+/// to disable unstable configuration options.
+///
+/// If we're being built by cargo (e.g. `cargo +nightly install rustfmt-nightly`),
+/// `CFG_RELEASE_CHANNEL` is not set. As we only support being built against the
+/// nightly compiler when installed from crates.io, default to nightly mode.
 macro_rules! is_nightly_channel {
     () => {
         option_env!("CFG_RELEASE_CHANNEL")
             .map(|c| c == "nightly")
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 }
 


### PR DESCRIPTION
Per discussion in #2228

https://github.com/rust-lang-nursery/rustfmt/pull/2228#issuecomment-348893294
https://github.com/rust-lang-nursery/rustfmt/pull/2228#issuecomment-349799548

Inline comment should explain the reasoning.

Open to bikeshed.