### PR TITLE
Getting `binop_separator="Back"` snippet in Configurations.md to pass

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -334,16 +334,16 @@ let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 #### `"Back"`:
 
 ```rust
-let or = foo ||
-    bar ||
-    foobar;
+fn main() {
+    r = foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo ||
+        barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar;
 
-let sum = 1234 +
-    5678 +
-    910;
+    let sum = 123456789012345678901234567890 + 123456789012345678901234567890 +
+        123456789012345678901234567890;
 
-let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+    let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; // 🐜 See #2364.
+}
 ```
 
 ## `combine_control_expr`


### PR DESCRIPTION
As the next phase of #1845 I am fixing the formatting failures uncovered by #2292. Most of them are straightforward and will arrive as one big PR. I am submitting this one separately because it potentially exposes a bug.

In terms of getting the test to pass, here's the line failure count for `cargo test -- --ignored` before the change:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `55`,
 right: `0`: 55 configurations tests failed', tests/system.rs:790:5
```

Here's the line failure count for `cargo test -- --ignored` after the change:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `54`,
 right: `0`: 54 configurations tests failed', tests/system.rs:790:5
```