### PR TITLE
Make rustfmt-bin's CARGO_PKG_VERSION envvar optional

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -387,7 +387,7 @@ fn print_usage_to_stdout(opts: &Options, reason: &str) {
 fn print_version() {
     println!(
         "{}-nightly{}",
-        env!("CARGO_PKG_VERSION"),
+        option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
         include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
     )
 }


### PR DESCRIPTION
This is a tiny PR that lets the rustfmt binary build without a CARGO_PKG_VERSION environment variable, using "unknown" in its place if necessary.

I happen to compile this library without Cargo, and thus don't have this variable present. It is possible for me to spoof the value if there are objections making the value optional.