### PR TITLE
Fixing straightforward configuration snippets (Part 1)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -664,33 +664,41 @@ trait Lorem {
 
 ```rust
 trait Lorem {
-    fn lorem(ipsum: Ipsum,
-             dolor: Dolor,
-             sit: Sit,
-             amet: Amet);
+    fn lorem(
+        ipsum: Ipsum,
+        dolor: Dolor,
+        sit: Sit,
+        amet: Amet,
+    );
 
-    fn lorem(ipsum: Ipsum,
-             dolor: Dolor,
-             sit: Sit,
-             amet: Amet) {
+    fn lorem(
+        ipsum: Ipsum,
+        dolor: Dolor,
+        sit: Sit,
+        amet: Amet,
+    ) {
         // body
     }
 
-    fn lorem(ipsum: Ipsum,
-             dolor: Dolor,
-             sit: Sit,
-             amet: Amet,
-             consectetur: Consectetur,
-             adipiscing: Adipiscing,
-             elit: Elit);
+    fn lorem(
+        ipsum: Ipsum,
+        dolor: Dolor,
+        sit: Sit,
+        amet: Amet,
+        consectetur: Consectetur,
+        adipiscing: Adipiscing,
+        elit: Elit,
+    );
 
-    fn lorem(ipsum: Ipsum,
-             dolor: Dolor,
-             sit: Sit,
-             amet: Amet,
-             consectetur: Consectetur,
-             adipiscing: Adipiscing,
-             elit: Elit) {
+    fn lorem(
+        ipsum: Ipsum,
+        dolor: Dolor,
+        sit: Sit,
+        amet: Amet,
+        consectetur: Consectetur,
+        adipiscing: Adipiscing,
+        elit: Elit,
+    ) {
         // body
     }
 }

--- a/Configurations.md
+++ b/Configurations.md
@@ -900,7 +900,7 @@ impl<T> Lorem for T
 where
     Option<T>: Ipsum,
 {
-    ...
+    // body
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -128,16 +128,18 @@ fn lorem(ipsum: usize,
 #### `"Block"` (default):
 
 ```rust
-lorem(
-    "lorem",
-    "ipsum",
-    "dolor",
-    "sit",
-    "amet",
-    "consectetur",
-    "adipiscing",
-    "elit",
-);
+fn main() {
+    lorem(
+        "lorem",
+        "ipsum",
+        "dolor",
+        "sit",
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit",
+    );
+}
 ```
 
 #### `"Visual"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1009,9 +1009,8 @@ Indent style of imports
 #### `"Visual"` (default):
 
 ```rust
-use foo::{xxx,
-          yyy,
-          zzz};
+use foo::{xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+          zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz};
 ```
 
 #### `"Block"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -31,15 +31,17 @@ Indent on expressions or items.
 #### `"Block"` (default):
 
 ```rust
-let lorem = vec![
-    "ipsum",
-    "dolor",
-    "sit",
-    "amet",
-    "consectetur",
-    "adipiscing",
-    "elit",
-];
+fn main() {
+    let lorem = vec![
+        "ipsum",
+        "dolor",
+        "sit",
+        "amet",
+        "consectetur",
+        "adipiscing",
+        "elit",
+    ];
+}
 ```
 
 #### `"Visual"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -529,10 +529,12 @@ Brace style for control flow constructs
 #### `"AlwaysSameLine"` (default):
 
 ```rust
-if lorem {
-    println!("ipsum!");
-} else {
-    println!("dolor!");
+fn main() {
+    if lorem {
+        println!("ipsum!");
+    } else {
+        println!("dolor!");
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -908,8 +908,9 @@ where
 
 ```rust
 impl<T> Lorem for T
-where Option<T>: Ipsum {
-    ...
+where Option<T>: Ipsum
+{
+    // body
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1054,14 +1054,14 @@ use foo::{aaa, bbb, ccc, ddd, eee, fff};
 #### `"HorizontalVertical"`:
 
 ```rust
-use foo::{xxx, yyy, zzz};
+use foo::{xxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzz};
 
-use foo::{aaa,
-          bbb,
-          ccc,
-          ddd,
-          eee,
-          fff};
+use foo::{aaaaaaaaaaaaaaaaaa,
+          bbbbbbbbbbbbbbbbbb,
+          cccccccccccccccccc,
+          dddddddddddddddddd,
+          eeeeeeeeeeeeeeeeee,
+          ffffffffffffffffff};
 ```
 
 #### `"Vertical"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -286,7 +286,11 @@ fn main() {
         "adipiscing",
     );
 
-    let lorem = Lorem { ipsum: dolor, sit: amet };
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+    let lorem = Lorem { ipsum: dolor };
 
     let lorem = if ipsum { dolor } else { sit };
 }

--- a/Configurations.md
+++ b/Configurations.md
@@ -1035,10 +1035,10 @@ Item layout inside a imports block
 #### `"Mixed"` (default):
 
 ```rust
-use foo::{xxx, yyy, zzz};
+use foo::{xxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzz};
 
-use foo::{aaa, bbb, ccc,
-          ddd, eee, fff};
+use foo::{aaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccc, dddddddddddddddddd,
+          eeeeeeeeeeeeeeeeee, ffffffffffffffffff};
 ```
 
 #### `"Horizontal"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1017,9 +1017,8 @@ use foo::{xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
 
 ```rust
 use foo::{
-    xxx,
-    yyy,
-    zzz,
+    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+    zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz,
 };
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -210,10 +210,12 @@ fn lorem<Ipsum: Eq = usize,
 #### `"Block"` (default):
 
 ```rust
-let lorem = Lorem {
-    ipsum: dolor,
-    sit: amet,
-};
+fn main() {
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+}
 ```
 
 #### `"Visual"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -192,15 +192,15 @@ fn lorem<Ipsum: Eq = usize,
          Amet: Eq = usize,
          Adipiscing: Eq = usize,
          Consectetur: Eq = usize,
-         Elit: Eq = usize>
-    (ipsum: Ipsum,
-     dolor: Dolor,
-     sit: Sit,
-     amet: Amet,
-     adipiscing: Adipiscing,
-     consectetur: Consectetur,
-     elit: Elit)
-     -> T {
+         Elit: Eq = usize>(
+    ipsum: Ipsum,
+    dolor: Dolor,
+    sit: Sit,
+    amet: Amet,
+    adipiscing: Adipiscing,
+    consectetur: Consectetur,
+    elit: Elit)
+    -> T {
     // body
 }
 ```

--- a/Configurations.md
+++ b/Configurations.md
@@ -47,13 +47,15 @@ fn main() {
 #### `"Visual"`:
 
 ```rust
-let lorem = vec!["ipsum",
-                 "dolor",
-                 "sit",
-                 "amet",
-                 "consectetur",
-                 "adipiscing",
-                 "elit"];
+fn main() {
+    let lorem = vec!["ipsum",
+                     "dolor",
+                     "sit",
+                     "amet",
+                     "consectetur",
+                     "adipiscing",
+                     "elit"];
+}
 ```
 
 ### Control flow

--- a/Configurations.md
+++ b/Configurations.md
@@ -335,16 +335,16 @@ Where to put a binary operator when a binary expression goes multiline.
 #### `"Front"` (default):
 
 ```rust
-let or = foo
-    || bar
-    || foobar;
+fn main() {
+    let or = foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo
+        || barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar;
 
-let sum = 1234
-    + 5678
-    + 910;
+    let sum = 123456789012345678901234567890 + 123456789012345678901234567890
+        + 123456789012345678901234567890;
 
-let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+    let range = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        ..bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+}
 ```
 
 #### `"Back"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -239,7 +239,7 @@ where
     Ipsum: Eq,
     Dolor: Eq,
     Sit: Eq,
-    Amet: Eq
+    Amet: Eq,
 {
     // body
 }

--- a/Configurations.md
+++ b/Configurations.md
@@ -1091,11 +1091,13 @@ Put a trailing comma after a block based match arm (non-block arms are not affec
 #### `false` (default):
 
 ```rust
-match lorem {
-    Lorem::Ipsum => {
-        println!("ipsum");
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        }
+        Lorem::Dolor => println!("dolor"),
     }
-    Lorem::Dolor => println!("dolor"),
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -504,7 +504,10 @@ Replace strings of _ wildcards by a single .. in tuple patterns
 #### `false` (default):
 
 ```rust
-let (lorem, ipsum, _, _) = (1, 2, 3, 4);
+fn main() {
+    let (lorem, ipsum, _, _) = (1, 2, 3, 4);
+    let (lorem, ipsum, ..) = (1, 2, 3, 4);
+}
 ```
 
 #### `true`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -513,7 +513,9 @@ fn main() {
 #### `true`:
 
 ```rust
-let (lorem, ipsum, ..) = (1, 2, 3, 4);
+fn main() {
+    let (lorem, ipsum, ..) = (1, 2, 3, 4);
+}
 ```
 
 ## `control_brace_style`

--- a/Configurations.md
+++ b/Configurations.md
@@ -1104,11 +1104,13 @@ fn main() {
 #### `true`:
 
 ```rust
-match lorem {
-    Lorem::Ipsum => {
-        println!("ipsum");
-    },
-    Lorem::Dolor => println!("dolor"),
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            println!("ipsum");
+        },
+        Lorem::Dolor => println!("dolor"),
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -798,7 +798,8 @@ struct Lorem
 }
 
 struct Dolor<T>
-    where T: Eq
+where
+    T: Eq,
 {
     sit: T,
 }

--- a/Configurations.md
+++ b/Configurations.md
@@ -169,7 +169,7 @@ fn lorem<
     Amet: Eq = usize,
     Adipiscing: Eq = usize,
     Consectetur: Eq = usize,
-    Elit: Eq = usize
+    Elit: Eq = usize,
 >(
     ipsum: Ipsum,
     dolor: Dolor,

--- a/Configurations.md
+++ b/Configurations.md
@@ -145,14 +145,16 @@ fn main() {
 #### `"Visual"`:
 
 ```rust
-lorem("lorem",
-      "ipsum",
-      "dolor",
-      "sit",
-      "amet",
-      "consectetur",
-      "adipiscing",
-      "elit");
+fn main() {
+    lorem("lorem",
+          "ipsum",
+          "dolor",
+          "sit",
+          "amet",
+          "consectetur",
+          "adipiscing",
+          "elit");
+}
 ```
 
 ### Generics

--- a/Configurations.md
+++ b/Configurations.md
@@ -814,7 +814,8 @@ struct Lorem {
 }
 
 struct Dolor<T>
-    where T: Eq {
+where
+    T: Eq, {
     sit: T,
 }
 ```

--- a/Configurations.md
+++ b/Configurations.md
@@ -963,9 +963,10 @@ fn main() {
 #### `true`:
 
 ```rust
-let lorem =
-    "ipsum dolor sit amet consectetur \
-     adipiscing elit lorem ipsum dolor sit";
+fn main() {
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit amet \
+                 consectetur adipiscing";
+}
 ```
 
 See also [`max_width`](#max_width).

--- a/Configurations.md
+++ b/Configurations.md
@@ -541,13 +541,15 @@ fn main() {
 #### `"AlwaysNextLine"`:
 
 ```rust
-if lorem
-{
-    println!("ipsum!");
-}
-else
-{
-    println!("dolor!");
+fn main() {
+    if lorem
+    {
+        println!("ipsum!");
+    }
+    else
+    {
+        println!("dolor!");
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -783,7 +783,8 @@ struct Lorem {
 }
 
 struct Dolor<T>
-    where T: Eq
+where
+    T: Eq,
 {
     sit: T,
 }

--- a/Configurations.md
+++ b/Configurations.md
@@ -954,7 +954,10 @@ Format string literals where necessary
 #### `false` (default):
 
 ```rust
-let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit";
+fn main() {
+    let lorem =
+        "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit amet consectetur adipiscing";
+}
 ```
 
 #### `true`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -556,11 +556,13 @@ fn main() {
 #### `"ClosingNextLine"`:
 
 ```rust
-if lorem {
-    println!("ipsum!");
-}
-else {
-    println!("dolor!");
+fn main() {
+    if lorem {
+        println!("ipsum!");
+    }
+    else {
+        println!("dolor!");
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -221,8 +221,10 @@ fn main() {
 #### `"Visual"`:
 
 ```rust
-let lorem = Lorem { ipsum: dolor,
-                    sit: amet, };
+fn main() {
+    let lorem = Lorem { ipsum: dolor,
+                        sit: amet, };
+}
 ```
 
 See also: [`struct_lit_single_line`](#struct_lit_single_line), [`indent_style`](#indent_style).


### PR DESCRIPTION
This is the first batch of straightforward configuration snippet fixes for #1845. The second batch will follow, but I wanted to get this out since it has been accumulating for a while.

The fixes use a few approaches. The most common changes are to wrap the snippet in a function and to make the line longer to reach the default max width, which often triggers formatting.

This batch corrects thirty configuration snippets, as can be seen with `cargo test -- --ignored`. Here is the output on master:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `54`,
 right: `0`: 54 configurations tests failed', tests/system.rs:790:5
```

Here is the output on the PR branch:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `24`,
 right: `0`: 24 configurations tests failed', tests/system.rs:790:5
```