### PR TITLE
Use correct offset when unindenting code block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,12 @@ pub fn format_code_block(code_snippet: &str, config: &Config) -> Option<String> 
                     let indent_str =
                         Indent::from_width(config, config.tab_spaces()).to_string(config);
                     if line.starts_with(indent_str.as_ref()) {
-                        &line[config.tab_spaces()..]
+                        let offset = if config.hard_tabs() {
+                            1
+                        } else {
+                            config.tab_spaces()
+                        };
+                        &line[offset..]
                     } else {
                         line
                     }

--- a/tests/target/issue-2401.rs
+++ b/tests/target/issue-2401.rs
@@ -1,0 +1,7 @@
+// rustfmt-hard_tabs = true
+// rustfmt-normalize_comments = true
+
+/// ```
+/// println!("Hello, World!");
+/// ```
+fn main() {}


### PR DESCRIPTION
When using hard tabs, we should only remove `\t`.

Closes #2401.