### PR TITLE
Add example to Configurations.md for blank_lines_lower_bound.

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -614,6 +614,48 @@ Error if unable to get all comment lines within `comment_width`.
 
 See also [`comment_width`](#comment_width).
 
+## `blank_lines_upper_bound`
+
+Maximum number of blank lines which can be put between items.
+
+- **Default value**: `1`
+- **Possible values**: Any number representable by a `usize`
+- **Stable**: No
+
+#### `1` (default):
+
+```rust
+fn foo() {}
+fn bar() {}
+
+// comment
+fn foobar() {}
+
+fn foo1() {}
+fn bar1() {}
+
+// comment
+fn foobar1() {}
+```
+
+#### `2`:
+
+```rust
+fn foo() {}
+fn bar() {}
+
+// comment
+fn foobar() {}
+
+
+fn foo1() {}
+fn bar1() {}
+
+
+// comment
+fn foobar1() {}
+```
+
 ## `fn_args_density`
 
 Argument density in functions


### PR DESCRIPTION
Referenced in issue #2312 

I'm not sure how to tell if this setting is in stable or not. If it is in stable, I'll need to make a small tweak before this is merged.

I chose a location in the file that kind of makes sense, but if it should be somewhere else, I'll also change that.