### PR TITLE
Format stable macro_rules

### DIFF
--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -97,7 +97,7 @@ fn execute() -> i32 {
 }
 
 macro_rules! print_usage {
-    ($print:ident, $opts:ident, $reason:expr) => ({
+    ($print: ident, $opts: ident, $reason: expr) => ({
         let msg = format!("{}\nusage: cargo fmt [options]", $reason);
         $print!(
             "{}\nThis utility formats all bin and lib files of the current crate using rustfmt. \

--- a/src/bin/cargo-fmt.rs
+++ b/src/bin/cargo-fmt.rs
@@ -97,14 +97,14 @@ fn execute() -> i32 {
 }
 
 macro_rules! print_usage {
-    ($print: ident, $opts: ident, $reason: expr) => ({
+    ($print: ident, $opts: ident, $reason: expr) => {{
         let msg = format!("{}\nusage: cargo fmt [options]", $reason);
         $print!(
             "{}\nThis utility formats all bin and lib files of the current crate using rustfmt. \
              Arguments after `--` are passed to rustfmt.",
             $opts.usage(&msg)
         );
-    })
+    }};
 }
 
 fn print_usage_to_stdout(opts: &Options, reason: &str) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ macro_rules! is_nightly_channel {
         option_env!("CFG_RELEASE_CHANNEL")
             .map(|c| c == "nightly")
             .unwrap_or(true)
-    }
+    };
 }
 
 macro_rules! configuration_option_enum{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,7 +33,8 @@ use syntax::util::ThinVec;
 use codemap::SpanUtils;
 use comment::{contains_comment, remove_trailing_white_spaces, FindUncommented};
 use expr::{rewrite_array, rewrite_call_inner};
-use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorPlace, SeparatorTactic};
+use lists::{itemize_list, write_list, DefinitiveListTactic, ListFormatting, SeparatorPlace,
+            SeparatorTactic};
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
 use utils::{format_visibility, mk_sp};
@@ -102,7 +103,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
                     parser.sess.span_diagnostic.reset_err_count();
                 }
             }
-        }
+        };
     }
 
     parse_macro_arg!(Expr, parse_expr);
