### PR TITLE
Disable formatting macro-def if args do not fit on one line

### DIFF
--- a/rustfmt-core/tests/source/macro_rules.rs
+++ b/rustfmt-core/tests/source/macro_rules.rs
@@ -49,3 +49,13 @@ macro m2 {
 	mod macro_item    {  struct $item ; }
 }
 }
+
+// #2439
+macro_rules! m {
+    (
+        $line0_xxxxxxxxxxxxxxxxx: expr,
+        $line1_xxxxxxxxxxxxxxxxx: expr,
+        $line2_xxxxxxxxxxxxxxxxx: expr,
+        $line3_xxxxxxxxxxxxxxxxx: expr,
+    ) => {};
+}

--- a/rustfmt-core/tests/target/macro_rules.rs
+++ b/rustfmt-core/tests/target/macro_rules.rs
@@ -41,3 +41,13 @@ macro m2 {
         }
     }
 }
+
+// #2439
+macro_rules! m {
+    (
+        $line0_xxxxxxxxxxxxxxxxx: expr,
+        $line1_xxxxxxxxxxxxxxxxx: expr,
+        $line2_xxxxxxxxxxxxxxxxx: expr,
+        $line3_xxxxxxxxxxxxxxxxx: expr,
+    ) => {};
+}


### PR DESCRIPTION
Closes  #2439.