### PR TITLE
Skipping formatting of some configuration snippets

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1931,6 +1931,8 @@ lines are found, they are trimmed down to match this integer.
 Original Code:
 
 ```rust
+#![rustfmt_skip]
+
 fn foo() {
     println!("a");
 }
@@ -1988,6 +1990,8 @@ them, additional blank lines are inserted.
 Original Code (rustfmt will not change it with the default value of `0`):
 
 ```rust
+#![rustfmt_skip]
+
 fn foo() {
     println!("a");
 }


### PR DESCRIPTION
[Configurations.md](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md) contains two snippets ([here](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#example) and [here](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#example-1)) whose format is not meant to verified. The current code in master tries and fails to format those snippets. This PR introduces a mechanism to opt configuration code snippets out of verification.

To opt a snippet out of verification, add `// rustfmt: skip` to the top of the snippet. This is visible when viewing the file through the web UI.

![image](https://user-images.githubusercontent.com/933552/35770587-fe1d2e64-08d2-11e8-96da-4b46df027a94.png)


Here is the output of `cargo test -- --ignored` on master:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `0`: 6 configurations tests failed', tests/system.rs:800:5
```

Here is the output of `cargo test -- --ignored` on the PR branch:
```
---- configuration_snippet_tests stdout ----
        Ran 104 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `0`: 4 configurations tests failed', tests/system.rs:810:5
```

This is part of #1845.