### PR TITLE
Do not report errors on skipped items or statements 

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -285,7 +285,7 @@ impl<'a> FmtVisitor<'a> {
             }
             Some(ref s) => {
                 self.format_missing_with_indent(source!(self, span).lo());
-                self.buffer.push_str(s);
+                self.push_str(s);
                 self.last_pos = source!(self, span).hi();
             }
             None => {

--- a/src/items.rs
+++ b/src/items.rs
@@ -240,12 +240,12 @@ impl<'a> FnSig<'a> {
 
 impl<'a> FmtVisitor<'a> {
     fn format_item(&mut self, item: Item) {
-        self.buffer.push_str(&item.abi);
+        self.push_str(&item.abi);
 
         let snippet = self.snippet(item.span);
         let brace_pos = snippet.find_uncommented("{").unwrap();
 
-        self.buffer.push_str("{");
+        self.push_str("{");
         if !item.body.is_empty() || contains_comment(&snippet[brace_pos..]) {
             // FIXME: this skips comments between the extern keyword and the opening
             // brace.
@@ -255,9 +255,8 @@ impl<'a> FmtVisitor<'a> {
             if item.body.is_empty() {
                 self.format_missing_no_indent(item.span.hi() - BytePos(1));
                 self.block_indent = self.block_indent.block_unindent(self.config);
-
-                self.buffer
-                    .push_str(&self.block_indent.to_string(self.config));
+                let indent_str = self.block_indent.to_string(self.config);
+                self.push_str(&indent_str);
             } else {
                 for item in &item.body {
                     self.format_body_element(item);
@@ -268,7 +267,7 @@ impl<'a> FmtVisitor<'a> {
             }
         }
 
-        self.buffer.push_str("}");
+        self.push_str("}");
         self.last_pos = item.span.hi();
     }
 
@@ -423,7 +422,7 @@ impl<'a> FmtVisitor<'a> {
         span: Span,
     ) {
         let enum_header = format_header("enum ", ident, vis);
-        self.buffer.push_str(&enum_header);
+        self.push_str(&enum_header);
 
         let enum_snippet = self.snippet(span);
         let brace_pos = enum_snippet.find_uncommented("{").unwrap();
@@ -441,23 +440,23 @@ impl<'a> FmtVisitor<'a> {
             mk_sp(span.lo(), body_start),
             last_line_width(&enum_header),
         ).unwrap();
-        self.buffer.push_str(&generics_str);
+        self.push_str(&generics_str);
 
         self.last_pos = body_start;
 
         self.block_indent = self.block_indent.block_indent(self.config);
         let variant_list = self.format_variant_list(enum_def, body_start, span.hi() - BytePos(1));
         match variant_list {
-            Some(ref body_str) => self.buffer.push_str(body_str),
+            Some(ref body_str) => self.push_str(body_str),
             None => self.format_missing_no_indent(span.hi() - BytePos(1)),
         }
         self.block_indent = self.block_indent.block_unindent(self.config);
 
         if variant_list.is_some() || contains_comment(&enum_snippet[brace_pos..]) {
-            self.buffer
-                .push_str(&self.block_indent.to_string(self.config));
+            let indent_str = self.block_indent.to_string(self.config);
+            self.push_str(&indent_str);
         }
-        self.buffer.push_str("}");
+        self.push_str("}");
         self.last_pos = span.hi();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,6 @@ fn format_lines(
     config: &Config,
     report: &mut FormatReport,
 ) {
-    println!("skipped_range: {:?}", skipped_range);
     // Iterate over the chars in the file map.
     let mut trims = vec![];
     let mut last_wspace: Option<usize> = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,11 @@ where
             visitor.format_separate_mod(module, &*filemap);
         };
 
+        assert_eq!(
+            visitor.line_number,
+            ::utils::count_newlines(&format!("{}", visitor.buffer))
+        );
+
         has_diff |= match after_file(path_str, &mut visitor.buffer) {
             Ok(result) => result,
             Err(e) => {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -54,6 +54,8 @@ implement_spanned!(ast::Field);
 implement_spanned!(ast::ForeignItem);
 implement_spanned!(ast::Item);
 implement_spanned!(ast::Local);
+implement_spanned!(ast::TraitItem);
+implement_spanned!(ast::ImplItem);
 
 impl Spanned for ast::Stmt {
     fn span(&self) -> Span {


### PR DESCRIPTION
Closes #1298.
Closes #2006.
Closes #2037.
cc #1978.

Note that this PR still warns on nested expressions with `[rustfmt_skip]`:

```rust
fn foo() {
    // Does not report an error.
    #[rustfmt_skip]
    let a = foo(
        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27],
    );

    // Reports an error.
    let a = bar(
        #[rustfmt_skip] vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27],
    );
}
```

Handling nested expressions is hard because we do not use visitor for them. Assuming that most of the usage of `#[rustfmt_skip]` is on items or statements, I will send this PR anyway.