### PR TITLE
LineOverflow: Count tabs as tab_spaces when measuring line length for overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ fn format_lines(
             is_string = false;
         } else {
             newline_count = 0;
-            line_len += 1;
+            line_len += if c == '\t' { config.tab_spaces() } else { 1 };
             if c.is_whitespace() {
                 if last_wspace.is_none() {
                     last_wspace = Some(b);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -261,6 +261,16 @@ fn format_lines_errors_are_reported() {
     assert!(error_summary.has_formatting_errors());
 }
 
+#[test]
+fn format_lines_errors_are_reported_with_tabs() {
+    let long_identifier = String::from_utf8(vec![b'a'; 97]).unwrap();
+    let input = Input::Text(format!("fn a() {{\n\t{}\n}}", long_identifier));
+    let config = Config::from_toml("hard_tabs = true").unwrap();
+    let (error_summary, _file_map, _report) =
+        format_input::<io::Stdout>(input, &config, None).unwrap();
+    assert!(error_summary.has_formatting_errors());
+}
+
 // For each file, run rustfmt and collect the output.
 // Returns the number of files checked and the number of failures.
 fn check_files(files: Vec<PathBuf>) -> (Vec<FormatReport>, u32, u32) {


### PR DESCRIPTION
## Issue

Tabs are currently measured as `1` character when detecting `ErrorKind::LineOverflow`. Instead, they should use `config.tab_spaces()` to ensure `hard_tabs = true` correctly identifies failing lines.

## Expected

The following configuring should produce:

```
error: line exceeded maximum width (maximum: 20, found: 21)
```

```toml
hard_tabs = true
max_width = 20
```

```rs
fn method() {
	aaaaaaaaaaaaaaaaa
}
```

## Actual

No error occurs. The tab is counted as a single character (`found: 18`).