### PR TITLE
[Refactoring] Better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +319,8 @@ dependencies = [
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -392,6 +413,15 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,6 +525,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
@@ -530,6 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ derive-new = "0.5"
 cargo_metadata = "0.4"
 rustc-ap-syntax = "12.0.0"
 rustc-ap-rustc_errors = "12.0.0"
+failure = "0.1"
+failure_derive = "0.1"
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -36,7 +36,8 @@ use getopts::{Matches, Options};
 /// Error type for cargo-fmt.
 #[derive(Debug, Fail)]
 enum CargoFmtError {
-    #[fail(display = "failed to execute `cargo manifest`: {}", _0)] CargoManifestError(String),
+    #[fail(display = "failed to execute `cargo manifest`: {}", _0)]
+    CargoManifestError(String),
     #[fail(display = "package `{}` is not a member of this workspace", _0)]
     UnknownWorkspaceMember(String),
 }

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -14,20 +14,34 @@
 #![deny(warnings)]
 
 extern crate cargo_metadata;
+#[macro_use]
+extern crate failure;
 extern crate getopts;
+extern crate rustfmt_nightly as rustfmt;
 extern crate serde_json as json;
 
 use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::{self, Write};
+use std::io::Write;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::str;
 
+use failure::Error;
 use getopts::{Matches, Options};
+
+/// Error type for cargo-fmt.
+#[derive(Debug, Fail)]
+enum CargoFmtError {
+    #[fail(display = "failed to execute `cargo manifest`: {}", _0)] CargoManifestError(String),
+    #[fail(display = "package `{}` is not a member of this workspace", _0)]
+    UnknownWorkspaceMember(String),
+}
+
+type CargoFmtResult<T> = Result<T, CargoFmtError>;
 
 fn main() {
     let exit_status = execute();
@@ -58,7 +72,7 @@ fn execute() -> i32 {
         if arg.starts_with('-') {
             is_package_arg = arg.starts_with("--package");
         } else if !is_package_arg {
-            print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`.", arg));
+            print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`", arg));
             return FAILURE;
         } else {
             is_package_arg = false;
@@ -122,7 +136,7 @@ pub enum Verbosity {
     Quiet,
 }
 
-fn handle_command_status(status: Result<ExitStatus, io::Error>, opts: &getopts::Options) -> i32 {
+fn handle_command_status(status: Result<ExitStatus, Error>, opts: &getopts::Options) -> i32 {
     match status {
         Err(e) => {
             print_usage_to_stderr(opts, &e.to_string());
@@ -138,14 +152,11 @@ fn handle_command_status(status: Result<ExitStatus, io::Error>, opts: &getopts::
     }
 }
 
-fn get_version(verbosity: Verbosity) -> Result<ExitStatus, io::Error> {
+fn get_version(verbosity: Verbosity) -> Result<ExitStatus, Error> {
     run_rustfmt(&[], &[String::from("--version")], verbosity)
 }
 
-fn format_crate(
-    verbosity: Verbosity,
-    strategy: &CargoFmtStrategy,
-) -> Result<ExitStatus, io::Error> {
+fn format_crate(verbosity: Verbosity, strategy: &CargoFmtStrategy) -> Result<ExitStatus, Error> {
     let rustfmt_args = get_fmt_args();
     let targets = if rustfmt_args.iter().any(|s| s == "--dump-default-config") {
         HashSet::new()
@@ -228,7 +239,7 @@ impl CargoFmtStrategy {
 }
 
 /// Based on the specified `CargoFmtStrategy`, returns a set of main source files.
-fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error> {
+fn get_targets(strategy: &CargoFmtStrategy) -> CargoFmtResult<HashSet<Target>> {
     let mut targets = HashSet::new();
 
     match *strategy {
@@ -238,16 +249,15 @@ fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error
     }
 
     if targets.is_empty() {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Failed to find targets".to_owned(),
+        Err(CargoFmtError::CargoManifestError(
+            "failed to find targets".to_owned(),
         ))
     } else {
         Ok(targets)
     }
 }
 
-fn get_targets_root_only(targets: &mut HashSet<Target>) -> Result<(), io::Error> {
+fn get_targets_root_only(targets: &mut HashSet<Target>) -> CargoFmtResult<()> {
     let metadata = get_cargo_metadata(None)?;
 
     for package in metadata.packages {
@@ -263,7 +273,7 @@ fn get_targets_recursive(
     manifest_path: Option<&Path>,
     mut targets: &mut HashSet<Target>,
     visited: &mut HashSet<String>,
-) -> Result<(), io::Error> {
+) -> CargoFmtResult<()> {
     let metadata = get_cargo_metadata(manifest_path)?;
 
     for package in metadata.packages {
@@ -294,7 +304,7 @@ fn get_targets_recursive(
 fn get_targets_with_hitlist(
     hitlist: &[String],
     targets: &mut HashSet<Target>,
-) -> Result<(), io::Error> {
+) -> CargoFmtResult<()> {
     let metadata = get_cargo_metadata(None)?;
 
     let mut workspace_hitlist: HashSet<&String> = HashSet::from_iter(hitlist);
@@ -311,10 +321,7 @@ fn get_targets_with_hitlist(
         Ok(())
     } else {
         let package = workspace_hitlist.iter().next().unwrap();
-        Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("package `{}` is not a member of the workspace", package),
-        ))
+        Err(CargoFmtError::UnknownWorkspaceMember((*package).clone()))
     }
 }
 
@@ -328,7 +335,7 @@ fn run_rustfmt(
     files: &[PathBuf],
     fmt_args: &[String],
     verbosity: Verbosity,
-) -> Result<ExitStatus, io::Error> {
+) -> Result<ExitStatus, Error> {
     let stdout = if verbosity == Verbosity::Quiet {
         std::process::Stdio::null()
     } else {
@@ -350,24 +357,14 @@ fn run_rustfmt(
         .stdout(stdout)
         .args(files)
         .args(fmt_args)
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => io::Error::new(
-                io::ErrorKind::Other,
-                "Could not run rustfmt, please make sure it is in your PATH.",
-            ),
-            _ => e,
-        })?;
+        .spawn()?;
 
-    command.wait()
+    Ok(command.wait()?)
 }
 
-fn get_cargo_metadata(manifest_path: Option<&Path>) -> Result<cargo_metadata::Metadata, io::Error> {
+fn get_cargo_metadata(manifest_path: Option<&Path>) -> CargoFmtResult<cargo_metadata::Metadata> {
     match cargo_metadata::metadata(manifest_path) {
         Ok(metadata) => Ok(metadata),
-        Err(..) => Err(io::Error::new(
-            io::ErrorKind::Other,
-            "`cargo manifest` failed.",
-        )),
+        Err(e) => Err(CargoFmtError::CargoManifestError(format!("{}", e))),
     }
 }

--- a/src/bin/git-rustfmt.rs
+++ b/src/bin/git-rustfmt.rs
@@ -80,9 +80,10 @@ fn fmt_files(files: &[&str]) -> i32 {
 
     let mut exit_code = 0;
     for file in files {
-        let summary = run(Input::File(PathBuf::from(file)), &config);
-        if !summary.has_no_errors() {
-            exit_code = 1;
+        match run(Input::File(PathBuf::from(file)), &config) {
+            Ok(summary) if !summary.has_no_errors() => exit_code = 1,
+            Err(..) => exit_code = 1,
+            _ => (),
         }
     }
     exit_code

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use syntax::codemap::FileName;
+
+use std::convert::From;
+use std::io;
+use std::path::PathBuf;
+
+pub type RustfmtResult<T> = Result<T, RustfmtError>;
+
+#[derive(Debug, Fail)]
+pub enum RustfmtError {
+    #[fail(display = "{}", _0)] IOError(io::Error),
+    #[fail(display = "{}: {}", _0, _1)] FileIOError(FileName, io::Error),
+    #[fail(display = "unknown config option found: `{}`", _0)] UnknownConfig(String),
+    #[fail(display = "failed to find a config file for the given path `{:?}`", _0)]
+    ConfigFileNotFound(PathBuf),
+    #[fail(display = "failed to parse a config file: {}", _0)] ConfigFileParseError(String),
+    // Since parse errors are already emitted by the parser, we do no to emit anything.
+    #[fail(display = "")] ParseError,
+    #[fail(display = "unstable features are only available on nightly channel")] UnstableFeature,
+    #[fail(display = "invalid command line argument found for {}: {}", _0, _1)]
+    InvalidCommandLineOption(String, String),
+}
+
+impl From<io::Error> for RustfmtError {
+    fn from(err: io::Error) -> Self {
+        RustfmtError::IOError(err)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,15 +18,21 @@ pub type RustfmtResult<T> = Result<T, RustfmtError>;
 
 #[derive(Debug, Fail)]
 pub enum RustfmtError {
-    #[fail(display = "{}", _0)] IOError(io::Error),
-    #[fail(display = "{}: {}", _0, _1)] FileIOError(FileName, io::Error),
-    #[fail(display = "unknown config option found: `{}`", _0)] UnknownConfig(String),
+    #[fail(display = "{}", _0)]
+    IOError(io::Error),
+    #[fail(display = "{}: {}", _0, _1)]
+    FileIOError(FileName, io::Error),
+    #[fail(display = "unknown config option found: `{}`", _0)]
+    UnknownConfig(String),
     #[fail(display = "failed to find a config file for the given path `{:?}`", _0)]
     ConfigFileNotFound(PathBuf),
-    #[fail(display = "failed to parse a config file: {}", _0)] ConfigFileParseError(String),
+    #[fail(display = "failed to parse a config file: {}", _0)]
+    ConfigFileParseError(String),
     // Since parse errors are already emitted by the parser, we do no to emit anything.
-    #[fail(display = "")] ParseError,
-    #[fail(display = "unstable features are only available on nightly channel")] UnstableFeature,
+    #[fail(display = "")]
+    ParseError,
+    #[fail(display = "unstable features are only available on nightly channel")]
+    UnstableFeature,
     #[fail(display = "invalid command line argument found for {}: {}", _0, _1)]
     InvalidCommandLineOption(String, String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,7 @@ extern crate syntax;
 extern crate term;
 extern crate unicode_segmentation;
 
-use std::collections::HashMap;
-use std::fmt;
 use std::io::{self, stdout, Write};
-use std::iter::repeat;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
@@ -43,13 +40,12 @@ pub use syntax::codemap::FileName;
 use syntax::parse::{self, ParseSess};
 
 use checkstyle::{output_footer, output_header};
-use comment::{CharClasses, FullCodeCharKind};
 pub use config::Config;
 use filemap::FileMap;
-use issues::{BadIssueSeeker, Issue};
 use shape::Indent;
 use utils::use_colored_tty;
 use visitor::{FmtVisitor, SnippetProvider};
+pub use report::*;
 
 pub use self::summary::Summary;
 
@@ -81,245 +77,30 @@ mod macros;
 mod patterns;
 mod summary;
 mod vertical;
-
-#[derive(Clone, Copy)]
-pub enum ErrorKind {
-    // Line has exceeded character limit (found, maximum)
-    LineOverflow(usize, usize),
-    // Line ends in whitespace
-    TrailingWhitespace,
-    // TO-DO or FIX-ME item without an issue number
-    BadIssue(Issue),
-}
-
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            ErrorKind::LineOverflow(found, maximum) => write!(
-                fmt,
-                "line exceeded maximum width (maximum: {}, found: {})",
-                maximum, found
-            ),
-            ErrorKind::TrailingWhitespace => write!(fmt, "left behind trailing whitespace"),
-            ErrorKind::BadIssue(issue) => write!(fmt, "found {}", issue),
-        }
-    }
-}
-
-// Formatting errors that are identified *after* rustfmt has run.
-pub struct FormattingError {
-    line: usize,
-    kind: ErrorKind,
-    is_comment: bool,
-    is_string: bool,
-    line_buffer: String,
-}
-
-impl FormattingError {
-    fn msg_prefix(&self) -> &str {
-        match self.kind {
-            ErrorKind::LineOverflow(..) | ErrorKind::TrailingWhitespace => "error:",
-            ErrorKind::BadIssue(_) => "WARNING:",
-        }
-    }
-
-    fn msg_suffix(&self) -> &str {
-        if self.is_comment || self.is_string {
-            "set `error_on_unformatted = false` to suppress \
-             the warning against comments or string literals\n"
-        } else {
-            ""
-        }
-    }
-
-    // (space, target)
-    pub fn format_len(&self) -> (usize, usize) {
-        match self.kind {
-            ErrorKind::LineOverflow(found, max) => (max, found - max),
-            ErrorKind::TrailingWhitespace => {
-                let trailing_ws_len = self.line_buffer
-                    .chars()
-                    .rev()
-                    .take_while(|c| c.is_whitespace())
-                    .count();
-                (self.line_buffer.len() - trailing_ws_len, trailing_ws_len)
-            }
-            _ => unreachable!(),
-        }
-    }
-}
-
-pub struct FormatReport {
-    // Maps stringified file paths to their associated formatting errors.
-    file_error_map: HashMap<FileName, Vec<FormattingError>>,
-}
-
-impl FormatReport {
-    fn new() -> FormatReport {
-        FormatReport {
-            file_error_map: HashMap::new(),
-        }
-    }
-
-    pub fn warning_count(&self) -> usize {
-        self.file_error_map
-            .iter()
-            .map(|(_, errors)| errors.len())
-            .sum()
-    }
-
-    pub fn has_warnings(&self) -> bool {
-        self.warning_count() > 0
-    }
-
-    pub fn print_warnings_fancy(
-        &self,
-        mut t: Box<term::Terminal<Output = io::Stderr>>,
-    ) -> Result<(), term::Error> {
-        for (file, errors) in &self.file_error_map {
-            for error in errors {
-                let prefix_space_len = error.line.to_string().len();
-                let prefix_spaces: String = repeat(" ").take(1 + prefix_space_len).collect();
-
-                // First line: the overview of error
-                t.fg(term::color::RED)?;
-                t.attr(term::Attr::Bold)?;
-                write!(t, "{} ", error.msg_prefix())?;
-                t.reset()?;
-                t.attr(term::Attr::Bold)?;
-                write!(t, "{}\n", error.kind)?;
-
-                // Second line: file info
-                write!(t, "{}--> ", &prefix_spaces[1..])?;
-                t.reset()?;
-                write!(t, "{}:{}\n", file, error.line)?;
-
-                // Third to fifth lines: show the line which triggered error, if available.
-                if !error.line_buffer.is_empty() {
-                    let (space_len, target_len) = error.format_len();
-                    t.attr(term::Attr::Bold)?;
-                    write!(t, "{}|\n{} | ", prefix_spaces, error.line)?;
-                    t.reset()?;
-                    write!(t, "{}\n", error.line_buffer)?;
-                    t.attr(term::Attr::Bold)?;
-                    write!(t, "{}| ", prefix_spaces)?;
-                    t.fg(term::color::RED)?;
-                    write!(t, "{}\n", target_str(space_len, target_len))?;
-                    t.reset()?;
-                }
-
-                // The last line: show note if available.
-                let msg_suffix = error.msg_suffix();
-                if !msg_suffix.is_empty() {
-                    t.attr(term::Attr::Bold)?;
-                    write!(t, "{}= note: ", prefix_spaces)?;
-                    t.reset()?;
-                    write!(t, "{}\n", error.msg_suffix())?;
-                } else {
-                    write!(t, "\n")?;
-                }
-                t.reset()?;
-            }
-        }
-
-        if !self.file_error_map.is_empty() {
-            t.attr(term::Attr::Bold)?;
-            write!(t, "warning: ")?;
-            t.reset()?;
-            write!(
-                t,
-                "rustfmt may have failed to format. See previous {} errors.\n\n",
-                self.warning_count(),
-            )?;
-        }
-
-        Ok(())
-    }
-}
-
-fn target_str(space_len: usize, target_len: usize) -> String {
-    let empty_line: String = repeat(" ").take(space_len).collect();
-    let overflowed: String = repeat("^").take(target_len).collect();
-    empty_line + &overflowed
-}
-
-impl fmt::Display for FormatReport {
-    // Prints all the formatting errors.
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        for (file, errors) in &self.file_error_map {
-            for error in errors {
-                let prefix_space_len = error.line.to_string().len();
-                let prefix_spaces: String = repeat(" ").take(1 + prefix_space_len).collect();
-
-                let error_line_buffer = if error.line_buffer.is_empty() {
-                    String::from(" ")
-                } else {
-                    let (space_len, target_len) = error.format_len();
-                    format!(
-                        "{}|\n{} | {}\n{}| {}",
-                        prefix_spaces,
-                        error.line,
-                        error.line_buffer,
-                        prefix_spaces,
-                        target_str(space_len, target_len)
-                    )
-                };
-
-                let error_info = format!("{} {}", error.msg_prefix(), error.kind);
-                let file_info = format!("{}--> {}:{}", &prefix_spaces[1..], file, error.line);
-                let msg_suffix = error.msg_suffix();
-                let note = if msg_suffix.is_empty() {
-                    String::new()
-                } else {
-                    format!("{}note= ", prefix_spaces)
-                };
-
-                write!(
-                    fmt,
-                    "{}\n{}\n{}\n{}{}\n",
-                    error_info,
-                    file_info,
-                    error_line_buffer,
-                    note,
-                    error.msg_suffix()
-                )?;
-            }
-        }
-        if !self.file_error_map.is_empty() {
-            write!(
-                fmt,
-                "warning: rustfmt may have failed to format. See previous {} errors.\n",
-                self.warning_count(),
-            )?;
-        }
-        Ok(())
-    }
-}
+mod report;
 
 // Formatting which depends on the AST.
-fn format_ast<F>(
+fn format_ast<T: Write>(
     krate: &ast::Crate,
     parse_session: &mut ParseSess,
     main_file: &FileName,
     config: &Config,
-    mut after_file: F,
-) -> Result<(FileMap, bool), io::Error>
-where
-    F: FnMut(&FileName, &mut String, &[(usize, usize)]) -> Result<bool, io::Error>,
-{
+    mut out: &mut Option<&mut T>,
+) -> Result<(FileMap, bool, FormatReport), io::Error> {
     let mut result = FileMap::new();
+    let mut report = FormatReport::new();
     // diff mode: check if any files are differing
     let mut has_diff = false;
 
     // We always skip children for the "Plain" write mode, since there is
     // nothing to distinguish the nested module contents.
     let skip_children = config.skip_children() || config.write_mode() == config::WriteMode::Plain;
-    for (path, module) in modules::list_files(krate, parse_session.codemap())? {
-        if skip_children && path != *main_file {
+    for (file_name, module) in modules::list_files(krate, parse_session.codemap())? {
+        if skip_children && file_name != *main_file {
             continue;
         }
         if config.verbose() {
-            println!("Formatting {}", path);
+            println!("Formatting {}", file_name);
         }
         let filemap = parse_session
             .codemap()
@@ -329,7 +110,7 @@ where
         let snippet_provider = SnippetProvider::new(filemap.start_pos, big_snippet);
         let mut visitor = FmtVisitor::from_codemap(parse_session, config, &snippet_provider);
         // Format inner attributes if available.
-        if !krate.attrs.is_empty() && path == *main_file {
+        if !krate.attrs.is_empty() && file_name == *main_file {
             visitor.skip_empty_lines(filemap.end_pos);
             if visitor.visit_attrs(&krate.attrs, ast::AttrStyle::Inner) {
                 visitor.push_rewrite(module.inner, None);
@@ -347,156 +128,27 @@ where
             ::utils::count_newlines(&format!("{}", visitor.buffer))
         );
 
-        let filename = path.clone();
-        has_diff |= match after_file(&filename, &mut visitor.buffer, &visitor.skipped_range) {
-            Ok(result) => result,
+        let maybe_has_diff = visitor.report_errors_after_format(&file_name, &mut report, &mut out);
+
+        has_diff |= match maybe_has_diff {
+            Ok(diff) => diff,
             Err(e) => {
-                // Create a new error with path_str to help users see which files failed
-                let err_msg = format!("{}: {}", path, e);
+                // Create a new error with file name to help users see which files failed
+                let err_msg = format!("{}: {}", file_name, e);
                 return Err(io::Error::new(e.kind(), err_msg));
             }
         };
 
-        result.push((filename, visitor.buffer));
+        result.push((file_name, visitor.buffer));
     }
 
-    Ok((result, has_diff))
+    Ok((result, has_diff, report))
 }
 
-/// Returns true if the line with the given line number was skipped by `#[rustfmt_skip]`.
-fn is_skipped_line(line_number: usize, skipped_range: &[(usize, usize)]) -> bool {
-    skipped_range
-        .iter()
-        .any(|&(lo, hi)| lo <= line_number && line_number <= hi)
-}
-
-fn should_report_error(
-    config: &Config,
-    char_kind: FullCodeCharKind,
-    is_string: bool,
-    error_kind: ErrorKind,
-) -> bool {
-    let allow_error_report = if char_kind.is_comment() || is_string {
-        config.error_on_unformatted()
-    } else {
-        true
-    };
-
-    match error_kind {
-        ErrorKind::LineOverflow(..) => config.error_on_line_overflow() && allow_error_report,
-        ErrorKind::TrailingWhitespace => allow_error_report,
-        _ => true,
-    }
-}
-
-// Formatting done on a char by char or line by line basis.
-// FIXME(#209) warn on bad license
-// FIXME(#20) other stuff for parity with make tidy
-fn format_lines(
-    text: &mut String,
-    name: &FileName,
-    skipped_range: &[(usize, usize)],
-    config: &Config,
-    report: &mut FormatReport,
-) {
-    // Iterate over the chars in the file map.
-    let mut trims = vec![];
-    let mut last_wspace: Option<usize> = None;
-    let mut line_len = 0;
-    let mut cur_line = 1;
-    let mut newline_count = 0;
-    let mut errors = vec![];
-    let mut issue_seeker = BadIssueSeeker::new(config.report_todo(), config.report_fixme());
-    let mut line_buffer = String::with_capacity(config.max_width() * 2);
-    let mut is_string = false; // true if the current line contains a string literal.
-    let mut format_line = config.file_lines().contains_line(name, cur_line);
-
-    for (kind, (b, c)) in CharClasses::new(text.chars().enumerate()) {
-        if c == '\r' {
-            continue;
-        }
-
-        if format_line {
-            // Add warnings for bad todos/ fixmes
-            if let Some(issue) = issue_seeker.inspect(c) {
-                errors.push(FormattingError {
-                    line: cur_line,
-                    kind: ErrorKind::BadIssue(issue),
-                    is_comment: false,
-                    is_string: false,
-                    line_buffer: String::new(),
-                });
-            }
-        }
-
-        if c == '\n' {
-            if format_line {
-                // Check for (and record) trailing whitespace.
-                if let Some(..) = last_wspace {
-                    if should_report_error(config, kind, is_string, ErrorKind::TrailingWhitespace) {
-                        trims.push((cur_line, kind, line_buffer.clone()));
-                    }
-                    line_len -= 1;
-                }
-
-                // Check for any line width errors we couldn't correct.
-                let error_kind = ErrorKind::LineOverflow(line_len, config.max_width());
-                if line_len > config.max_width() && !is_skipped_line(cur_line, skipped_range)
-                    && should_report_error(config, kind, is_string, error_kind)
-                {
-                    errors.push(FormattingError {
-                        line: cur_line,
-                        kind: error_kind,
-                        is_comment: kind.is_comment(),
-                        is_string: is_string,
-                        line_buffer: line_buffer.clone(),
-                    });
-                }
-            }
-
-            line_len = 0;
-            cur_line += 1;
-            format_line = config.file_lines().contains_line(name, cur_line);
-            newline_count += 1;
-            last_wspace = None;
-            line_buffer.clear();
-            is_string = false;
-        } else {
-            newline_count = 0;
-            line_len += if c == '\t' { config.tab_spaces() } else { 1 };
-            if c.is_whitespace() {
-                if last_wspace.is_none() {
-                    last_wspace = Some(b);
-                }
-            } else {
-                last_wspace = None;
-            }
-            line_buffer.push(c);
-            if kind.is_string() {
-                is_string = true;
-            }
-        }
-    }
-
-    if newline_count > 1 {
-        debug!("track truncate: {} {}", text.len(), newline_count);
-        let line = text.len() - newline_count + 1;
-        text.truncate(line);
-    }
-
-    for &(l, kind, ref b) in &trims {
-        if !is_skipped_line(l, skipped_range) {
-            errors.push(FormattingError {
-                line: l,
-                kind: ErrorKind::TrailingWhitespace,
-                is_comment: kind.is_comment(),
-                is_string: kind.is_string(),
-                line_buffer: b.clone(),
-            });
-        }
-    }
-
-    report.file_error_map.insert(name.clone(), errors);
+#[derive(Debug)]
+pub enum Input {
+    File(PathBuf),
+    Text(String),
 }
 
 fn parse_input(
@@ -530,6 +182,131 @@ fn parse_input(
             }
         }
         Err(e) => Err(Some(e)),
+    }
+}
+
+pub fn format_input<T: Write>(
+    input: Input,
+    config: &Config,
+    mut out: Option<&mut T>,
+) -> Result<(Summary, FileMap, FormatReport), (io::Error, Summary)> {
+    let mut summary = Summary::default();
+    if config.disable_all_formatting() {
+        // When the input is from stdin, echo back the input.
+        if let Input::Text(ref buf) = input {
+            if let Err(e) = io::stdout().write_all(buf.as_bytes()) {
+                return Err((e, summary));
+            }
+        }
+        return Ok((summary, FileMap::new(), FormatReport::new()));
+    }
+    let codemap = Rc::new(CodeMap::new(FilePathMapping::empty()));
+
+    let tty_handler = if config.hide_parse_errors() {
+        let silent_emitter = Box::new(EmitterWriter::new(
+            Box::new(Vec::new()),
+            Some(codemap.clone()),
+            false,
+        ));
+        Handler::with_emitter(true, false, silent_emitter)
+    } else {
+        Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(codemap.clone()))
+    };
+    let mut parse_session = ParseSess::with_span_handler(tty_handler, codemap.clone());
+
+    let main_file = match input {
+        Input::File(ref file) => FileName::Real(file.clone()),
+        Input::Text(..) => FileName::Custom("stdin".to_owned()),
+    };
+
+    let krate = match parse_input(input, &parse_session) {
+        Ok(krate) => {
+            if parse_session.span_diagnostic.has_errors() {
+                summary.add_parsing_error();
+            }
+            krate
+        }
+        Err(diagnostic) => {
+            if let Some(mut diagnostic) = diagnostic {
+                diagnostic.emit();
+            }
+            summary.add_parsing_error();
+            return Ok((summary, FileMap::new(), FormatReport::new()));
+        }
+    };
+
+    summary.mark_parse_time();
+
+    // Suppress error output after parsing.
+    let silent_emitter = Box::new(EmitterWriter::new(
+        Box::new(Vec::new()),
+        Some(codemap.clone()),
+        false,
+    ));
+    parse_session.span_diagnostic = Handler::with_emitter(true, false, silent_emitter);
+
+    let format_result = format_ast(&krate, &mut parse_session, &main_file, config, &mut out);
+
+    summary.mark_format_time();
+
+    if config.verbose() {
+        fn duration_to_f32(d: Duration) -> f32 {
+            d.as_secs() as f32 + d.subsec_nanos() as f32 / 1_000_000_000f32
+        }
+
+        println!(
+            "Spent {0:.3} secs in the parsing phase, and {1:.3} secs in the formatting phase",
+            duration_to_f32(summary.get_parse_time().unwrap()),
+            duration_to_f32(summary.get_format_time().unwrap()),
+        );
+    }
+
+    match format_result {
+        Ok((file_map, has_diff, report)) => {
+            if report.has_warnings() {
+                summary.add_formatting_error();
+            }
+
+            if has_diff {
+                summary.add_diff();
+            }
+
+            Ok((summary, file_map, report))
+        }
+        Err(e) => Err((e, summary)),
+    }
+}
+
+/// An entry point to rustfmt.
+pub fn run(input: Input, config: &Config) -> Summary {
+    let out = &mut stdout();
+    output_header(out, config.write_mode()).ok();
+    match format_input(input, config, Some(out)) {
+        Ok((summary, _, report)) => {
+            output_footer(out, config.write_mode()).ok();
+
+            if report.has_warnings() {
+                match term::stderr() {
+                    Some(ref t)
+                        if use_colored_tty(config.color()) && t.supports_color()
+                            && t.supports_attr(term::Attr::Bold) =>
+                    {
+                        match report.print_warnings_fancy(term::stderr().unwrap()) {
+                            Ok(..) => (),
+                            Err(..) => panic!("Unable to write to stderr: {}", report),
+                        }
+                    }
+                    _ => msg!("{}", report),
+                }
+            }
+
+            summary
+        }
+        Err((msg, mut summary)) => {
+            msg!("Error writing files: {}", msg);
+            summary.add_operational_error();
+            summary
+        }
     }
 }
 
@@ -581,154 +358,6 @@ pub fn format_code_block(code_snippet: &str, config: &Config) -> Option<String> 
             .collect::<Vec<_>>()
             .join("\n")
     })
-}
-
-pub fn format_input<T: Write>(
-    input: Input,
-    config: &Config,
-    mut out: Option<&mut T>,
-) -> Result<(Summary, FileMap, FormatReport), (io::Error, Summary)> {
-    let mut summary = Summary::default();
-    if config.disable_all_formatting() {
-        // When the input is from stdin, echo back the input.
-        if let Input::Text(ref buf) = input {
-            if let Err(e) = io::stdout().write_all(buf.as_bytes()) {
-                return Err((e, summary));
-            }
-        }
-        return Ok((summary, FileMap::new(), FormatReport::new()));
-    }
-    let codemap = Rc::new(CodeMap::new(FilePathMapping::empty()));
-
-    let tty_handler = if config.hide_parse_errors() {
-        let silent_emitter = Box::new(EmitterWriter::new(
-            Box::new(Vec::new()),
-            Some(codemap.clone()),
-            false,
-        ));
-        Handler::with_emitter(true, false, silent_emitter)
-    } else {
-        Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(codemap.clone()))
-    };
-    let mut parse_session = ParseSess::with_span_handler(tty_handler, codemap.clone());
-
-    let main_file = match input {
-        Input::File(ref file) => FileName::Real(file.clone()),
-        Input::Text(..) => FileName::Custom("stdin".to_owned()),
-    };
-
-    let krate = match parse_input(input, &parse_session) {
-        Ok(krate) => krate,
-        Err(diagnostic) => {
-            if let Some(mut diagnostic) = diagnostic {
-                diagnostic.emit();
-            }
-            summary.add_parsing_error();
-            return Ok((summary, FileMap::new(), FormatReport::new()));
-        }
-    };
-
-    summary.mark_parse_time();
-
-    if parse_session.span_diagnostic.has_errors() {
-        summary.add_parsing_error();
-    }
-
-    // Suppress error output after parsing.
-    let silent_emitter = Box::new(EmitterWriter::new(
-        Box::new(Vec::new()),
-        Some(codemap.clone()),
-        false,
-    ));
-    parse_session.span_diagnostic = Handler::with_emitter(true, false, silent_emitter);
-
-    let mut report = FormatReport::new();
-
-    let format_result = format_ast(
-        &krate,
-        &mut parse_session,
-        &main_file,
-        config,
-        |file_name, file, skipped_range| {
-            // For some reason, the codemap does not include terminating
-            // newlines so we must add one on for each file. This is sad.
-            filemap::append_newline(file);
-
-            format_lines(file, file_name, skipped_range, config, &mut report);
-
-            if let Some(ref mut out) = out {
-                return filemap::write_file(file, file_name, out, config);
-            }
-            Ok(false)
-        },
-    );
-
-    summary.mark_format_time();
-
-    if config.verbose() {
-        fn duration_to_f32(d: Duration) -> f32 {
-            d.as_secs() as f32 + d.subsec_nanos() as f32 / 1_000_000_000f32
-        }
-
-        println!(
-            "Spent {0:.3} secs in the parsing phase, and {1:.3} secs in the formatting phase",
-            duration_to_f32(summary.get_parse_time().unwrap()),
-            duration_to_f32(summary.get_format_time().unwrap()),
-        );
-    }
-
-    match format_result {
-        Ok((file_map, has_diff)) => {
-            if report.has_warnings() {
-                summary.add_formatting_error();
-            }
-
-            if has_diff {
-                summary.add_diff();
-            }
-
-            Ok((summary, file_map, report))
-        }
-        Err(e) => Err((e, summary)),
-    }
-}
-
-#[derive(Debug)]
-pub enum Input {
-    File(PathBuf),
-    Text(String),
-}
-
-pub fn run(input: Input, config: &Config) -> Summary {
-    let out = &mut stdout();
-    output_header(out, config.write_mode()).ok();
-    match format_input(input, config, Some(out)) {
-        Ok((summary, _, report)) => {
-            output_footer(out, config.write_mode()).ok();
-
-            if report.has_warnings() {
-                match term::stderr() {
-                    Some(ref t)
-                        if use_colored_tty(config.color()) && t.supports_color()
-                            && t.supports_attr(term::Attr::Bold) =>
-                    {
-                        match report.print_warnings_fancy(term::stderr().unwrap()) {
-                            Ok(..) => (),
-                            Err(..) => panic!("Unable to write to stderr: {}", report),
-                        }
-                    }
-                    _ => msg!("{}", report),
-                }
-            }
-
-            summary
-        }
-        Err((msg, mut summary)) => {
-            msg!("Error writing files: {}", msg);
-            summary.add_operational_error();
-            summary
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![feature(match_default_bindings)]
-#![feature(rustc_private)]
 #![feature(type_ascription)]
 
 #[macro_use]

--- a/src/report.rs
+++ b/src/report.rs
@@ -338,7 +338,7 @@ pub fn report_errors_in_formatted_text(
             is_string = false;
         } else {
             newline_count = 0;
-            line_len += 1;
+            line_len += if c == '\t' { config.tab_spaces() } else { 1 };
             if c.is_whitespace() {
                 if last_wspace.is_none() {
                     last_wspace = Some(b);

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,398 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Find and report errors *after* rustfmt has run.
+
+use syntax::codemap::FileName;
+use term;
+
+use comment::{CharClasses, FullCodeCharKind};
+use config::Config;
+use issues::{BadIssueSeeker, Issue};
+use filemap::{append_newline, write_file};
+use visitor::FmtVisitor;
+
+use std::collections::HashMap;
+use std::fmt;
+use std::iter::repeat;
+use std::io;
+
+/// Returns true if the line with the given line number was skipped by `#[rustfmt_skip]`.
+fn is_skipped_line(line_number: usize, skipped_range: &[(usize, usize)]) -> bool {
+    skipped_range
+        .iter()
+        .any(|&(lo, hi)| lo <= line_number && line_number <= hi)
+}
+
+#[derive(Clone, Copy)]
+enum ErrorKind {
+    /// Line has exceeded character limit (found, maximum)
+    LineOverflow(usize, usize),
+    /// Line ends in whitespace
+    TrailingWhitespace,
+    /// TO-DO or FIX-ME item without an issue number
+    BadIssue(Issue),
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ErrorKind::LineOverflow(found, maximum) => write!(
+                fmt,
+                "line exceeded maximum width (maximum: {}, found: {})",
+                maximum, found
+            ),
+            ErrorKind::TrailingWhitespace => write!(fmt, "left behind trailing whitespace"),
+            ErrorKind::BadIssue(issue) => write!(fmt, "found {}", issue),
+        }
+    }
+}
+
+/// Formatting errors that are identified *after* rustfmt has run.
+pub struct FormattingError {
+    line: usize,
+    kind: ErrorKind,
+    is_comment: bool,
+    is_string: bool,
+    line_buffer: String,
+}
+
+impl FormattingError {
+    fn msg_prefix(&self) -> &str {
+        match self.kind {
+            ErrorKind::LineOverflow(..) | ErrorKind::TrailingWhitespace => "error:",
+            ErrorKind::BadIssue(_) => "WARNING:",
+        }
+    }
+
+    fn msg_suffix(&self) -> &str {
+        if self.is_comment || self.is_string {
+            "set `error_on_unformatted = false` to suppress \
+             the warning against comments or string literals\n"
+        } else {
+            ""
+        }
+    }
+
+    // (space, target)
+    pub fn format_len(&self) -> (usize, usize) {
+        match self.kind {
+            ErrorKind::LineOverflow(found, max) => (max, found - max),
+            ErrorKind::TrailingWhitespace => {
+                let trailing_ws_len = self.line_buffer
+                    .chars()
+                    .rev()
+                    .take_while(|c| c.is_whitespace())
+                    .count();
+                (self.line_buffer.len() - trailing_ws_len, trailing_ws_len)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn target_str(space_len: usize, target_len: usize) -> String {
+    let empty_line: String = repeat(" ").take(space_len).collect();
+    let overflowed: String = repeat("^").take(target_len).collect();
+    empty_line + &overflowed
+}
+
+/// Maps stringified file paths to their associated formatting errors.
+pub struct FormatReport {
+    file_error_map: HashMap<FileName, Vec<FormattingError>>,
+}
+
+impl FormatReport {
+    pub fn new() -> FormatReport {
+        FormatReport {
+            file_error_map: HashMap::new(),
+        }
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.file_error_map
+            .iter()
+            .map(|(_, errors)| errors.len())
+            .fold(0, |acc, x| acc + x)
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        self.warning_count() > 0
+    }
+
+    pub fn print_warnings_fancy(
+        &self,
+        mut t: Box<term::Terminal<Output = io::Stderr>>,
+    ) -> Result<(), term::Error> {
+        for (file, errors) in &self.file_error_map {
+            for error in errors {
+                let prefix_space_len = error.line.to_string().len();
+                let prefix_spaces: String = repeat(" ").take(1 + prefix_space_len).collect();
+
+                // First line: the overview of error
+                t.fg(term::color::RED)?;
+                t.attr(term::Attr::Bold)?;
+                write!(t, "{} ", error.msg_prefix())?;
+                t.reset()?;
+                t.attr(term::Attr::Bold)?;
+                write!(t, "{}\n", error.kind)?;
+
+                // Second line: file info
+                write!(t, "{}--> ", &prefix_spaces[1..])?;
+                t.reset()?;
+                write!(t, "{}:{}\n", file, error.line)?;
+
+                // Third to fifth lines: show the line which triggered error, if available.
+                if !error.line_buffer.is_empty() {
+                    let (space_len, target_len) = error.format_len();
+                    t.attr(term::Attr::Bold)?;
+                    write!(t, "{}|\n{} | ", prefix_spaces, error.line)?;
+                    t.reset()?;
+                    write!(t, "{}\n", error.line_buffer)?;
+                    t.attr(term::Attr::Bold)?;
+                    write!(t, "{}| ", prefix_spaces)?;
+                    t.fg(term::color::RED)?;
+                    write!(t, "{}\n", target_str(space_len, target_len))?;
+                    t.reset()?;
+                }
+
+                // The last line: show note if available.
+                let msg_suffix = error.msg_suffix();
+                if !msg_suffix.is_empty() {
+                    t.attr(term::Attr::Bold)?;
+                    write!(t, "{}= note: ", prefix_spaces)?;
+                    t.reset()?;
+                    write!(t, "{}\n", error.msg_suffix())?;
+                } else {
+                    write!(t, "\n")?;
+                }
+                t.reset()?;
+            }
+        }
+
+        if !self.file_error_map.is_empty() {
+            t.attr(term::Attr::Bold)?;
+            write!(t, "warning: ")?;
+            t.reset()?;
+            write!(
+                t,
+                "rustfmt may have failed to format. See previous {} errors.\n\n",
+                self.warning_count(),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for FormatReport {
+    // Prints all the formatting errors.
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for (file, errors) in &self.file_error_map {
+            for error in errors {
+                let prefix_space_len = error.line.to_string().len();
+                let prefix_spaces: String = repeat(" ").take(1 + prefix_space_len).collect();
+
+                let error_line_buffer = if error.line_buffer.is_empty() {
+                    String::from(" ")
+                } else {
+                    let (space_len, target_len) = error.format_len();
+                    format!(
+                        "{}|\n{} | {}\n{}| {}",
+                        prefix_spaces,
+                        error.line,
+                        error.line_buffer,
+                        prefix_spaces,
+                        target_str(space_len, target_len)
+                    )
+                };
+
+                let error_info = format!("{} {}", error.msg_prefix(), error.kind);
+                let file_info = format!("{}--> {}:{}", &prefix_spaces[1..], file, error.line);
+                let msg_suffix = error.msg_suffix();
+                let note = if msg_suffix.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}note= ", prefix_spaces)
+                };
+
+                write!(
+                    fmt,
+                    "{}\n{}\n{}\n{}{}\n",
+                    error_info,
+                    file_info,
+                    error_line_buffer,
+                    note,
+                    error.msg_suffix()
+                )?;
+            }
+        }
+        if !self.file_error_map.is_empty() {
+            write!(
+                fmt,
+                "warning: rustfmt may have failed to format. See previous {} errors.\n",
+                self.warning_count(),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn should_report_error(
+    config: &Config,
+    char_kind: FullCodeCharKind,
+    is_string: bool,
+    error_kind: ErrorKind,
+) -> bool {
+    let allow_error_report = if char_kind.is_comment() || is_string {
+        config.error_on_unformatted()
+    } else {
+        true
+    };
+
+    match error_kind {
+        ErrorKind::LineOverflow(..) => config.error_on_line_overflow() && allow_error_report,
+        ErrorKind::TrailingWhitespace => allow_error_report,
+        _ => true,
+    }
+}
+
+/// Iterate over formatted text. If any error is found, add it to the report.
+/// FIXME(#209) warn on bad license
+/// FIXME(#20) other stuff for parity with make tidy
+pub fn report_errors_in_formatted_text(
+    text: &mut String,
+    name: &FileName,
+    skipped_range: &[(usize, usize)],
+    config: &Config,
+    report: &mut FormatReport,
+) {
+    // Iterate over the chars in the file map.
+    let mut trims = vec![];
+    let mut last_wspace: Option<usize> = None;
+    let mut line_len = 0;
+    let mut cur_line = 1;
+    let mut newline_count = 0;
+    let mut errors = vec![];
+    let mut issue_seeker = BadIssueSeeker::new(config.report_todo(), config.report_fixme());
+    let mut line_buffer = String::with_capacity(config.max_width() * 2);
+    let mut is_string = false; // true if the current line contains a string literal.
+    let mut format_line = config.file_lines().contains_line(name, cur_line);
+
+    for (kind, (b, c)) in CharClasses::new(text.chars().enumerate()) {
+        if c == '\r' {
+            continue;
+        }
+
+        if format_line {
+            // Add warnings for bad todos/ fixmes
+            if let Some(issue) = issue_seeker.inspect(c) {
+                errors.push(FormattingError {
+                    line: cur_line,
+                    kind: ErrorKind::BadIssue(issue),
+                    is_comment: false,
+                    is_string: false,
+                    line_buffer: String::new(),
+                });
+            }
+        }
+
+        if c == '\n' {
+            if format_line {
+                // Check for (and record) trailing whitespace.
+                if let Some(..) = last_wspace {
+                    if should_report_error(config, kind, is_string, ErrorKind::TrailingWhitespace) {
+                        trims.push((cur_line, kind, line_buffer.clone()));
+                    }
+                    line_len -= 1;
+                }
+
+                // Check for any line width errors we couldn't correct.
+                let error_kind = ErrorKind::LineOverflow(line_len, config.max_width());
+                if line_len > config.max_width() && !is_skipped_line(cur_line, skipped_range)
+                    && should_report_error(config, kind, is_string, error_kind)
+                {
+                    errors.push(FormattingError {
+                        line: cur_line,
+                        kind: error_kind,
+                        is_comment: kind.is_comment(),
+                        is_string: is_string,
+                        line_buffer: line_buffer.clone(),
+                    });
+                }
+            }
+
+            line_len = 0;
+            cur_line += 1;
+            format_line = config.file_lines().contains_line(name, cur_line);
+            newline_count += 1;
+            last_wspace = None;
+            line_buffer.clear();
+            is_string = false;
+        } else {
+            newline_count = 0;
+            line_len += 1;
+            if c.is_whitespace() {
+                if last_wspace.is_none() {
+                    last_wspace = Some(b);
+                }
+            } else {
+                last_wspace = None;
+            }
+            line_buffer.push(c);
+            if kind.is_string() {
+                is_string = true;
+            }
+        }
+    }
+
+    if newline_count > 1 {
+        debug!("track truncate: {} {}", text.len(), newline_count);
+        let line = text.len() - newline_count + 1;
+        text.truncate(line);
+    }
+
+    for &(l, kind, ref b) in &trims {
+        if !is_skipped_line(l, skipped_range) {
+            errors.push(FormattingError {
+                line: l,
+                kind: ErrorKind::TrailingWhitespace,
+                is_comment: kind.is_comment(),
+                is_string: kind.is_string(),
+                line_buffer: b.clone(),
+            });
+        }
+    }
+
+    report.file_error_map.insert(name.clone(), errors);
+}
+
+impl<'a> FmtVisitor<'a> {
+    pub fn report_errors_after_format<T: io::Write>(
+        &mut self,
+        file_name: &FileName,
+        report: &mut FormatReport,
+        out: &mut Option<T>,
+    ) -> Result<bool, io::Error> {
+        // For some reason, the codemap does not include terminating
+        // newlines so we must add one on for each file. This is sad.
+        append_newline(&mut self.buffer);
+        report_errors_in_formatted_text(
+            &mut self.buffer,
+            file_name,
+            &self.skipped_range,
+            self.config,
+            report,
+        );
+        out.as_mut().map_or(Ok(false), |out| {
+            write_file(&self.buffer, file_name, out, self.config)
+        })
+    }
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,3 +1,13 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use std::time::{Duration, Instant};
 use std::default::Default;
 


### PR DESCRIPTION
Currently rustfmt uses `String` and `std::io::Error` for error type in many places. This is ok, acceptable, working fine in practice, but I think we can do better. This PR is an attempt to improve the error handling in rustfmt via failure crate.