### PR TITLE
Modifying failure messages to be consistent with mismatch message

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -651,14 +651,16 @@ impl ConfigCodeBlock {
 
         if self.config_name.is_none() {
             write_message(format!(
-                "configuration name not found for block beginning at line {}",
+                "No configuration name for {}:{}",
+                CONFIGURATIONS_FILE_NAME,
                 self.code_block_start.unwrap()
             ));
             return false;
         }
         if self.config_value.is_none() {
             write_message(format!(
-                "configuration value not found for block beginning at line {}",
+                "No configuration value for {}:{}",
+                CONFIGURATIONS_FILE_NAME,
                 self.code_block_start.unwrap()
             ));
             return false;
@@ -669,9 +671,9 @@ impl ConfigCodeBlock {
     fn has_parsing_errors(&self, error_summary: Summary) -> bool {
         if error_summary.has_parsing_errors() {
             write_message(format!(
-                "\u{261d}\u{1f3fd} Failed to format block starting at Line {} in {}",
-                self.code_block_start.unwrap(),
-                CONFIGURATIONS_FILE_NAME
+                "\u{261d}\u{1f3fd} Cannot format {}:{}",
+                CONFIGURATIONS_FILE_NAME,
+                self.code_block_start.unwrap()
             ));
             return true;
         }


### PR DESCRIPTION
While looking at the list of examples to update in Configurations.md, I realized the failure messages added in #2292 aren't consistent with the format used in the mismatch failure message. This commit modifies them to be more consistent and more concise.