### PR TITLE
Changing comment to use standard `FIXME` notation

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -341,8 +341,9 @@ fn main() {
     let sum = 123456789012345678901234567890 + 123456789012345678901234567890 +
         123456789012345678901234567890;
 
+    // FIXME(#2364) range notation operator ("..") should be at the end of the first line.
     let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; // 🐜 See #2364.
+        ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
 }
 ```
 


### PR DESCRIPTION
This is a follow-up PR triggered by [this comment](https://github.com/rust-lang-nursery/rustfmt/pull/2361#discussion_r161636338) in #2361. You can see the change live [here](https://github.com/davidalber/rustfmt/blob/modify-config-snippet-comment/Configurations.md#back).