### PR TITLE
Updating descriptions to use `..=` instead of `...`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1468,7 +1468,7 @@ struct Foo {
 
 ## `spaces_around_ranges`
 
-Put spaces around the .. and ... range operators
+Put spaces around the .. and ..= range operators
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`

--- a/src/config.rs
+++ b/src/config.rs
@@ -638,7 +638,7 @@ create_config! {
         "Determines if '+' or '=' are wrapped in spaces in the punctuation of types";
     space_before_colon: bool, false, false, "Leave a space before the colon";
     space_after_colon: bool, true, false, "Leave a space after the colon";
-    spaces_around_ranges: bool, false, false, "Put spaces around the  .. and ... range operators";
+    spaces_around_ranges: bool, false, false, "Put spaces around the .. and ..= range operators";
     spaces_within_parens_and_brackets: bool, false, false,
         "Put spaces within non-empty parentheses or brackets";
 


### PR DESCRIPTION
The `..=` syntax support was added in #2000. This updates text descriptions that were missed in that change.

Fixes #2372.