### PR TITLE
Fix wrong indentation on type alias

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2754,11 +2754,13 @@ pub fn rewrite_assign_rhs<S: Into<String>, R: Rewrite>(
     shape: Shape,
 ) -> Option<String> {
     let lhs = lhs.into();
-    let last_line_width = last_line_width(&lhs) - if lhs.contains('\n') {
-        shape.indent.width()
-    } else {
-        0
-    };
+    let last_line_width = last_line_width(&lhs)
+        .checked_sub(if lhs.contains('\n') {
+            shape.indent.width()
+        } else {
+            0
+        })
+        .unwrap_or(0);
     // 1 = space between operator and rhs.
     let orig_shape = shape.offset_left(last_line_width + 1).unwrap_or(Shape {
         width: 0,

--- a/tests/target/type_alias.rs
+++ b/tests/target/type_alias.rs
@@ -26,9 +26,8 @@ pub type LongGenericListTest<
 
 pub type Exactly100CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B> = Vec<i32>;
 
-pub type Exactly101CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B> = Vec<
-    Test,
->;
+pub type Exactly101CharsTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B> =
+    Vec<Test>;
 
 pub type Exactly100CharsToEqualTest<'a, 'b, 'c, 'd, LONGPARAMETERNAME, LONGPARAMETERNAME, A, B, C> =
     Vec<i32>;
@@ -71,11 +70,7 @@ where
 type RegisterPlugin = unsafe fn(pt: *const c_char, plugin: *mut c_void, data: *mut CallbackData);
 
 // #1683
-pub type Between<Lhs, Rhs> = super::operators::Between<
-    Lhs,
-    super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>,
->;
-pub type NotBetween<Lhs, Rhs> = super::operators::NotBetween<
-    Lhs,
-    super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>,
->;
+pub type Between<Lhs, Rhs> =
+    super::operators::Between<Lhs, super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>>;
+pub type NotBetween<Lhs, Rhs> =
+    super::operators::NotBetween<Lhs, super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>>;


### PR DESCRIPTION
Use `rewrite_assign_rhs()` when rewriting type alias.

cc #2294, where macro in type position is indented excessively.