### PR TITLE
Restoring accidentally-removed characters

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -335,7 +335,7 @@ let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 ```rust
 fn main() {
-    r = foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo ||
+    let or = foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo ||
         barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar;
 
     let sum = 123456789012345678901234567890 + 123456789012345678901234567890 +


### PR DESCRIPTION
#2361 accidentally changed `let or =` into `r =`. This change corrects that.