### PR TITLE
Return `None` when format_code_block may have failed

### DIFF
--- a/rustfmt-core/tests/source/macro_rules.rs
+++ b/rustfmt-core/tests/source/macro_rules.rs
@@ -50,6 +50,15 @@ macro m2 {
 }
 }
 
+
+// #2438
+macro_rules! m {
+    () => {
+        this_line_is_99_characters_long_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+        ); // this line is drifting
+    };
+}
+
 // #2439
 macro_rules! m {
     (

--- a/rustfmt-core/tests/target/macro_rules.rs
+++ b/rustfmt-core/tests/target/macro_rules.rs
@@ -42,6 +42,14 @@ macro m2 {
     }
 }
 
+// #2438
+macro_rules! m {
+    () => {
+        this_line_is_99_characters_long_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+        ); // this line is drifting
+    };
+}
+
 // #2439
 macro_rules! m {
     (


### PR DESCRIPTION
`MacroBranch::rewrite()` assumes that when `format_code_block()` returns `Some(s)`, then `s` is a correctly formatted code block. Currently this is not the case, `format_code_block()` may return `Some(s)` even if if has failed to format the code. This PR tries to fix it by checking the width of each line and if it is not exceeding the max width. 

Closes  #2438.