### PR TITLE
Removing unused name

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -10,7 +10,7 @@
 
 use std::borrow::Cow;
 use std::cmp::min;
-use std::iter::{repeat, ExactSizeIterator};
+use std::iter::repeat;
 
 use syntax::{ast, ptr};
 use syntax::codemap::{BytePos, CodeMap, Span};


### PR DESCRIPTION
`ExactSizeIterator` is seemingly unused in expr.rs. This removes it from the block of `use` statements.