### PR TITLE
Fixing path to Configurations.md

### DIFF
--- a/rustfmt-core/tests/lib.rs
+++ b/rustfmt-core/tests/lib.rs
@@ -792,7 +792,7 @@ fn configuration_snippet_tests() {
     // entry for each Rust code block found.
     fn get_code_blocks() -> Vec<ConfigCodeBlock> {
         let mut file_iter = BufReader::new(
-            fs::File::open(CONFIGURATIONS_FILE_NAME)
+            fs::File::open(Path::new("..").join(CONFIGURATIONS_FILE_NAME))
                 .expect(&format!("Couldn't read file {}", CONFIGURATIONS_FILE_NAME)),
         ).lines()
             .map(|l| l.unwrap())


### PR DESCRIPTION
Issue #2419 changed the directory in which `configuration_snippet_tests` runs, which broke the test. Since the test is currently annotated with `#[ignore]`, the break wasn't caught before merge.

Currently, running `cargo test -- --ignored` on master currently yields the following.
```
---- configuration_snippet_tests stdout ----
        thread 'configuration_snippet_tests' panicked at 'Couldn't read file Configurations.md: Os { code: 2, kind: NotFound, message: "No such file or directory" }', libcore/result.rs:945:5
```

Running `cargo test -- --ignored` on the PR branch yields the following.
```
.
.
.
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `0`: 4 configurations tests failed', rustfmt-core/tests/lib.rs:817:5
```