### PR TITLE
Refactorings from cargo clippy etc.

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -54,7 +54,7 @@ fn execute() -> i32 {
     // If there is any invalid argument passed to `cargo fmt`, return without formatting.
     let mut is_package_arg = false;
     for arg in env::args().skip(2).take_while(|a| a != "--") {
-        if arg.starts_with("-") {
+        if arg.starts_with('-') {
             is_package_arg = arg.starts_with("--package");
         } else if !is_package_arg {
             print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`.", arg));
@@ -215,7 +215,7 @@ impl CargoFmtStrategy {
     }
 }
 
-/// Based on the specified CargoFmtStrategy, returns a set of main source files.
+/// Based on the specified `CargoFmtStrategy`, returns a set of main source files.
 fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error> {
     let mut targets = HashSet::new();
 
@@ -228,7 +228,7 @@ fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error
     if targets.is_empty() {
         Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("Failed to find targets"),
+            "Failed to find targets".to_owned(),
         ))
     } else {
         Ok(targets)
@@ -310,7 +310,7 @@ fn get_targets_with_hitlist(
 
 fn add_targets(target_paths: &[cargo_metadata::Target], targets: &mut HashSet<Target>) {
     for target in target_paths {
-        targets.insert(Target::from_target(&target));
+        targets.insert(Target::from_target(target));
     }
 }
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -930,7 +930,7 @@ pub fn recover_comment_removed(
     context: &RewriteContext,
 ) -> Option<String> {
     let snippet = context.snippet(span);
-    if snippet != new && changed_comment_content(&snippet, &new) {
+    if snippet != new && changed_comment_content(snippet, &new) {
         // We missed some comments. Keep the original text.
         Some(snippet.to_owned())
     } else {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -304,7 +304,7 @@ pub fn format_expr(
         })
 }
 
-#[derive(new)]
+#[derive(new, Clone, Copy)]
 pub struct PairParts<'a> {
     prefix: &'a str,
     infix: &'a str,
@@ -729,7 +729,7 @@ struct ControlFlow<'a> {
     span: Span,
 }
 
-fn to_control_flow<'a>(expr: &'a ast::Expr, expr_type: ExprType) -> Option<ControlFlow<'a>> {
+fn to_control_flow(expr: &ast::Expr, expr_type: ExprType) -> Option<ControlFlow> {
     match expr.node {
         ast::ExprKind::If(ref cond, ref if_block, ref else_block) => Some(ControlFlow::new_if(
             cond,
@@ -2122,16 +2122,12 @@ fn is_every_args_simple<T: ToExpr>(lists: &[&T]) -> bool {
 
 /// In case special-case style is required, returns an offset from which we start horizontal layout.
 fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<usize> {
-    if FORMAT_LIKE_WHITELIST
-        .iter()
-        .find(|s| **s == callee_str)
-        .is_some() && args.len() >= 1 && is_every_args_simple(args)
+    if FORMAT_LIKE_WHITELIST.iter().any(|s| *s == callee_str) && args.len() >= 1
+        && is_every_args_simple(args)
     {
         Some(1)
-    } else if WRITE_LIKE_WHITELIST
-        .iter()
-        .find(|s| **s == callee_str)
-        .is_some() && args.len() >= 2 && is_every_args_simple(args)
+    } else if WRITE_LIKE_WHITELIST.iter().any(|s| *s == callee_str) && args.len() >= 2
+        && is_every_args_simple(args)
     {
         Some(2)
     } else {

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -45,7 +45,7 @@ where
 }
 
 // Prints all newlines either as `\n` or as `\r\n`.
-pub fn write_system_newlines<T>(writer: T, text: &String, config: &Config) -> Result<(), io::Error>
+pub fn write_system_newlines<T>(writer: T, text: &str, config: &Config) -> Result<(), io::Error>
 where
     T: Write,
 {
@@ -79,7 +79,7 @@ where
 }
 
 pub fn write_file<T>(
-    text: &String,
+    text: &str,
     filename: &str,
     out: &mut T,
     config: &Config,
@@ -88,7 +88,7 @@ where
     T: Write,
 {
     fn source_and_formatted_text(
-        text: &String,
+        text: &str,
         filename: &str,
         config: &Config,
     ) -> Result<(String, String), io::Error> {
@@ -103,7 +103,7 @@ where
 
     fn create_diff(
         filename: &str,
-        text: &String,
+        text: &str,
         config: &Config,
     ) -> Result<Vec<Mismatch>, io::Error> {
         let (ori, fmt) = source_and_formatted_text(text, filename, config)?;

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -108,10 +108,10 @@ fn compare_use_trees(a: &ast::UseTree, b: &ast::UseTree, nested: bool) -> Orderi
 fn compare_use_items(context: &RewriteContext, a: &ast::Item, b: &ast::Item) -> Option<Ordering> {
     match (&a.node, &b.node) {
         (&ast::ItemKind::Use(ref a_tree), &ast::ItemKind::Use(ref b_tree)) => {
-            Some(compare_use_trees(&a_tree, &b_tree, false))
+            Some(compare_use_trees(a_tree, b_tree, false))
         }
         (&ast::ItemKind::ExternCrate(..), &ast::ItemKind::ExternCrate(..)) => {
-            Some(context.snippet(a.span).cmp(&context.snippet(b.span)))
+            Some(context.snippet(a.span).cmp(context.snippet(b.span)))
         }
         _ => None,
     }
@@ -141,7 +141,7 @@ impl Rewrite for ast::UseTree {
             ast::UseTreeKind::Glob => {
                 let prefix_shape = shape.sub_width(3)?;
 
-                if self.prefix.segments.len() > 0 {
+                if !self.prefix.segments.is_empty() {
                     let path_str = rewrite_prefix(&self.prefix, context, prefix_shape)?;
                     Some(format!("{}::*", path_str))
                 } else {
@@ -476,7 +476,7 @@ fn rewrite_nested_use_tree(
         let mut items = vec![ListItem::from_str("")];
         let iter = itemize_list(
             context.codemap,
-            trees.iter().map(|ref tree| &tree.0),
+            trees.iter().map(|tree| &tree.0),
             "}",
             ",",
             |tree| tree.span.lo(),

--- a/src/items.rs
+++ b/src/items.rs
@@ -239,8 +239,8 @@ impl<'a> FnSig<'a> {
 }
 
 impl<'a> FmtVisitor<'a> {
-    fn format_item(&mut self, item: Item) {
-        self.push_str(&item.abi);
+    fn format_item(&mut self, item: &Item) {
+        self.buffer.push_str(&item.abi);
 
         let snippet = self.snippet(item.span);
         let brace_pos = snippet.find_uncommented("{").unwrap();
@@ -279,7 +279,7 @@ impl<'a> FmtVisitor<'a> {
 
     pub fn format_foreign_mod(&mut self, fm: &ast::ForeignMod, span: Span) {
         let item = Item::from_foreign_mod(fm, span, self.config);
-        self.format_item(item);
+        self.format_item(&item);
     }
 
     fn format_foreign_item(&mut self, item: &ast::ForeignItem) {
@@ -950,7 +950,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
                 .span_after(item.span, &format!("{}", item.ident));
             let bound_hi = type_param_bounds.last().unwrap().span().hi();
             let snippet = context.snippet(mk_sp(ident_hi, bound_hi));
-            if contains_comment(&snippet) {
+            if contains_comment(snippet) {
                 return None;
             }
         }
@@ -1175,7 +1175,7 @@ pub fn format_struct_struct(
             result.push('\n');
             result.push_str(&offset.to_string(context.config));
         } else {
-            result.push_str(&snippet);
+            result.push_str(snippet);
         }
         result.push('}');
         return Some(result);
@@ -1307,7 +1307,7 @@ fn format_tuple_struct(
             result.push('\n');
             result.push_str(&offset.to_string(context.config));
         } else {
-            result.push_str(&snippet);
+            result.push_str(snippet);
         }
         result.push(')');
     } else {
@@ -2718,7 +2718,7 @@ fn format_header(item_name: &str, ident: ast::Ident, vis: &ast::Visibility) -> S
     format!("{}{}{}", format_visibility(vis), item_name, ident)
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum BracePos {
     None,
     Auto,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,7 +144,7 @@ pub fn rewrite_macro(
     };
 
     let ts: TokenStream = mac.node.stream();
-    if ts.is_empty() && !contains_comment(&context.snippet(mac.span)) {
+    if ts.is_empty() && !contains_comment(context.snippet(mac.span)) {
         return match style {
             MacroStyle::Parens if position == MacroPosition::Item => {
                 Some(format!("{}();", macro_name))

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -20,9 +20,28 @@ use shape::{Indent, Shape};
 use utils::{count_newlines, last_line_width, mk_sp};
 use visitor::FmtVisitor;
 
+struct SnippetStatus {
+    /// An offset to the current line from the beginnig of the original snippet.
+    line_start: usize,
+    /// A length of trailing whitespaces on the current line.
+    last_wspace: Option<usize>,
+    /// The current line number.
+    cur_line: usize,
+}
+
+impl SnippetStatus {
+    fn new(cur_line: usize) -> Self {
+        SnippetStatus {
+            line_start: 0,
+            last_wspace: None,
+            cur_line,
+        }
+    }
+}
+
 impl<'a> FmtVisitor<'a> {
     fn output_at_start(&self) -> bool {
-        self.buffer.len() == 0
+        self.buffer.is_empty()
     }
 
     // TODO these format_missing methods are ugly. Refactor and add unit tests
@@ -77,8 +96,8 @@ impl<'a> FmtVisitor<'a> {
         let snippet = self.snippet(span);
         if snippet.trim().is_empty() && !out_of_file_lines_range!(self, span) {
             // Keep vertical spaces within range.
-            self.push_vertical_spaces(count_newlines(&snippet));
-            process_last_snippet(self, "", &snippet);
+            self.push_vertical_spaces(count_newlines(snippet));
+            process_last_snippet(self, "", snippet);
         } else {
             self.write_snippet(span, &process_last_snippet);
         }
@@ -86,11 +105,7 @@ impl<'a> FmtVisitor<'a> {
 
     fn push_vertical_spaces(&mut self, mut newline_count: usize) {
         // The buffer already has a trailing newline.
-        let offset = if last_line_width(&self.buffer) == 0 {
-            0
-        } else {
-            1
-        };
+        let offset = if self.buffer.ends_with('\n') { 0 } else { 1 };
         let newline_upper_bound = self.config.blank_lines_upper_bound() + offset;
         let newline_lower_bound = self.config.blank_lines_lower_bound() + offset;
         if newline_count > newline_upper_bound {
@@ -121,86 +136,7 @@ impl<'a> FmtVisitor<'a> {
 
         debug!("write_snippet `{}`", snippet);
 
-        self.write_snippet_inner(big_snippet, big_diff, &snippet, span, process_last_snippet);
-    }
-
-    fn process_comment(
-        &mut self,
-        status: &mut SnippetStatus,
-        snippet: &str,
-        big_snippet: &str,
-        offset: usize,
-        big_diff: usize,
-        subslice: &str,
-        file_name: &str,
-    ) -> bool {
-        let last_char = big_snippet[..(offset + big_diff)]
-            .chars()
-            .rev()
-            .skip_while(|rev_c| [' ', '\t'].contains(rev_c))
-            .next();
-
-        let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
-
-        let subslice_num_lines = count_newlines(subslice);
-        let skip_this_range = !self.config.file_lines().intersects_range(
-            file_name,
-            status.cur_line,
-            status.cur_line + subslice_num_lines,
-        );
-
-        if status.rewrite_next_comment && skip_this_range {
-            status.rewrite_next_comment = false;
-        }
-
-        if status.rewrite_next_comment {
-            let comment_indent = if fix_indent {
-                if let Some('{') = last_char {
-                    self.push_str("\n");
-                }
-                let indent_str = self.block_indent.to_string(self.config);
-                self.push_str(&indent_str);
-                self.block_indent
-            } else {
-                self.push_str(" ");
-                Indent::from_width(self.config, last_line_width(&self.buffer))
-            };
-            let comment_width = ::std::cmp::min(
-                self.config.comment_width(),
-                self.config.max_width() - self.block_indent.width(),
-            );
-            let comment_shape = Shape::legacy(comment_width, comment_indent);
-            let comment_str = rewrite_comment(subslice, false, comment_shape, self.config)
-                .unwrap_or_else(|| String::from(subslice));
-            self.push_str(&comment_str);
-
-            status.last_wspace = None;
-            status.line_start = offset + subslice.len();
-
-            if let Some('/') = subslice.chars().nth(1) {
-                // check that there are no contained block comments
-                if !subslice
-                    .split('\n')
-                    .map(|s| s.trim_left())
-                    .any(|s| s.len() >= 2 && &s[0..2] == "/*")
-                {
-                    // Add a newline after line comments
-                    self.push_str("\n");
-                }
-            } else if status.line_start <= snippet.len() {
-                // For other comments add a newline if there isn't one at the end already
-                match snippet[status.line_start..].chars().next() {
-                    Some('\n') | Some('\r') => (),
-                    _ => self.push_str("\n"),
-                }
-            }
-
-            status.cur_line += subslice_num_lines;
-            true
-        } else {
-            status.rewrite_next_comment = false;
-            false
-        }
+        self.write_snippet_inner(big_snippet, big_diff, snippet, span, process_last_snippet);
     }
 
     fn write_snippet_inner<F>(
@@ -220,19 +156,6 @@ impl<'a> FmtVisitor<'a> {
         let file_name = &char_pos.file.name;
         let mut status = SnippetStatus::new(char_pos.line);
 
-        fn replace_chars<'a>(string: &'a str) -> Cow<'a, str> {
-            if string.contains(char::is_whitespace) {
-                Cow::from(
-                    string
-                        .chars()
-                        .map(|ch| if ch.is_whitespace() { ch } else { 'X' })
-                        .collect::<String>(),
-                )
-            } else {
-                Cow::from(string)
-            }
-        }
-
         let snippet = &*match self.config.write_mode() {
             WriteMode::Coverage => replace_chars(old_snippet),
             _ => Cow::from(old_snippet),
@@ -241,98 +164,148 @@ impl<'a> FmtVisitor<'a> {
         for (kind, offset, subslice) in CommentCodeSlices::new(snippet) {
             debug!("{:?}: {:?}", kind, subslice);
 
-            if let CodeCharKind::Comment = kind {
-                if self.process_comment(
+            let newline_count = count_newlines(subslice);
+            let within_file_lines_range = self.config.file_lines().intersects_range(
+                file_name,
+                status.cur_line,
+                status.cur_line + newline_count,
+            );
+
+            if CodeCharKind::Comment == kind && within_file_lines_range {
+                // 1: comment.
+                self.process_comment(
                     &mut status,
                     snippet,
-                    big_snippet,
+                    &big_snippet[..(offset + big_diff)],
                     offset,
-                    big_diff,
                     subslice,
-                    file_name,
-                ) {
-                    continue;
-                }
-            }
-
-            let newline_count = count_newlines(&subslice);
-            if subslice.trim().is_empty() && newline_count > 0
-                && self.config.file_lines().intersects_range(
-                    file_name,
-                    status.cur_line,
-                    status.cur_line + newline_count,
-                ) {
+                );
+            } else if subslice.trim().is_empty() && newline_count > 0 && within_file_lines_range {
+                // 2: blank lines.
                 self.push_vertical_spaces(newline_count);
                 status.cur_line += newline_count;
-                status.rewrite_next_comment = true;
                 status.line_start = offset + newline_count;
             } else {
-                for (mut i, c) in subslice.char_indices() {
-                    i += offset;
-
-                    if c == '\n' {
-                        if !self.config
-                            .file_lines()
-                            .contains_line(file_name, status.cur_line)
-                        {
-                            status.last_wspace = None;
-                        }
-
-                        if let Some(lw) = status.last_wspace {
-                            self.push_str(&snippet[status.line_start..lw]);
-                            self.push_str("\n");
-                        } else {
-                            self.push_str(&snippet[status.line_start..i + 1]);
-                        }
-
-                        status.cur_line += 1;
-                        status.line_start = i + 1;
-                        status.last_wspace = None;
-                        status.rewrite_next_comment = true;
-                    } else if c.is_whitespace() {
-                        if status.last_wspace.is_none() {
-                            status.last_wspace = Some(i);
-                        }
-                    } else if c == ';' {
-                        if status.last_wspace.is_some() {
-                            status.line_start = i;
-                        }
-
-                        status.rewrite_next_comment = true;
-                        status.last_wspace = None;
-                    } else {
-                        status.rewrite_next_comment = true;
-                        status.last_wspace = None;
-                    }
-                }
-
-                let remaining = snippet[status.line_start..subslice.len() + offset].trim();
-                if !remaining.is_empty() {
-                    self.push_str(remaining);
-                    status.line_start = subslice.len() + offset;
-                    status.rewrite_next_comment = true;
-                }
+                // 3: code which we failed to format or which is not within file-lines range.
+                self.process_missing_code(&mut status, snippet, subslice, offset, file_name);
             }
         }
 
         process_last_snippet(self, &snippet[status.line_start..], snippet);
     }
-}
 
-struct SnippetStatus {
-    line_start: usize,
-    last_wspace: Option<usize>,
-    rewrite_next_comment: bool,
-    cur_line: usize,
-}
+    fn process_comment(
+        &mut self,
+        status: &mut SnippetStatus,
+        snippet: &str,
+        big_snippet: &str,
+        offset: usize,
+        subslice: &str,
+    ) {
+        let last_char = big_snippet
+            .chars()
+            .rev()
+            .skip_while(|rev_c| [' ', '\t'].contains(rev_c))
+            .next();
 
-impl SnippetStatus {
-    fn new(cur_line: usize) -> Self {
-        SnippetStatus {
-            line_start: 0,
-            last_wspace: None,
-            rewrite_next_comment: true,
-            cur_line,
+        let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
+
+        if fix_indent {
+            if let Some('{') = last_char {
+                self.push_str("\n");
+            }
+            let indent_str = self.block_indent.to_string(self.config);
+            self.push_str(&indent_str);
+        } else {
+            self.push_str(" ");
+        }
+
+        let comment_width = ::std::cmp::min(
+            self.config.comment_width(),
+            self.config.max_width() - self.block_indent.width(),
+        );
+        let comment_indent = Indent::from_width(self.config, last_line_width(&self.buffer));
+        let comment_shape = Shape::legacy(comment_width, comment_indent);
+        let comment_str = rewrite_comment(subslice, false, comment_shape, self.config)
+            .unwrap_or_else(|| String::from(subslice));
+        self.push_str(&comment_str);
+
+        status.last_wspace = None;
+        status.line_start = offset + subslice.len();
+
+        if let Some('/') = subslice.chars().nth(1) {
+            // check that there are no contained block comments
+            if !subslice
+                .split('\n')
+                .map(|s| s.trim_left())
+                .any(|s| s.len() >= 2 && &s[0..2] == "/*")
+            {
+                // Add a newline after line comments
+                self.push_str("\n");
+            }
+        } else if status.line_start <= snippet.len() {
+            // For other comments add a newline if there isn't one at the end already
+            match snippet[status.line_start..].chars().next() {
+                Some('\n') | Some('\r') => (),
+                _ => self.push_str("\n"),
+            }
+        }
+
+        status.cur_line += count_newlines(subslice);
+    }
+
+    fn process_missing_code(
+        &mut self,
+        status: &mut SnippetStatus,
+        snippet: &str,
+        subslice: &str,
+        offset: usize,
+        file_name: &str,
+    ) {
+        for (mut i, c) in subslice.char_indices() {
+            i += offset;
+
+            if c == '\n' {
+                let skip_this_line = !self.config
+                    .file_lines()
+                    .contains_line(file_name, status.cur_line);
+                if skip_this_line {
+                    status.last_wspace = None;
+                }
+
+                if let Some(lw) = status.last_wspace {
+                    self.push_str(&snippet[status.line_start..lw]);
+                    self.push_str("\n");
+                    status.last_wspace = None;
+                } else {
+                    self.push_str(&snippet[status.line_start..i + 1]);
+                }
+
+                status.cur_line += 1;
+                status.line_start = i + 1;
+            } else if c.is_whitespace() && status.last_wspace.is_none() {
+                status.last_wspace = Some(i);
+            } else if c == ';' && status.last_wspace.is_some() {
+                status.line_start = i;
+                status.last_wspace = None;
+            } else {
+                status.last_wspace = None;
+            }
+        }
+
+        let remaining = snippet[status.line_start..subslice.len() + offset].trim();
+        if !remaining.is_empty() {
+            self.push_str(remaining);
+            status.line_start = subslice.len() + offset;
         }
     }
+}
+
+fn replace_chars(string: &str) -> Cow<str> {
+    Cow::from(
+        string
+            .chars()
+            .map(|ch| if ch.is_whitespace() { ch } else { 'X' })
+            .collect::<String>(),
+    )
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,5 +1,5 @@
 #[must_use]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Summary {
     // Encountered e.g. an IO error.
     has_operational_errors: bool,


### PR DESCRIPTION
This PR

1. applies refactorings from `cargo clippy`.
2. refactors `write_snippet_inner()`. First split it into `process_comment()` and `process_missing_code()`, then simplify each functions.