### PR TITLE
Skip formatting macro_rules! that are not using {} 

### DIFF
--- a/rustfmt-core/src/macros.rs
+++ b/rustfmt-core/src/macros.rs
@@ -294,6 +294,9 @@ pub fn rewrite_macro_def(
     span: Span,
 ) -> Option<String> {
     let snippet = Some(remove_trailing_white_spaces(context.snippet(span)));
+    if snippet.as_ref().map_or(true, |s| s.ends_with(";")) {
+        return snippet;
+    }
 
     let mut parser = MacroParser::new(def.stream().into_trees());
     let parsed_def = match parser.parse() {

--- a/rustfmt-core/tests/source/macro_rules.rs
+++ b/rustfmt-core/tests/source/macro_rules.rs
@@ -68,3 +68,12 @@ macro_rules! m {
         $line3_xxxxxxxxxxxxxxxxx: expr,
     ) => {};
 }
+
+// #2466
+// Skip formatting `macro_rules!` that are not using `{}`.
+macro_rules! m (
+    () => ()
+);
+macro_rules! m [
+    () => ()
+];

--- a/rustfmt-core/tests/target/macro_rules.rs
+++ b/rustfmt-core/tests/target/macro_rules.rs
@@ -59,3 +59,12 @@ macro_rules! m {
         $line3_xxxxxxxxxxxxxxxxx: expr,
     ) => {};
 }
+
+// #2466
+// Skip formatting `macro_rules!` that are not using `{}`.
+macro_rules! m (
+    () => ()
+);
+macro_rules! m [
+    () => ()
+];


### PR DESCRIPTION
A body of `macro_rules!` can be surrounded by `{}`, `();` or `[];`. rustfmt can handle the first one, but cannot the others. IMO the latter two are rarely used, so this PR just skip formatting those to avoid panicking.

Closes #2466.