### PR TITLE
Do not reorder items with '#[macro_use]'

### DIFF
--- a/tests/source/configs/reorder_extern_crates/false.rs
+++ b/tests/source/configs/reorder_extern_crates/false.rs
@@ -1,0 +1,11 @@
+// rustfmt-reorder_extern_crates: false
+
+extern crate foo;
+extern crate bar;
+extern crate foobar;
+
+#[macro_use]
+extern crate nom;
+extern crate regex;
+#[macro_use]
+extern crate log;

--- a/tests/source/configs/reorder_extern_crates/true.rs
+++ b/tests/source/configs/reorder_extern_crates/true.rs
@@ -1,0 +1,11 @@
+// rustfmt-reorder_extern_crates: true
+
+extern crate foo;
+extern crate bar;
+extern crate foobar;
+
+#[macro_use]
+extern crate nom;
+extern crate regex;
+#[macro_use]
+extern crate log;

--- a/tests/target/configs/reorder_extern_crates/false.rs
+++ b/tests/target/configs/reorder_extern_crates/false.rs
@@ -1,0 +1,11 @@
+// rustfmt-reorder_extern_crates: false
+
+extern crate foo;
+extern crate bar;
+extern crate foobar;
+
+#[macro_use]
+extern crate nom;
+extern crate regex;
+#[macro_use]
+extern crate log;

--- a/tests/target/configs/reorder_extern_crates/true.rs
+++ b/tests/target/configs/reorder_extern_crates/true.rs
@@ -1,0 +1,11 @@
+// rustfmt-reorder_extern_crates: true
+
+extern crate bar;
+extern crate foo;
+extern crate foobar;
+
+#[macro_use]
+extern crate nom;
+extern crate regex;
+#[macro_use]
+extern crate log;


### PR DESCRIPTION
Closes #2399.

Currently rustfmt reorders items without attributes. This PR relaxes this rule, and items without `#[macro_use]` will be reordered. AFAIK the only attribute that makes items order-dependent is `#[macro_use]`, so I think this change is safe, but I could easily be wrong.

r? @nrc