### PR TITLE
Fixing binop_separator="Back" for ranges (Issue #2364)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -341,8 +341,8 @@ fn main() {
     let sum = 123456789012345678901234567890 + 123456789012345678901234567890 +
         123456789012345678901234567890;
 
-    let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; // 🐜 See #2364.
+    let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
 }
 ```
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -250,7 +250,7 @@ pub fn format_expr(
                         PairParts::new("", &sp_delim, ""),
                         context,
                         shape,
-                        SeparatorPlace::Front,
+                        context.config.binop_separator(),
                     )
                 }
                 (None, Some(rhs)) => {


### PR DESCRIPTION
Hard coded SeparatorPlace::Front in call to rewrite_pair for range
caused binop_separator="Back" to be handled incorrectly

Fixed call to rewrite_pair and the example in Configuration.md showing
the faulty behavior