### PR TITLE
Put attributes and enum variants on different lines

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -134,6 +134,11 @@ fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyle {
     }
 }
 
+/// Combine `prev_str` and `next_str` into a single `String`. `span` may contain
+/// comments between two strings. If there are such comments, then that will be
+/// recovered. If `allow_extend` is true and there is no comment between the two
+/// strings, then they will be put on a single line as long as doing so does not
+/// exceed max width.
 pub fn combine_strs_with_missing_comments(
     context: &RewriteContext,
     prev_str: &str,

--- a/src/items.rs
+++ b/src/items.rs
@@ -504,7 +504,7 @@ impl<'a> FmtVisitor<'a> {
             items = itemize_list_with(0);
         }
 
-        let shape = self.shape().sub_width(2).unwrap();
+        let shape = self.shape().sub_width(2)?;
         let fmt = ListFormatting {
             tactic: DefinitiveListTactic::Vertical,
             separator: ",",
@@ -558,14 +558,7 @@ impl<'a> FmtVisitor<'a> {
             }
         };
 
-        combine_strs_with_missing_comments(
-            &context,
-            &attrs_str,
-            &variant_body,
-            span,
-            shape,
-            is_attributes_extendable(&attrs_str),
-        )
+        combine_strs_with_missing_comments(&context, &attrs_str, &variant_body, span, shape, false)
     }
 }
 

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -180,3 +180,15 @@ enum WidthOf101 {
     Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(::std::io::Error),
     Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(::std::io::Error),
 }
+
+// #2389
+pub enum QlError {
+    #[fail(display = "Parsing error: {}", 0)] LexError(parser::lexer::LexError),
+    #[fail(display = "Parsing error: {:?}", 0)] ParseError(parser::ParseError),
+    #[fail(display = "Validation error: {:?}", 0)] ValidationError(Vec<validation::Error>),
+    #[fail(display = "Execution error: {}", 0)] ExecutionError(String),
+    // (from, to)
+    #[fail(display = "Translation error: from {} to {}", 0, 1)] TranslationError(String, String),
+    // (kind, input, expected)
+    #[fail(display = "Could not find {}: Found: {}, expected: {:?}", 0, 1, 2)] ResolveError(&'static str, String, Option<String>),
+}

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -24,7 +24,8 @@ enum EmtpyWithComment {
 // C-style enum
 enum Bar {
     A = 1,
-    #[someAttr(test)] B = 2, // comment
+    #[someAttr(test)]
+    B = 2, // comment
     C,
 }
 
@@ -225,11 +226,30 @@ enum AnError {
 
 // #2193
 enum WidthOf101 {
-    #[fail(display = ".....................................................")] Io(::std::io::Error),
+    #[fail(display = ".....................................................")]
+    Io(::std::io::Error),
     #[fail(display = ".....................................................")]
     Ioo(::std::io::Error),
     Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(::std::io::Error),
     Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
         ::std::io::Error,
     ),
+}
+
+// #2389
+pub enum QlError {
+    #[fail(display = "Parsing error: {}", 0)]
+    LexError(parser::lexer::LexError),
+    #[fail(display = "Parsing error: {:?}", 0)]
+    ParseError(parser::ParseError),
+    #[fail(display = "Validation error: {:?}", 0)]
+    ValidationError(Vec<validation::Error>),
+    #[fail(display = "Execution error: {}", 0)]
+    ExecutionError(String),
+    // (from, to)
+    #[fail(display = "Translation error: from {} to {}", 0, 1)]
+    TranslationError(String, String),
+    // (kind, input, expected)
+    #[fail(display = "Could not find {}: Found: {}, expected: {:?}", 0, 1, 2)]
+    ResolveError(&'static str, String, Option<String>),
 }


### PR DESCRIPTION
Closes #2389.

We still put attributes and fields on the same line inside variant (I hope I am using the right terminologies). For example,

```rust
// Attributes on the same line
pub enum Entry<'a, K: 'a, V: 'a> {
    Vacant(#[stable(feature = "rust1", since = "1.0.0")] VacantEntry<'a, K, V>),
    Occupied(#[stable(feature = "rust1", since = "1.0.0")] OccupiedEntry<'a, K, V>),
}

// Attributes on the different line
pub enum Entry<'a, K: 'a, V: 'a> {
    #[stable(feature = "rust1", since = "1.0.0")]
    Vacant(VacantEntry<'a, K, V>),
    #[stable(feature = "rust1", since = "1.0.0")]
    Occupied(OccupiedEntry<'a, K, V>),
}
```