### PR TITLE
Configurations checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ getopts = "0.2"
 derive-new = "0.5"
 cargo_metadata = "0.4"
 
+[dev-dependencies]
+lazy_static = "1.0.0"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.11"
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -511,12 +511,12 @@ Maximum length of comments. No effect unless`wrap_comments = true`.
 
 **Note:** A value of `0` results in [`wrap_comments`](#wrap_comments) being applied regardless of a line's width.
 
-#### Comments shorter than `comment_width`:
+#### `80` (default; comments shorter than `comment_width`):
 ```rust
 // Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ```
 
-#### Comments longer than `comment_width`:
+#### `60` (comments longer than `comment_width`):
 ```rust
 // Lorem ipsum dolor sit amet,
 // consectetur adipiscing elit.

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -97,15 +97,28 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
     results
 }
 
+// A representation of how to write output.
+pub enum PrintType {
+    Fancy, // want to output color and the terminal supports it
+    Basic, // do not want to output color or the terminal does not support color
+}
+
+impl PrintType {
+    pub fn get(color: Color) -> Self {
+        match term::stdout() {
+            Some(ref t) if use_colored_tty(color) && t.supports_color() => PrintType::Fancy,
+            _ => PrintType::Basic,
+        }
+    }
+}
+
 pub fn print_diff<F>(diff: Vec<Mismatch>, get_section_title: F, color: Color)
 where
     F: Fn(u32) -> String,
 {
-    match term::stdout() {
-        Some(ref t) if use_colored_tty(color) && t.supports_color() => {
-            print_diff_fancy(diff, get_section_title, term::stdout().unwrap())
-        }
-        _ => print_diff_basic(diff, get_section_title),
+    match PrintType::get(color) {
+        PrintType::Fancy => print_diff_fancy(diff, get_section_title, term::stdout().unwrap()),
+        PrintType::Basic => print_diff_basic(diff, get_section_title),
     }
 }
 


### PR DESCRIPTION
This PR adds a test that extracts Rust code blocks from [Configurations.md](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md) and attempts to format them. This is the automation part of #1845. If we get through this, the next step will be fixing the formatting failures.

# Change Discussion
Some details on how this works:
- Rust code blocks are identifed by lines beginning with "```rust".
- One explicit configuration setting is supported per code block.
- Rust code blocks with no configuration setting are illegal and cause an assertion failure.
- Configuration names in Configurations.md must be in the form of "## \`NAME`".
- Configuration values in Configurations.md must be in the form of "#### \`VALUE`".
- Each extracted block is formatted.
- Mismatches are prepended by a message pointing to the line in Configurations.md where the diff begins.
- Failures due to parse errors are followed by a message indicating the first line of the block in Configurations.md that could not be parsed. Example:
  > ☝🏽 Failed to format block starting at Line 1676 in Configurations.md

## Message Printing
rustfmt potentially prints a couple different ways:
- via `writeln!` to `term::stdout`
- via `println!`

This changeset tries to ensure that mismatch and configuration failure messages are printed via the same approach (see the changes in rustfmt_diff.rs, for starters), but parsing errors do not follow the same logic as mismatch printing. When fancy diff printing isn't selected, the diff reporting function uses `println!`. Parsing failures are not falling back to `println!` in the same way, however, so in that case the failure message does not appear adjacent to the parsing failure message.

# Examples
The test is currently marked `#[ignore]` because there's a lot of formatting failures at the moment. You can run the test with the `--ignored` flag.
```
cargo test -- --ignored
```

You can see the fancy diff printing case [here](https://gist.github.com/davidalber/67201e613d731e8c2784aa49120b7eb7#file-to-term-out). You can see a non-fancy diff printing case [here](https://gist.github.com/davidalber/67201e613d731e8c2784aa49120b7eb7#file-redirected-out). That was triggered by redirecting test output to a file (`cargo test -- --ignored > foo.log 2>&1`).