### PR TITLE
Aligning text with its bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,25 +217,25 @@ See [Configurations.md](Configurations.md) for details.
 * If you get an error like `error while loading shared libraries` while starting
   up rustfmt you should try the following:
 
-On Linux:
+  On Linux:
 
-```
-export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
-```
+  ```
+  export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
+  ```
 
-On MacOS:
+  On MacOS:
 
-```
-export DYLD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$DYLD_LIBRARY_PATH
-```
+  ```
+  export DYLD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$DYLD_LIBRARY_PATH
+  ```
 
-On Windows (Git Bash/Mingw):
+  On Windows (Git Bash/Mingw):
 
-```
-export PATH=$(rustc --print sysroot)/lib/rustlib/x86_64-pc-windows-gnu/lib/:$PATH
-```
+  ```
+  export PATH=$(rustc --print sysroot)/lib/rustlib/x86_64-pc-windows-gnu/lib/:$PATH
+  ```
 
-(Substitute `x86_64` by `i686` and `gnu` by `msvc` depending on which version of rustc was used to install rustfmt).
+  (Substitute `x86_64` by `i686` and `gnu` by `msvc` depending on which version of rustc was used to install rustfmt).
 
 ## License
 


### PR DESCRIPTION
This is a minor README-formatting change that aligns text with the bullet it is part of. Look starting at "On Linux" in the screenshots below.

**[Current](https://github.com/rust-lang-nursery/rustfmt#tips):**
![image](https://user-images.githubusercontent.com/933552/34465247-93b8f2ac-ee5a-11e7-83b5-2479b8888846.png)

**[Updated](https://github.com/davidalber/rustfmt/tree/indent-bullet-text#tips):**
![image](https://user-images.githubusercontent.com/933552/34465250-a6c1ef3e-ee5a-11e7-801a-f006cb00a5c8.png)
