### PR TITLE
Attempt to improve error meassage from rustfmt

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -350,7 +350,7 @@ fn main() {
             }
         }
         Err(e) => {
-            print_usage_to_stderr(&opts, &e.to_string());
+            eprintln!("{}", e.to_string());
             1
         }
     };
@@ -364,23 +364,18 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-macro_rules! print_usage {
-    ($print:ident, $opts:ident, $reason:expr) => ({
-        let msg = format!(
-            "{}\n\nusage: {} [options] <file>...",
-            $reason,
-            env::args_os().next().unwrap().to_string_lossy()
-        );
-        $print!("{}", $opts.usage(&msg));
-    })
-}
-
 fn print_usage_to_stdout(opts: &Options, reason: &str) {
-    print_usage!(println, opts, reason);
-}
-
-fn print_usage_to_stderr(opts: &Options, reason: &str) {
-    print_usage!(eprintln, opts, reason);
+    let sep = if reason.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n\n", reason)
+    };
+    let msg = format!(
+        "{}Format Rust code\n\nusage: {} [options] <file>...",
+        sep,
+        env::args_os().next().unwrap().to_string_lossy()
+    );
+    println!("{}", opts.usage(&msg));
 }
 
 fn print_version() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -394,22 +394,23 @@ macro_rules! create_config {
                             $(
                                 stringify!($i) => (),
                             )+
-                                _ => {
-                                    let msg =
-                                        &format!("Warning: Unknown configuration option `{}`\n",
-                                                 key);
-                                    err.push_str(msg)
-                                }
+                            _ => {
+                                let msg =
+                                    &format!("Warning: Unknown configuration option `{}`\n", key);
+                                err.push_str(msg)
+                            }
                         }
                     }
                 }
                 match parsed.try_into() {
-                    Ok(parsed_config) =>
-                        Ok(Config::default().fill_from_parsed_config(parsed_config)),
+                    Ok(parsed_config) => {
+                        eprintln!("{}", err);
+                        Ok(Config::default().fill_from_parsed_config(parsed_config))
+                    }
                     Err(e) => {
                         err.push_str("Error: Decoding config file failed:\n");
                         err.push_str(format!("{}\n", e).as_str());
-                        err.push_str("Please check your config file.\n");
+                        err.push_str("Please check your config file.");
                         Err(err)
                     }
                 }


### PR DESCRIPTION
This PR

1. prevents printing usage when rustfmt failed due to IO errors. Also adds summary "Format Rust code".
2. warns when there are unknown configuration options. Currently rustfmt does not emit any warning. Since we have removed and combined many config options, we should explicitly warn these changes to the user. This is not a hard error: rustfmt still formats files even when unknown config options is in rustfmt.toml. 