### PR TITLE
Removing unused import

### DIFF
--- a/rustfmt-core/tests/lib.rs
+++ b/rustfmt-core/tests/lib.rs
@@ -27,7 +27,6 @@ use std::str::Chars;
 use rustfmt::*;
 use config::{Color, Config, ReportTactic};
 use config::summary::Summary;
-use config::file_lines::FileLines;
 use rustfmt::filemap::write_system_newlines;
 use rustfmt::rustfmt_diff::*;
 


### PR DESCRIPTION
The build is warning about an unused import ([see Line 603 of this build](https://travis-ci.org/rust-lang-nursery/rustfmt/jobs/340285804#L603), for example).
```
   Compiling rustfmt-core v0.4.0 (file:///home/travis/build/rust-lang-nursery/rustfmt/rustfmt-core)
warning: unused import: `config::file_lines::FileLines`
  --> rustfmt-core/tests/lib.rs:30:5
   |
30 | use config::file_lines::FileLines;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default
```

This PR remove the unused import.