@@ -312,8 +313,8 @@ pub fn rewrite_macro_def(
 
     let arm_shape = if multi_branch_style {
         shape
-        .block_indent(context.config.tab_spaces())
-        .with_max_width(context.config)
+            .block_indent(context.config.tab_spaces())
+            .with_max_width(context.config)
     } else {
         shape
     };
@@ -743,7 +744,12 @@ struct MacroBranch {
 }
 
 impl MacroBranch {
-    fn rewrite(&self, context: &RewriteContext, shape: Shape, multi_branch_style: bool) -> Option<String> {
+    fn rewrite(
+        &self,
+        context: &RewriteContext,
+        shape: Shape,
+        multi_branch_style: bool,
+    ) -> Option<String> {
         // Only attempt to format function-like macros.
         if self.args_paren_kind != DelimToken::Paren {
             // FIXME(#1539): implement for non-sugared macros.
@@ -807,10 +813,7 @@ impl MacroBranch {
         // FIXME: this could be *much* more efficient.
         for (old, new) in &substs {
             if old_body.find(new).is_some() {
-                debug!(
-                    "rewrite_macro_def: bailing matching variable: `{}`",
-                    new
-                );
+                debug!("rewrite_macro_def: bailing matching variable: `{}`", new);
                 return None;
             }
             new_body = new_body.replace(new, old);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -400,7 +400,7 @@ pub fn rewrite_macro_def(
 
         if has_block_body {
             result += new_body.trim();
-        } else {
+        } else if !new_body.is_empty() {
             result += "\n";
             result += &new_body;
             result += &mac_indent_str;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -324,7 +324,7 @@ pub fn rewrite_macro_def(
             return snippet;
         }
 
-        let args = format!("({})", format_macro_args(branch.args)?);
+        let args = format_macro_args(branch.args)?;
 
         if multi_branch_style {
             result += "\n";
@@ -758,10 +758,12 @@ impl MacroParser {
 
     // `(` ... `)` `=>` `{` ... `}`
     fn parse_branch(&mut self) -> Option<MacroBranch> {
-        let (args_paren_kind, args) = match self.toks.next()? {
+        let tok = self.toks.next()?;
+        let args_paren_kind = match tok {
             TokenTree::Token(..) => return None,
-            TokenTree::Delimited(_, ref d) => (d.delim, d.tts.clone()),
+            TokenTree::Delimited(_, ref d) => d.delim,
         };
+        let args = tok.joint().into();
         match self.toks.next()? {
             TokenTree::Token(_, Token::FatArrow) => {}
             _ => return None,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -415,10 +415,6 @@ pub fn rewrite_macro_def(
 
             result += "}";
 
-            if def.legacy {
-                result += ";";
-            }
-
             Some(result)
         },
         context.codemap.span_after(span, "{"),
@@ -432,8 +428,8 @@ pub fn rewrite_macro_def(
 
     let fmt = ListFormatting {
         tactic: DefinitiveListTactic::Vertical,
-        separator: "",
-        trailing_separator: SeparatorTactic::Never,
+        separator: if def.legacy { ";" } else { "" },
+        trailing_separator: SeparatorTactic::Always,
         separator_place: SeparatorPlace::Back,
         shape: arm_shape,
         ends_with_newline: true,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -323,12 +323,8 @@ pub fn rewrite_macro_def(
         parsed_def.branches.iter(),
         "}",
         ";",
-        |branch| {
-            branch.span.lo()
-        },
-        |branch| {
-            branch.span.hi()
-        },
+        |branch| branch.span.lo(),
+        |branch| branch.span.hi(),
         |branch| {
             // Only attempt to format function-like macros.
             if branch.args_paren_kind != DelimToken::Paren {
@@ -419,7 +415,7 @@ pub fn rewrite_macro_def(
         },
         context.codemap.span_after(span, "{"),
         span.hi(),
-        false
+        false,
     ).collect::<Vec<_>>();
 
     let arm_shape = shape
@@ -804,7 +800,10 @@ impl MacroParser {
             TokenTree::Token(..) => return None,
             TokenTree::Delimited(sp, _) => {
                 let data = sp.data();
-                (data.hi, Span::new(data.lo + BytePos(1), data.hi - BytePos(1), data.ctxt))
+                (
+                    data.hi,
+                    Span::new(data.lo + BytePos(1), data.hi - BytePos(1), data.ctxt),
+                )
             }
         };
         if let Some(TokenTree::Token(sp, Token::Semi)) = self.toks.look_ahead(0) {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -20,32 +20,30 @@ pub trait Spanned {
 }
 
 macro_rules! span_with_attrs_lo_hi {
-    ($this:ident, $lo:expr, $hi:expr) => {
-        {
-            let attrs = outer_attributes(&$this.attrs);
-            if attrs.is_empty() {
-                mk_sp($lo, $hi)
-            } else {
-                mk_sp(attrs[0].span.lo(), $hi)
-            }
+    ($this: ident, $lo: expr, $hi: expr) => {{
+        let attrs = outer_attributes(&$this.attrs);
+        if attrs.is_empty() {
+            mk_sp($lo, $hi)
+        } else {
+            mk_sp(attrs[0].span.lo(), $hi)
         }
-    }
+    }};
 }
 
 macro_rules! span_with_attrs {
-    ($this:ident) => {
+    ($this: ident) => {
         span_with_attrs_lo_hi!($this, $this.span.lo(), $this.span.hi())
-    }
+    };
 }
 
 macro_rules! implement_spanned {
-    ($this:ty) => {
+    ($this: ty) => {
         impl Spanned for $this {
             fn span(&self) -> Span {
                 span_with_attrs!(self)
             }
         }
-    }
+    };
 }
 
 // Implement `Spanned` for structs with `attrs` field.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -342,9 +342,9 @@ macro_rules! msg {
 // For format_missing and last_pos, need to use the source callsite (if applicable).
 // Required as generated code spans aren't guaranteed to follow on from the last span.
 macro_rules! source {
-    ($this:ident, $sp: expr) => {
+    ($this: ident, $sp: expr) => {
         $sp.source_callsite()
-    }
+    };
 }
 
 pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
@@ -353,28 +353,29 @@ pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
 
 // Return true if the given span does not intersect with file lines.
 macro_rules! out_of_file_lines_range {
-    ($self:ident, $span:expr) => {
-        !$self.config
+    ($self: ident, $span: expr) => {
+        !$self
+            .config
             .file_lines()
             .intersects(&$self.codemap.lookup_line_range($span))
-    }
+    };
 }
 
 macro_rules! skip_out_of_file_lines_range {
-    ($self:ident, $span:expr) => {
+    ($self: ident, $span: expr) => {
         if out_of_file_lines_range!($self, $span) {
             return None;
         }
-    }
+    };
 }
 
 macro_rules! skip_out_of_file_lines_range_visitor {
-    ($self:ident, $span:expr) => {
+    ($self: ident, $span: expr) => {
         if out_of_file_lines_range!($self, $span) {
             $self.push_rewrite($span, None);
             return;
         }
-    }
+    };
 }
 
 // Wraps String in an Option. Returns Some when the string adheres to the

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -451,6 +451,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             ast::ItemKind::MacroDef(ref def) => {
                 let rewrite = rewrite_macro_def(
                     &self.get_context(),
+                    self.shape(),
                     self.block_indent,
                     def,
                     item.ident,

--- a/tests/source/macro_rules.rs
+++ b/tests/source/macro_rules.rs
@@ -1,5 +1,5 @@
 macro_rules! m {
-	($expr :expr, $func : ident) => {
+	($expr :expr,  $( $func : ident    ) *   ) => {
 		{
 		let    x =    $expr;
 									                $func (

--- a/tests/source/macro_rules.rs
+++ b/tests/source/macro_rules.rs
@@ -1,0 +1,16 @@
+macro_rules! m {
+	($expr :expr, $func : ident) => {
+		{
+		let    x =    $expr;
+									                $func (
+														x
+											)
+	}
+	};
+
+   	()           => {  };
+
+( $item:ident  ) =>      {
+	mod macro_item    {  struct $item ; }
+};
+}

--- a/tests/source/macro_rules.rs
+++ b/tests/source/macro_rules.rs
@@ -1,4 +1,5 @@
 macro_rules! m {
+	// a
 	($expr :expr,  $( $func : ident    ) *   ) => {
 		{
 		let    x =    $expr;
@@ -8,8 +9,11 @@ macro_rules! m {
 	}
 	};
 
-   	()           => {  };
+				/* b */
 
+   	()           => {/* c */};
+
+// d
 ( $item:ident  ) =>      {
 	mod macro_item    {  struct $item ; }
 };

--- a/tests/source/macro_rules.rs
+++ b/tests/source/macro_rules.rs
@@ -13,8 +13,39 @@ macro_rules! m {
 
    	()           => {/* c */};
 
+		 				(@tag)   =>
+						 {
+
+						 };
+
 // d
 ( $item:ident  ) =>      {
 	mod macro_item    {  struct $item ; }
 };
+}
+
+macro m2 {
+	// a
+	($expr :expr,  $( $func : ident    ) *   ) => {
+		{
+		let    x =    $expr;
+									                $func (
+														x
+											)
+	}
+	}
+
+				/* b */
+
+   	()           => {/* c */}
+
+		 				(@tag)   =>
+						 {
+
+						 }
+
+// d
+( $item:ident  ) =>      {
+	mod macro_item    {  struct $item ; }
+}
 }

--- a/tests/target/macro_not_expr.rs
+++ b/tests/target/macro_not_expr.rs
@@ -1,6 +1,5 @@
 macro_rules! test {
-    ($($t: tt)*) => {
-    };
+    ($($t: tt)*) => {};
 }
 
 fn main() {

--- a/tests/target/macro_not_expr.rs
+++ b/tests/target/macro_not_expr.rs
@@ -1,5 +1,6 @@
 macro_rules! test {
-    ($($t:tt)*) => {}
+    ($($t: tt)*) => {
+    };
 }
 
 fn main() {

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -4,8 +4,7 @@ macro_rules! m {
         $func(x)
     }};
 
-    () => {
-    };
+    () => {};
 
     ($item: ident) => {
         mod macro_item {

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -1,5 +1,5 @@
 macro_rules! m {
-    ($expr: expr, $func: ident) => {{
+    ($expr: expr, $($func: ident)*) => {{
         let x = $expr;
         $func(x)
     }};

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -1,0 +1,17 @@
+macro_rules! m {
+    ($expr: expr, $func: ident) => {
+        {
+            let x = $expr;
+            $func(x)
+        }
+    };
+
+    () => {
+    };
+
+    ($item: ident) => {
+        mod macro_item {
+            struct $item;
+        }
+    };
+}

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -1,14 +1,43 @@
 macro_rules! m {
+    // a
     ($expr: expr, $($func: ident)*) => {{
         let x = $expr;
         $func(x)
     }};
 
-    () => {};
+    /* b */
+    () => {
+        /* c */
+    };
 
+    (@tag) => {};
+
+    // d
     ($item: ident) => {
         mod macro_item {
             struct $item;
         }
     };
+}
+
+macro m2 {
+    // a
+    ($expr: expr, $($func: ident)*) => {{
+        let x = $expr;
+        $func(x)
+    }}
+
+    /* b */
+    () => {
+        /* c */
+    }
+
+    (@tag) => {}
+
+    // d
+    ($item: ident) => {
+        mod macro_item {
+            struct $item;
+        }
+    }
 }

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -1,10 +1,8 @@
 macro_rules! m {
-    ($expr: expr, $func: ident) => {
-        {
-            let x = $expr;
-            $func(x)
-        }
-    };
+    ($expr: expr, $func: ident) => {{
+        let x = $expr;
+        $func(x)
+    }};
 
     () => {
     };

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -27,8 +27,9 @@ fn main() {
     );
 
     kaas!(
-        /* comments */ a, /* post macro */
-        b  /* another */
+        // comments
+        a, // post macro
+        b  // another
     );
 
     trailingcomma!(a, b, c,);

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -141,8 +141,7 @@ fn issue_1555() {
 
 fn issue1178() {
     macro_rules! foo {
-        (#[$attr: meta] $name: ident) => {
-        };
+        (#[$attr: meta] $name: ident) => {};
     }
 
     foo!(
@@ -890,8 +889,7 @@ fn macro_in_pattern_position() {
     };
 }
 
-macro foo() {
-}
+macro foo() {}
 
 pub macro bar($x: ident + $y: expr;) {
     fn foo($x: Foo) {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -27,9 +27,8 @@ fn main() {
     );
 
     kaas!(
-        // comments
-        a, // post macro
-        b  // another
+        /* comments */ a, /* post macro */
+        b  /* another */
     );
 
     trailingcomma!(a, b, c,);
@@ -890,29 +889,23 @@ fn macro_in_pattern_position() {
     };
 }
 
-macro foo {
-    () => {
+macro foo() {
+}
+
+pub macro bar($x: ident + $y: expr;) {
+    fn foo($x: Foo) {
+        long_function(
+            a_long_argument_to_a_long_function_is_what_this_is(AAAAAAAAAAAAAAAAAAAAAAAAAAAA),
+            $x.bar($y),
+        );
     }
 }
 
-pub macro bar {
-    ($x: ident + $y: expr;) => {
-        fn foo($x: Foo) {
-            long_function(
-                a_long_argument_to_a_long_function_is_what_this_is(AAAAAAAAAAAAAAAAAAAAAAAAAAAA),
-                $x.bar($y),
-            );
-        }
-    }
-}
-
-macro foo {
-    () => {
-        // a comment
-        fn foo() {
-            // another comment
-            bar();
-        }
+macro foo() {
+    // a comment
+    fn foo() {
+        // another comment
+        bar();
     }
 }
 

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -141,7 +141,8 @@ fn issue_1555() {
 
 fn issue1178() {
     macro_rules! foo {
-        (#[$attr:meta] $name:ident) => {}
+        (#[$attr: meta] $name: ident) => {
+        };
     }
 
     foo!(
@@ -246,11 +247,15 @@ fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
 
 // #878
 macro_rules! try_opt {
-    ($expr:expr) => (match $expr {
-        Some(val) => val,
+    ($expr: expr) => {
+        match $expr {
+            Some(val) => val,
 
-        None => { return None; }
-    })
+            None => {
+                return None;
+            }
+        }
+    };
 }
 
 // #2214
@@ -885,24 +890,29 @@ fn macro_in_pattern_position() {
     };
 }
 
-macro foo() {
-
-}
-
-pub macro bar($x: ident + $y: expr;) {
-    fn foo($x: Foo) {
-        long_function(
-            a_long_argument_to_a_long_function_is_what_this_is(AAAAAAAAAAAAAAAAAAAAAAAAAAAA),
-            $x.bar($y),
-        );
+macro foo {
+    () => {
     }
 }
 
-macro foo() {
-    // a comment
-    fn foo() {
-        // another comment
-        bar();
+pub macro bar {
+    ($x: ident + $y: expr;) => {
+        fn foo($x: Foo) {
+            long_function(
+                a_long_argument_to_a_long_function_is_what_this_is(AAAAAAAAAAAAAAAAAAAAAAAAAAAA),
+                $x.bar($y),
+            );
+        }
+    }
+}
+
+macro foo {
+    () => {
+        // a comment
+        fn foo() {
+            // another comment
+            bar();
+        }
     }
 }
 


### PR DESCRIPTION
I took an existing logic for Macros 2.0 and adapted for "legacy" (stable) `macro_rules` syntax. At this point it seems to produce quite consistent and expected results.

Admittedly the code is quite hacky, but I guess that's what one should expect when attempting to format macros. If not, I'm open to suggestions :)

Issue: #8