### PR TITLE
Extending `spaces_around_ranges` to ranges in match arm patterns

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1468,7 +1468,7 @@ struct Foo {
 
 ## `spaces_around_ranges`
 
-Put spaces around the .. and ... range operators
+Put spaces around the .., ..=, and ... range operators
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
@@ -1477,13 +1477,49 @@ Put spaces around the .. and ... range operators
 #### `false` (default):
 
 ```rust
-let lorem = 0..10;
+fn main() {
+    let lorem = 0..10;
+    let ipsum = 0..=10;
+
+    match lorem {
+        1..5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1..=5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1...5 => foo(),
+        _ => bar,
+    }
+}
 ```
 
 #### `true`:
 
 ```rust
-let lorem = 0 .. 10;
+fn main() {
+    let lorem = 0 .. 10;
+    let ipsum = 0 ..= 10;
+
+    match lorem {
+        1 .. 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ..= 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ... 5 => foo(),
+        _ => bar,
+    }
+}
 ```
 
 ## `spaces_within_parens_and_brackets`

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -65,10 +65,15 @@ impl Rewrite for Pat {
                     RangeEnd::Included(RangeSyntax::DotDotEq) => "..=",
                     RangeEnd::Excluded => "..",
                 };
+                let infix = if context.config.spaces_around_ranges() {
+                    format!(" {} ", infix)
+                } else {
+                    infix.to_owned()
+                };
                 rewrite_pair(
                     &**lhs,
                     &**rhs,
-                    PairParts::new("", infix, ""),
+                    PairParts::new("", &infix, ""),
                     context,
                     shape,
                     SeparatorPlace::Front,

--- a/tests/source/configs/spaces_around_ranges/false.rs
+++ b/tests/source/configs/spaces_around_ranges/false.rs
@@ -2,5 +2,21 @@
 // Spaces around ranges
 
 fn main() {
-    let lorem = 0..10;
+    let lorem = 0 .. 10;
+    let ipsum = 0 ..= 10;
+
+    match lorem {
+        1 .. 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ..= 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ... 5 => foo(),
+        _ => bar,
+    }
 }

--- a/tests/source/configs/spaces_around_ranges/true.rs
+++ b/tests/source/configs/spaces_around_ranges/true.rs
@@ -3,4 +3,20 @@
 
 fn main() {
     let lorem = 0..10;
+    let ipsum = 0..=10;
+
+    match lorem {
+        1..5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1..=5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1...5 => foo(),
+        _ => bar,
+    }
 }

--- a/tests/target/configs/spaces_around_ranges/false.rs
+++ b/tests/target/configs/spaces_around_ranges/false.rs
@@ -3,4 +3,20 @@
 
 fn main() {
     let lorem = 0..10;
+    let ipsum = 0..=10;
+
+    match lorem {
+        1..5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1..=5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1...5 => foo(),
+        _ => bar,
+    }
 }

--- a/tests/target/configs/spaces_around_ranges/true.rs
+++ b/tests/target/configs/spaces_around_ranges/true.rs
@@ -3,4 +3,20 @@
 
 fn main() {
     let lorem = 0 .. 10;
+    let ipsum = 0 ..= 10;
+
+    match lorem {
+        1 .. 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ..= 5 => foo(),
+        _ => bar,
+    }
+
+    match lorem {
+        1 ... 5 => foo(),
+        _ => bar,
+    }
 }


### PR DESCRIPTION
Currently, the `spaces_around_ranges` configuration option only affects ranges in statements. For example, `let lorem = 0..10;` becomes `let lorem = 0 .. 10;`, if `spaces_around_ranges=true`. However, if `spaces_around_ranges=true` the following is not formatted as one might expect:

```rust
match lorem {
    1..5 => foo(),
    _ => bar,
}
```

This PR extends the effect of `spaces_around_ranges` to match arm patterns.

Fixes #2372 and will supersede #2373, if accepted.