### PR TITLE
Fixing `indent_style` control flow examples

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -63,21 +63,24 @@ fn main() {
 #### `"Block"` (default):
 
 ```rust
-if lorem_ipsum &&
-    dolor_sit &&
-    amet_consectetur
-{
-    // ...
+fn main() {
+    if lorem_ipsum && dolor_sit && amet_consectetur && lorem_sit && dolor_consectetur && amet_ipsum
+        && lorem_consectetur
+    {
+        // ...
+    }
 }
 ```
 
 #### `"Visual"`:
 
 ```rust
-if lorem_ipsum &&
-   dolor_sit &&
-   amet_consectetur {
-    // ...
+fn main() {
+    if lorem_ipsum && dolor_sit && amet_consectetur && lorem_sit && dolor_consectetur && amet_ipsum
+       && lorem_consectetur
+    {
+        // ...
+    }
 }
 ```
 


### PR DESCRIPTION
This PR fixes the two [control flow snippets for in Configurations.md](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#control-flow) per the outcome of #2427.

Here is the current output of `cargo test -- --ignored` on master:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `0`: 6 configurations tests failed', tests/system.rs:800:5
```

Here is the output of `cargo test -- --ignored` on the PR branch:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `0`: 4 configurations tests failed', tests/system.rs:800:5
```

This is part of #1845.