### PR TITLE
Make `is_mod_decl` more accommodating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustfmt-nightly"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cargo_metadata 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfmt-nightly"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Nicholas Cameron <ncameron@mozilla.com>", "The Rustfmt developers"]
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang-nursery/rustfmt"

--- a/src/codemap.rs
+++ b/src/codemap.rs
@@ -48,8 +48,8 @@ pub trait LineRangeUtils {
 
 impl SpanUtils for CodeMap {
     fn span_after(&self, original: Span, needle: &str) -> BytePos {
-        let snippet = self.span_to_snippet(original).unwrap();
-        let offset = snippet.find_uncommented(needle).unwrap() + needle.len();
+        let snippet = self.span_to_snippet(original).expect("Bad snippet");
+        let offset = snippet.find_uncommented(needle).expect("Bad offset") + needle.len();
 
         original.lo() + BytePos(offset as u32)
     }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -44,10 +44,7 @@ pub fn filter_inline_attrs(attrs: &[ast::Attribute], outer_span: Span) -> Vec<as
 /// Returns true for `mod foo;`, false for `mod foo { .. }`.
 fn is_mod_decl(item: &ast::Item) -> bool {
     match item.node {
-        ast::ItemKind::Mod(ref m) => {
-            !(m.inner.lo() == BytePos(0) && m.inner.hi() == BytePos(0))
-                && m.inner.hi() != item.span.hi()
-        }
+        ast::ItemKind::Mod(ref m) => m.inner.hi() != item.span.hi(),
         _ => false,
     }
 }


### PR DESCRIPTION
Fixes #2403 (I think)

r? @topecongiro 

`is_mod_decl` was introduced for the re-ordering modules PR. I think the removed clause is bogus if we are formatting a program passed as a string rather than a file since in that case we have the 0s for `mod foo;`. Simply removing the clause seemed to pass tests, but I'm not sure if you had some use case in mind?