### PR TITLE
Fixing straightforward configuration snippets (Part 2)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1854,10 +1854,12 @@ fn main() {
 #### `false`:
 
 ```rust
-match lorem {
-    true =>
-        foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x),
-    false => println!("{}", sit),
+fn main() {
+    match lorem {
+        true =>
+            foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x),
+        false => println!("{}", sit),
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1720,15 +1720,17 @@ fn main() {
 #### `"Never"`:
 
 ```rust
-let Lorem { ipsum, dolor, sit } = amet;
-let Lorem {
-    ipsum,
-    dolor,
-    sit,
-    amet,
-    consectetur,
-    adipiscing
-} = elit;
+fn main() {
+    let Lorem { ipsum, dolor, sit } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing
+    } = elit;
+}
 ```
 
 See also: [`match_block_trailing_comma`](#match_block_trailing_comma).

--- a/Configurations.md
+++ b/Configurations.md
@@ -1601,17 +1601,19 @@ fn lorem<T: Eq>(t: T) {
 
 ```rust
 // generic arguments
-fn lorem< T: Eq >(t: T) {
+fn lorem< T: Eq >( t: T ) {
     // body
 }
 
 // non-empty parentheses
-fn lorem<T: Eq>( t: T ) {
+fn lorem< T: Eq >( t: T ) {
     let lorem = ( ipsum, dolor );
 }
 
 // non-empty square brackets
-let lorem: [ usize; 2 ] = [ ipsum, dolor ];
+fn lorem< T: Eq >( t: T ) {
+    let lorem: [ usize; 2 ] = [ ipsum, dolor ];
+}
 ```
 
 ## `struct_lit_single_line`

--- a/Configurations.md
+++ b/Configurations.md
@@ -1704,15 +1704,17 @@ fn main() {
 #### `"Always"`:
 
 ```rust
-let Lorem { ipsum, dolor, sit, } = amet;
-let Lorem {
-    ipsum,
-    dolor,
-    sit,
-    amet,
-    consectetur,
-    adipiscing,
-} = elit;
+fn main() {
+    let Lorem { ipsum, dolor, sit, } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing,
+    } = elit;
+}
 ```
 
 #### `"Never"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1658,7 +1658,7 @@ Number of spaces per tab
 fn lorem() {
     let ipsum = dolor();
     let sit = vec![
-        "amet consectetur adipiscing elit."
+        "amet consectetur adipiscing elit amet consectetur adipiscing elit amet consectetur.",
     ];
 }
 ```

--- a/Configurations.md
+++ b/Configurations.md
@@ -1179,21 +1179,22 @@ fn main() {
 #### `true`:
 
 ```rust
-
-result.and_then(|maybe_value| {
-    match maybe_value {
-        None => ...,
-        Some(value) => ...,
-    }
-})
-
-match lorem {
-    None => {
-        if ipsum {
-            println!("Hello World");
+fn main() {
+    result.and_then(|maybe_value| {
+        match maybe_value {
+            None => foo(),
+            Some(value) => bar(),
         }
+    });
+
+    match lorem {
+        None => {
+            if ipsum {
+                println!("Hello World");
+            }
+        }
+        Some(dolor) => foo(),
     }
-    Some(dolor) => ...,
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1688,15 +1688,17 @@ How to handle trailing commas for lists
 #### `"Vertical"` (default):
 
 ```rust
-let Lorem { ipsum, dolor, sit } = amet;
-let Lorem {
-    ipsum,
-    dolor,
-    sit,
-    amet,
-    consectetur,
-    adipiscing,
-} = elit;
+fn main() {
+    let Lorem { ipsum, dolor, sit } = amet;
+    let Lorem {
+        ipsum,
+        dolor,
+        sit,
+        amet,
+        consectetur,
+        adipiscing,
+    } = elit;
+}
 ```
 
 #### `"Always"`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1841,11 +1841,13 @@ Wrap the body of arms in blocks when it does not fit on the same line with the p
 #### `true` (default):
 
 ```rust
-match lorem {
-    true => {
-        foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x)
+fn main() {
+    match lorem {
+        true => {
+            foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x)
+        }
+        false => println!("{}", sit),
     }
-    false => println!("{}", sit),
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1792,7 +1792,9 @@ Replace uses of the try! macro by the ? shorthand
 #### `false` (default):
 
 ```rust
-let lorem = try!(ipsum.map(|dolor|dolor.sit()));
+fn main() {
+    let lorem = try!(ipsum.map(|dolor| dolor.sit()));
+}
 ```
 
 #### `true`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1592,7 +1592,9 @@ fn lorem<T: Eq>(t: T) {
 }
 
 // non-empty square brackets
-let lorem: [usize; 2] = [ipsum, dolor];
+fn lorem<T: Eq>(t: T) {
+    let lorem: [usize; 2] = [ipsum, dolor];
+}
 ```
 
 #### `true`:

--- a/Configurations.md
+++ b/Configurations.md
@@ -1769,7 +1769,7 @@ Determines if `+` or `=` are wrapped in spaces in the punctuation of types
 
 ```rust
 fn lorem<Ipsum: Dolor + Sit = Amet>() {
-	// body
+    // body
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1800,7 +1800,9 @@ fn main() {
 #### `true`:
 
 ```rust
-let lorem = ipsum.map(|dolor| dolor.sit())?;
+fn main() {
+    let lorem = ipsum.map(|dolor| dolor.sit())?;
+}
 ```
 
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1161,16 +1161,18 @@ Force multiline closure and match arm bodies to be wrapped in a block
 #### `false` (default):
 
 ```rust
-result.and_then(|maybe_value| match maybe_value {
-    None => ...,
-    Some(value) => ...,
-})
+fn main() {
+    result.and_then(|maybe_value| match maybe_value {
+        None => foo(),
+        Some(value) => bar(),
+    });
 
-match lorem {
-    None => if ipsum {
-        println!("Hello World");
-    },
-    Some(dolor) => ...,
+    match lorem {
+        None => if ipsum {
+            println!("Hello World");
+        },
+        Some(dolor) => foo(),
+    }
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1669,7 +1669,7 @@ fn lorem() {
 fn lorem() {
   let ipsum = dolor();
   let sit = vec![
-    "amet consectetur adipiscing elit."
+    "amet consectetur adipiscing elit amet consectetur adipiscing elit amet consectetur.",
   ];
 }
 ```

--- a/Configurations.md
+++ b/Configurations.md
@@ -1777,7 +1777,7 @@ fn lorem<Ipsum: Dolor + Sit = Amet>() {
 
 ```rust
 fn lorem<Ipsum: Dolor+Sit=Amet>() {
-	// body
+    // body
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -1633,10 +1633,12 @@ let lorem = Lorem { ipsum: dolor, sit: amet };
 #### `false`:
 
 ```rust
-let lorem = Lorem {
-    ipsum: dolor,
-    sit: amet,
-};
+fn main() {
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+}
 ```
 
 See also: [`indent_style`](#indent_style).


### PR DESCRIPTION
This is the second -- and final -- batch of straightforward configuration snippet fixes for #1845. See #2369 for the first batch.

As in the previous PR, the fixes use a few approaches. Most commonly, snippets are wrapped in a function and lines are made longer to reach the default max width, which often triggers formatting.

This batch corrects sixteen configuration snippets, as can be seen with `cargo test -- --ignored`. Here is the output on master:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `22`,
 right: `0`: 22 configurations tests failed', tests/system.rs:800:5
```

Here is the output on the PR branch:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `0`: 6 configurations tests failed', tests/system.rs:800:5
```

The fixes for the remaining six failing cases will be more involved or require more discussion, so they will arrive in separate PRs.