### PR TITLE
Preserve trailing spaces in doc comments even when options are set

### DIFF
--- a/rustfmt-core/tests/source/markdown-comment-with-options.rs
+++ b/rustfmt-core/tests/source/markdown-comment-with-options.rs
@@ -1,0 +1,17 @@
+// rustfmt-wrap_comments: true
+
+// Preserve two trailing whitespaces in doc comment,
+// but trim any whitespaces in normal comment.
+
+//! hello world  
+//! hello world 
+
+/// hello world    
+/// hello world 
+/// hello world  
+fn foo() {
+    // hello world  
+    // hello world 
+    let x = 3;
+    println!("x = {}", x);
+}

--- a/rustfmt-core/tests/target/markdown-comment-with-options.rs
+++ b/rustfmt-core/tests/target/markdown-comment-with-options.rs
@@ -1,0 +1,17 @@
+// rustfmt-wrap_comments: true
+
+// Preserve two trailing whitespaces in doc comment,
+// but trim any whitespaces in normal comment.
+
+//! hello world  
+//! hello world
+
+/// hello world    
+/// hello world
+/// hello world  
+fn foo() {
+    // hello world
+    // hello world
+    let x = 3;
+    println!("x = {}", x);
+}


### PR DESCRIPTION
Closes #37.