### PR TITLE
Issue 2329

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -34,7 +34,7 @@ use utils::{colon_spaces, contains_skip, first_line_width, format_abi, format_co
             format_defaultness, format_mutability, format_unsafety, format_visibility,
             is_attributes_extendable, last_line_contains_single_line_comment,
             last_line_used_width, last_line_width, mk_sp, semicolon_for_expr, starts_with_newline,
-            stmt_expr, trim_newlines, trimmed_last_line_width};
+            stmt_expr, trimmed_last_line_width};
 use vertical::rewrite_with_alignment;
 use visitor::FmtVisitor;
 
@@ -674,7 +674,7 @@ pub fn format_impl(
 
             result.push('\n');
             result.push_str(&inner_indent_str);
-            result.push_str(trim_newlines(visitor.buffer.to_string().trim()));
+            result.push_str(visitor.buffer.to_string().trim());
             result.push('\n');
             result.push_str(&outer_indent_str);
         }
@@ -1073,7 +1073,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
 
             result.push('\n');
             result.push_str(&inner_indent_str);
-            result.push_str(trim_newlines(visitor.buffer.to_string().trim()));
+            result.push_str(visitor.buffer.to_string().trim());
             result.push('\n');
             result.push_str(&outer_indent_str);
         } else if result.contains('\n') {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -254,17 +254,6 @@ pub fn count_newlines(input: &str) -> usize {
     input.chars().filter(|&c| c == '\n').count()
 }
 
-#[inline]
-pub fn trim_newlines(input: &str) -> &str {
-    match input.find(|c| c != '\n' && c != '\r') {
-        Some(start) => {
-            let end = input.rfind(|c| c != '\n' && c != '\r').unwrap_or(0) + 1;
-            &input[start..end]
-        }
-        None => "",
-    }
-}
-
 // Macro for deriving implementations of Serialize/Deserialize for enums
 #[macro_export]
 macro_rules! impl_enum_serialize_and_deserialize {

--- a/tests/target/issue-2329.rs
+++ b/tests/target/issue-2329.rs
@@ -1,0 +1,30 @@
+// Comments with characters which must be represented by multibyte.
+
+// フー
+use foo;
+// バー
+use bar;
+
+impl MyStruct {
+    // コメント
+    fn f1() {} // こんにちは
+    fn f2() {} // ありがとう
+               // コメント
+}
+
+trait MyTrait {
+    // コメント
+    fn f1() {} // こんにちは
+    fn f2() {} // ありがとう
+               // コメント
+}
+
+fn main() {
+    // コメント
+    let x = 1; // Ｘ
+    println!(
+        "x = {}", // xの値
+        x,        // Ｘ
+    );
+    // コメント
+}


### PR DESCRIPTION
The panic was caused by `+1` inside `trim_newlines()`. It turns out that this function is unnecessary, because we call this against `trim()`med buffer 😛 

Closes #2329.