### PR TITLE
Proposal: add badge for Travis CI example status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rustfmt [![Build Status](https://travis-ci.org/rust-lang-nursery/rustfmt.svg)](https://travis-ci.org/rust-lang-nursery/rustfmt) [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt?svg=true)](https://ci.appveyor.com/project/nrc/rustfmt) [![crates.io](https://img.shields.io/crates/v/rustfmt-nightly.svg)](https://crates.io/crates/rustfmt-nightly)
+# rustfmt [![Build Status](https://travis-ci.org/rust-lang-nursery/rustfmt.svg)](https://travis-ci.org/rust-lang-nursery/rustfmt) [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rustfmt?svg=true)](https://ci.appveyor.com/project/nrc/rustfmt) [![crates.io](https://img.shields.io/crates/v/rustfmt-nightly.svg)](https://crates.io/crates/rustfmt-nightly) [![Travis Configuration Status](https://img.shields.io/travis/davidalber/rustfmt-travis.svg?label=travis%20example)](https://travis-ci.org/davidalber/rustfmt-travis)
 
 A tool for formatting Rust code according to style guidelines.
 
@@ -17,6 +17,11 @@ the `master` branch, however, this only supports nightly toolchains. If you use
 stable or beta Rust toolchains, you must use the Syntex version (which is likely
 to be a bit out of date). Version 0.1 of rustfmt-nightly is forked from version
 0.9 of the syntex branch.
+
+You can use rustfmt in Travis CI builds. We provide a minimal Travis CI
+configuration (see [here](#checking-style-on-a-ci-server)) and verify its status
+using another repository. The status of that repository's build is reported by
+the "travis example" badge above.
 
 
 ## Quick start


### PR DESCRIPTION
I set up a [project](https://github.com/davidalber/rustfmt-travis) that verifies [the minimal Travis CI config from the README](https://github.com/rust-lang-nursery/rustfmt#checking-style-on-a-ci-server). That project's build will fail if the Travis config stops working. It also has a test to verify that its .travis.yml matches the example in the rustfmt README.

This PR adds a badge of the other repository's build so that there will be a visual indicator whether the configuration still works. You can see the live change [here](https://github.com/davidalber/rustfmt/tree/travis-config-badge#checking-style-on-a-ci-server).

![image](https://user-images.githubusercontent.com/933552/36006276-cf73f396-0cf0-11e8-839d-ab97a83ae5f3.png)

It seems like a good idea to me, and I'd like to read comments on it. If you like the idea, but don't want it in a repository outside the organization, I'm happy to help move it.

