### PR TITLE
Disabling macOS CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rust:
  - nightly
 os:
  - linux
- - osx
 cache:
  directories:
   - $HOME/.cargo
@@ -20,15 +19,8 @@ addons:
 
 before_script:
 - |
-  if [ $TRAVIS_OS_NAME = 'osx' ]; then
-    brew install python3 &&
-    virtualenv env -p python3 &&
-    source env/bin/activate &&
-    pip install 'travis-cargo<0.2'
-  else
-    pip install 'travis-cargo<0.2' --user &&
-    export PATH="$(python -m site --user-base)/bin:$PATH"
-  fi
+  pip install 'travis-cargo<0.2' --user &&
+  export PATH="$(python -m site --user-base)/bin:$PATH"
 
 script:
 - |


### PR DESCRIPTION
I propose we disable the Travis CI macOS build until the build queue gets under control. The Travis CI macOS build queue has been growing faster than jobs are finishing for more than a week (with a brief exception).

Here's what the [PR queue](https://github.com/rust-lang-nursery/rustfmt/pulls) looks like at the moment:
![image](https://user-images.githubusercontent.com/933552/35259955-888b6648-ffbd-11e7-8eaa-dda7c721eb0a.png)

The six most recent PRs failed because Travis CI could not schedule a macOS build within many hours of submission. The shortest build of those six failed after 9.5 hours. Three of them ran for more than twenty-four hours. It's making it difficult to look at the PR queue and immediately recognize which PRs are marked as failing for reasons that were due to the code changes.

Here's the last thirty days of the macOS queue (from [here](https://www.traviscistatus.com/#month)):
![image](https://user-images.githubusercontent.com/933552/35260067-2c45a866-ffbe-11e7-8dd4-0e39eebef947.png)

The backlog has gone up a lot since the beginning of the month. The queue currently contains 1,900 jobs. Over the weekend it dropped to 600, but we still had PRs failing the build during that period. There is an [incident report](https://www.traviscistatus.com/incidents/mc9x2wmpnvhg) from four days ago, and there was one PR that successfully built right around the time of the incident being closed. None have succeeded since.

Not running the macOS build comes with some risks, of course, but it's not helping us at all right now. Unless we are waiting until it starts scheduling builds again, there's a case to disable. If we do that, we should monitor the situation to watch for when it becomes feasible to enable the macOS build again.