### PR TITLE
Fix #2346: empty comments should not have any trailing space added

### DIFF
--- a/rustfmt-core/src/comment.rs
+++ b/rustfmt-core/src/comment.rs
@@ -466,7 +466,7 @@ fn rewrite_comment_inner(
     }
 
     result.push_str(closer);
-    if result == opener && result.ends_with(' ') {
+    if result.ends_with(opener) && opener.ends_with(' ') {
         // Trailing space.
         result.pop();
     }

--- a/rustfmt-core/tests/target/issue-2346.rs
+++ b/rustfmt-core/tests/target/issue-2346.rs
@@ -1,0 +1,4 @@
+// rustfmt-normalize_comments: true
+// the following empty comment should not have any trailing space added.
+//
+fn main() {}


### PR DESCRIPTION
Fixes #2346

not entirely sure whether that's the right fix, but i guessed so because `result` seems to contain multiple lines of a comment, which makes the equality check come to nothing.