### PR TITLE
Skip rewriting macro def with repeat

### DIFF
--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -332,3 +332,7 @@ macro foo() {
   bar();
   }
 }
+
+macro lex_err($kind: ident $(, $body: expr)*) {
+    Err(QlError::LexError(LexError::$kind($($body,)*)))
+}

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -905,3 +905,7 @@ macro foo() {
         bar();
     }
 }
+
+macro lex_err($kind: ident $(, $body: expr)*) {
+    Err(QlError::LexError(LexError::$kind($($body,)*)))
+}


### PR DESCRIPTION
Formatting macro def with repeat is a bit rough, so just skip it for now. This PR at least avoids panicking reported in #2388.