### PR TITLE
Add assert_eq! to special-cased macros

### DIFF
--- a/src/codemap.rs
+++ b/src/codemap.rs
@@ -86,11 +86,9 @@ impl LineRangeUtils for CodeMap {
         let hi = self.lookup_char_pos(span.hi());
 
         assert_eq!(
-            lo.file.name,
-            hi.file.name,
+            lo.file.name, hi.file.name,
             "span crossed file boundary: lo: {:?}, hi: {:?}",
-            lo,
-            hi
+            lo, hi
         );
 
         LineRange {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1811,24 +1811,33 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     )
 }
 
-const FORMAT_LIKE_WHITELIST: &[&str] = &[
+const SPECIAL_MACRO_WHITELIST: &[(&str, usize)] = &[
+    // format! like macros
     // From the Rust Standard Library.
-    "eprint!",
-    "eprintln!",
-    "format!",
-    "format_args!",
-    "print!",
-    "println!",
-    "panic!",
-    "unreachable!",
+    ("eprint!", 0),
+    ("eprintln!", 0),
+    ("format!", 0),
+    ("format_args!", 0),
+    ("print!", 0),
+    ("println!", 0),
+    ("panic!", 0),
+    ("unreachable!", 0),
     // From the `log` crate.
-    "debug!",
-    "error!",
-    "info!",
-    "warn!",
+    ("debug!", 0),
+    ("error!", 0),
+    ("info!", 0),
+    ("warn!", 0),
+    // write! like macros
+    ("assert!", 1),
+    ("debug_assert!", 1),
+    ("write!", 1),
+    ("writeln!", 1),
+    // assert_eq! like macros
+    ("assert_eq!", 2),
+    ("assert_ne!", 2),
+    ("debug_assert_eq!", 2),
+    ("debug_assert_ne!", 2),
 ];
-
-const WRITE_LIKE_WHITELIST: &[&str] = &["assert!", "write!", "writeln!"];
 
 pub fn rewrite_call(
     context: &RewriteContext,
@@ -2066,25 +2075,31 @@ where
             } else {
                 tactic = default_tactic();
 
-                // For special-case macros, we may want to use different tactics.
-                let maybe_args_offset = maybe_get_args_offset(callee_str, args);
+                if tactic == DefinitiveListTactic::Vertical {
+                    if let Some((all_simple_before, all_simple_after, num_args_before)) =
+                        maybe_get_args_offset(callee_str, args)
+                    {
+                        let one_line_before = all_simple_before
+                            && definitive_tactic(
+                                &item_vec[..num_args_before - 1],
+                                ListTactic::HorizontalVertical,
+                                Separator::Comma,
+                                nested_shape.width,
+                            ) == DefinitiveListTactic::Horizontal;
 
-                if tactic == DefinitiveListTactic::Vertical && maybe_args_offset.is_some() {
-                    let args_offset = maybe_args_offset.unwrap();
-                    let args_tactic = definitive_tactic(
-                        &item_vec[args_offset..],
-                        ListTactic::HorizontalVertical,
-                        Separator::Comma,
-                        nested_shape.width,
-                    );
+                        let one_line_after = all_simple_after
+                            && definitive_tactic(
+                                &item_vec[num_args_before + 1..],
+                                ListTactic::HorizontalVertical,
+                                Separator::Comma,
+                                nested_shape.width,
+                            ) == DefinitiveListTactic::Horizontal;
 
-                    // Every argument is simple and fits on a single line.
-                    if args_tactic == DefinitiveListTactic::Horizontal {
-                        tactic = if args_offset == 1 {
-                            DefinitiveListTactic::FormatCall
-                        } else {
-                            DefinitiveListTactic::WriteCall
-                        };
+                        tactic = DefinitiveListTactic::SpecialMacro(
+                            one_line_before,
+                            one_line_after,
+                            num_args_before,
+                        );
                     }
                 }
             }
@@ -2120,15 +2135,18 @@ fn is_every_args_simple<T: ToExpr>(lists: &[&T]) -> bool {
 }
 
 /// In case special-case style is required, returns an offset from which we start horizontal layout.
-fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<usize> {
-    if FORMAT_LIKE_WHITELIST.iter().any(|s| *s == callee_str) && args.len() >= 1
-        && is_every_args_simple(args)
+fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, bool, usize)> {
+    if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
+        .iter()
+        .find(|&&(s, _)| s == callee_str)
     {
-        Some(1)
-    } else if WRITE_LIKE_WHITELIST.iter().any(|s| *s == callee_str) && args.len() >= 2
-        && is_every_args_simple(args)
-    {
-        Some(2)
+        let all_simple_before = num_args_before >= 1 && args.len() >= num_args_before
+            && is_every_args_simple(&args[..num_args_before]);
+
+        let all_simple_after =
+            args.len() >= num_args_before + 1 && is_every_args_simple(&args[num_args_before + 1..]);
+
+        Some((all_simple_before, all_simple_after, num_args_before))
     } else {
         None
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2081,7 +2081,7 @@ where
                     {
                         let one_line_before = all_simple_before
                             && definitive_tactic(
-                                &item_vec[..num_args_before - 1],
+                                &item_vec[..num_args_before],
                                 ListTactic::HorizontalVertical,
                                 Separator::Comma,
                                 nested_shape.width,
@@ -2140,8 +2140,8 @@ fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bo
         .iter()
         .find(|&&(s, _)| s == callee_str)
     {
-        let all_simple_before = num_args_before >= 1 && args.len() >= num_args_before
-            && is_every_args_simple(&args[..num_args_before]);
+        let all_simple_before =
+            args.len() >= num_args_before && is_every_args_simple(&args[..num_args_before]);
 
         let all_simple_after =
             args.len() >= num_args_before + 1 && is_every_args_simple(&args[num_args_before + 1..]);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2082,18 +2082,16 @@ where
                 tactic = default_tactic();
 
                 if tactic == DefinitiveListTactic::Vertical {
-                    if let Some((all_simple_before, all_simple_after, num_args_before)) =
+                    if let Some((all_simple, num_args_before)) =
                         maybe_get_args_offset(callee_str, args)
                     {
-                        let one_line_before = all_simple_before
+                        let one_line = all_simple
                             && definitive_tactic(
                                 &item_vec[..num_args_before],
                                 ListTactic::HorizontalVertical,
                                 Separator::Comma,
                                 nested_shape.width,
-                            ) == DefinitiveListTactic::Horizontal;
-
-                        let one_line_after = all_simple_after
+                            ) == DefinitiveListTactic::Horizontal
                             && definitive_tactic(
                                 &item_vec[num_args_before + 1..],
                                 ListTactic::HorizontalVertical,
@@ -2101,11 +2099,9 @@ where
                                 nested_shape.width,
                             ) == DefinitiveListTactic::Horizontal;
 
-                        tactic = DefinitiveListTactic::SpecialMacro(
-                            one_line_before,
-                            one_line_after,
-                            num_args_before,
-                        );
+                        if one_line {
+                            tactic = DefinitiveListTactic::SpecialMacro(num_args_before);
+                        };
                     }
                 }
             }
@@ -2141,18 +2137,14 @@ fn is_every_args_simple<T: ToExpr>(lists: &[&T]) -> bool {
 }
 
 /// In case special-case style is required, returns an offset from which we start horizontal layout.
-fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, bool, usize)> {
+fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, usize)> {
     if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
         .iter()
         .find(|&&(s, _)| s == callee_str)
     {
-        let all_simple_before =
-            args.len() >= num_args_before && is_every_args_simple(&args[..num_args_before]);
+        let all_simple = args.len() >= num_args_before && is_every_args_simple(args);
 
-        let all_simple_after =
-            args.len() >= num_args_before + 1 && is_every_args_simple(&args[num_args_before + 1..]);
-
-        Some((all_simple_before, all_simple_after, num_args_before))
+        Some((all_simple, num_args_before))
     } else {
         None
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1811,6 +1811,12 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     )
 }
 
+/// A list of `format!`-like macros, that take a long format string and a list of arguments to
+/// format.
+///
+/// Organized as a list of `(&str, usize)` tuples, giving the name of the macro and the number of
+/// arguments before the format string (none for `format!("format", ...)`, one for `assert!(result,
+/// "format", ...)`, two for `assert_eq!(left, right, "format", ...)`).
 const SPECIAL_MACRO_WHITELIST: &[(&str, usize)] = &[
     // format! like macros
     // From the Rust Standard Library.

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -161,7 +161,7 @@ pub enum DefinitiveListTactic {
     Horizontal,
     Mixed,
     /// Special case tactic for `format!()`, `write!()` style macros.
-    SpecialMacro(bool, bool, usize),
+    SpecialMacro(usize),
 }
 
 impl DefinitiveListTactic {
@@ -311,30 +311,16 @@ where
             DefinitiveListTactic::Horizontal if !first => {
                 result.push(' ');
             }
-            DefinitiveListTactic::SpecialMacro(
-                one_line_before,
-                one_line_after,
-                num_args_before,
-            ) => {
+            DefinitiveListTactic::SpecialMacro(num_args_before) => {
                 if i == 0 {
                     // Nothing
                 } else if i < num_args_before {
-                    if one_line_before {
-                        result.push(' ');
-                    } else {
-                        result.push('\n');
-                        result.push_str(indent_str);
-                    }
+                    result.push(' ');
                 } else if i <= num_args_before + 1 {
                     result.push('\n');
                     result.push_str(indent_str);
                 } else {
-                    if one_line_after {
-                        result.push(' ');
-                    } else {
-                        result.push('\n');
-                        result.push_str(indent_str);
-                    }
+                    result.push(' ');
                 }
             }
             DefinitiveListTactic::Vertical if !first => {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -160,7 +160,7 @@ pub enum DefinitiveListTactic {
     Vertical,
     Horizontal,
     Mixed,
-    // Special case tactic for `format!()`, `write!()` style macros.
+    /// Special case tactic for `format!()`, `write!()` style macros.
     SpecialMacro(bool, bool, usize),
 }
 
@@ -325,13 +325,10 @@ where
                         result.push('\n');
                         result.push_str(indent_str);
                     }
-                } else if i == num_args_before {
+                } else if i <= num_args_before + 1 {
                     result.push('\n');
                     result.push_str(indent_str);
-                } else if i == num_args_before + 1 {
-                    result.push('\n');
-                    result.push_str(indent_str);
-                } else if i > num_args_before + 1 {
+                } else {
                     if one_line_after {
                         result.push(' ');
                     } else {

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -266,16 +266,21 @@ fn special_case_macros() {
     warn!("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     warn!("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
-    assert!(result, "Ahoy there, {}!", target);
-    assert!(result, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
-    assert!(result, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
+    assert!(result == 42, "Ahoy there, {}!", target);
+    assert!(result == 42, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert!(result == 42, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
+
+    assert_eq!(left, right, "Ahoy there, {}!", target);
+    assert_eq!(left, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(left + 42, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(left, right, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     write!(&mut s, "Ahoy there, {}!", target);
-    write!(&mut s, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
+    write!(&mut s, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
     write!(&mut s, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     writeln!(&mut s, "Ahoy there, {}!", target);
-    writeln!(&mut s, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
+    writeln!(&mut s, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
     writeln!(&mut s, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 }
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -272,6 +272,7 @@ fn special_case_macros() {
 
     assert_eq!(left, right, "Ahoy there, {}!", target);
     assert_eq!(left, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(first_realllllllllllly_long_variable_that_doesnt_fit_one_one_line, second_reallllllllllly_long_variable_that_doesnt_fit_one_one_line, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
     assert_eq!(left + 42, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
     assert_eq!(left, right, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -267,21 +267,21 @@ fn special_case_macros() {
     warn!("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     assert!(result == 42, "Ahoy there, {}!", target);
-    assert!(result == 42, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert!(result == 42, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
     assert!(result == 42, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     assert_eq!(left, right, "Ahoy there, {}!", target);
-    assert_eq!(left, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
-    assert_eq!(first_realllllllllllly_long_variable_that_doesnt_fit_one_one_line, second_reallllllllllly_long_variable_that_doesnt_fit_one_one_line, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
-    assert_eq!(left + 42, right, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(left, right, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(first_realllllllllllly_long_variable_that_doesnt_fit_one_one_line, second_reallllllllllly_long_variable_that_doesnt_fit_one_one_line, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
+    assert_eq!(left + 42, right, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
     assert_eq!(left, right, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     write!(&mut s, "Ahoy there, {}!", target);
-    write!(&mut s, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    write!(&mut s, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
     write!(&mut s, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
     writeln!(&mut s, "Ahoy there, {}!", target);
-    writeln!(&mut s, "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')", result, input, expected);
+    writeln!(&mut s, "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')", result, input, expected);
     writeln!(&mut s, "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -137,8 +137,7 @@ fn self_tests() {
     }
 
     assert_eq!(
-        warnings,
-        0,
+        warnings, 0,
         "Rustfmt's code generated {} warnings",
         warnings
     );

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -735,6 +735,12 @@ fn special_case_macros() {
         result, input, expected
     );
     assert_eq!(
+        first_realllllllllllly_long_variable_that_doesnt_fit_one_one_line,
+        second_reallllllllllly_long_variable_that_doesnt_fit_one_one_line,
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        result, input, expected
+    );
+    assert_eq!(
         left + 42,
         right,
         "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -691,14 +691,57 @@ fn special_case_macros() {
         26
     );
 
-    assert!(result, "Ahoy there, {}!", target);
+    assert!(result == 42, "Ahoy there, {}!", target);
     assert!(
-        result,
-        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        result == 42,
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
         result, input, expected
     );
     assert!(
-        result,
+        result == 42,
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26
+    );
+
+    assert_eq!(left, right, "Ahoy there, {}!", target);
+    assert_eq!(
+        left, right,
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        result, input, expected
+    );
+    assert_eq!(
+        left + 42,
+        right,
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        result, input, expected
+    );
+    assert_eq!(
+        left, right,
         "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         1,
         2,
@@ -731,7 +774,7 @@ fn special_case_macros() {
     write!(&mut s, "Ahoy there, {}!", target);
     write!(
         &mut s,
-        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
         result, input, expected
     );
     write!(
@@ -768,7 +811,7 @@ fn special_case_macros() {
     writeln!(&mut s, "Ahoy there, {}!", target);
     writeln!(
         &mut s,
-        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
         result, input, expected
     );
     writeln!(

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -694,8 +694,10 @@ fn special_case_macros() {
     assert!(result == 42, "Ahoy there, {}!", target);
     assert!(
         result == 42,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
-        result, input, expected
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        result,
+        input,
+        expected
     );
     assert!(
         result == 42,
@@ -731,23 +733,28 @@ fn special_case_macros() {
     assert_eq!(left, right, "Ahoy there, {}!", target);
     assert_eq!(
         left, right,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
         result, input, expected
     );
     assert_eq!(
         first_realllllllllllly_long_variable_that_doesnt_fit_one_one_line,
         second_reallllllllllly_long_variable_that_doesnt_fit_one_one_line,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
-        result, input, expected
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        result,
+        input,
+        expected
     );
     assert_eq!(
         left + 42,
         right,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
-        result, input, expected
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
+        result,
+        input,
+        expected
     );
     assert_eq!(
-        left, right,
+        left,
+        right,
         "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         1,
         2,
@@ -780,7 +787,7 @@ fn special_case_macros() {
     write!(&mut s, "Ahoy there, {}!", target);
     write!(
         &mut s,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
         result, input, expected
     );
     write!(
@@ -817,7 +824,7 @@ fn special_case_macros() {
     writeln!(&mut s, "Ahoy there, {}!", target);
     writeln!(
         &mut s,
-        "Arr! Batten down the hatches, we got '{}' but not '{}' (we expected '{}')",
+        "Arr! While plunderin' the hold, we got '{}' when given '{}' (we expected '{}')",
         result, input, expected
     );
     writeln!(


### PR DESCRIPTION
Continuing with the implementation of rust-lang-nursery/fmt-rfcs#86, allows for this form of `assert_eq!` macros:
```rust
assert_eq!(
    left.id, right.id,
    "IDs are not equal: {:?} {:?}",
    left, right
);
```

As a side-effect of how I implemented this it also allows for `assert!` macros to have the format arguments split across multiple lines even if the assert condition is not simple:
```rust
assert!(
    result >= 42,
    "The result must be at least 42: {:?}",
    result, result.code, context
);
```
I think that's reasonable behaviour, although not explicitly specified in the RFC pull request (rust-lang-nursery/fmt-rfcs#110)