### PR TITLE
`option_env!` -> `std::env::var` to allow "nightly" check to happen at runtime rather than compile time

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -71,7 +71,7 @@ impl CliOptions {
         options.skip_children = matches.opt_present("skip-children");
         options.verbose = matches.opt_present("verbose");
         let unstable_features = matches.opt_present("unstable-features");
-        let rust_nightly = option_env!("CFG_RELEASE_CHANNEL")
+        let rust_nightly = env::var("CFG_RELEASE_CHANNEL")
             .map(|c| c == "nightly")
             .unwrap_or(false);
         if unstable_features && !rust_nightly {

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use Summary;
 
 macro_rules! is_nightly_channel {
     () => {
-        option_env!("CFG_RELEASE_CHANNEL")
+        env::var("CFG_RELEASE_CHANNEL")
             .map(|c| c == "nightly")
             .unwrap_or(false)
     }


### PR DESCRIPTION
Allow `--unstable-features` to be used in conjunction with setting the CFG_RELEASE_CHANNEL environment variable to `nightly`.