### PR TITLE
Preserve trailing two whitespace in comments

### DIFF
--- a/rustfmt-core/src/comment.rs
+++ b/rustfmt-core/src/comment.rs
@@ -508,11 +508,9 @@ pub fn recover_missing_comment_in_span(
     }
 }
 
-/// Trim trailing whitespaces unless they consist of two whitespaces.
+/// Trim trailing whitespaces unless they consist of two or more whitespaces.
 fn trim_right_unless_two_whitespaces(s: &str, is_doc_comment: bool) -> &str {
-    if is_doc_comment && s.ends_with("  ")
-        && !s.chars().rev().nth(2).map_or(true, char::is_whitespace)
-    {
+    if is_doc_comment && s.ends_with("  ") {
         s
     } else {
         s.trim_right()
@@ -541,7 +539,7 @@ fn light_rewrite_comment(
             } else {
                 ""
             };
-            // Preserve markdown's double-space line break syntax.
+            // Preserve markdown's double-space line break syntax in doc comment.
             trim_right_unless_two_whitespaces(left_trimmed, is_doc_comment)
         })
         .collect();

--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -19,7 +19,7 @@ use syntax::parse::ParseSess;
 use codemap::{LineRangeUtils, SpanUtils};
 use comment::{combine_strs_with_missing_comments, contains_comment, CodeCharKind,
               CommentCodeSlices, FindUncommented};
-use comment::rewrite_comment;
+use comment::rewrite_doc_comment;
 use config::{BraceStyle, Config};
 use expr::rewrite_literal;
 use items::{format_impl, format_trait, format_trait_alias, rewrite_associated_impl_type,
@@ -892,7 +892,7 @@ impl Rewrite for ast::Attribute {
                     .unwrap_or(0),
                 ..shape
             };
-            rewrite_comment(snippet, false, doc_shape, context.config)
+            rewrite_doc_comment(snippet, doc_shape, context.config)
         } else {
             if contains_comment(snippet) {
                 return Some(snippet.to_owned());
@@ -957,7 +957,7 @@ fn rewrite_first_group_attrs(
             .join("\n");
         return Some((
             sugared_docs.len(),
-            rewrite_comment(&snippet, false, shape, context.config)?,
+            rewrite_doc_comment(&snippet, shape, context.config)?,
         ));
     }
     // Rewrite `#[derive(..)]`s.

--- a/rustfmt-core/tests/source/markdown-comment.rs
+++ b/rustfmt-core/tests/source/markdown-comment.rs
@@ -4,7 +4,7 @@
 //! hello world  
 //! hello world 
 
-/// hello world  
+/// hello world    
 /// hello world 
 /// hello world  
 fn foo() {

--- a/rustfmt-core/tests/source/markdown-comment.rs
+++ b/rustfmt-core/tests/source/markdown-comment.rs
@@ -1,8 +1,12 @@
+// Preserve two trailing whitespaces in doc comment,
+// but trim any whitespaces in normal comment.
+
 //! hello world  
 //! hello world 
 
 /// hello world  
 /// hello world 
+/// hello world  
 fn foo() {
     // hello world  
     // hello world 

--- a/rustfmt-core/tests/source/markdown-comment.rs
+++ b/rustfmt-core/tests/source/markdown-comment.rs
@@ -1,0 +1,11 @@
+//! hello world  
+//! hello world 
+
+/// hello world  
+/// hello world 
+fn foo() {
+    // hello world  
+    // hello world 
+    let x = 3;
+    println!("x = {}", x);
+}

--- a/rustfmt-core/tests/target/markdown-comment.rs
+++ b/rustfmt-core/tests/target/markdown-comment.rs
@@ -4,7 +4,7 @@
 //! hello world  
 //! hello world
 
-/// hello world  
+/// hello world    
 /// hello world
 /// hello world  
 fn foo() {

--- a/rustfmt-core/tests/target/markdown-comment.rs
+++ b/rustfmt-core/tests/target/markdown-comment.rs
@@ -1,10 +1,14 @@
+// Preserve two trailing whitespaces in doc comment,
+// but trim any whitespaces in normal comment.
+
 //! hello world  
 //! hello world
 
 /// hello world  
 /// hello world
+/// hello world  
 fn foo() {
-    // hello world  
+    // hello world
     // hello world
     let x = 3;
     println!("x = {}", x);

--- a/rustfmt-core/tests/target/markdown-comment.rs
+++ b/rustfmt-core/tests/target/markdown-comment.rs
@@ -1,0 +1,11 @@
+//! hello world  
+//! hello world
+
+/// hello world  
+/// hello world
+fn foo() {
+    // hello world  
+    // hello world
+    let x = 3;
+    println!("x = {}", x);
+}


### PR DESCRIPTION
Closes #2434.