### PR TITLE
Apply optimization suggested by perf

### DIFF
--- a/rustfmt-config/src/file_lines.rs
+++ b/rustfmt-config/src/file_lines.rs
@@ -132,6 +132,11 @@ impl FileLines {
         FileLines(None)
     }
 
+    /// Returns true if this `FileLines` contains all lines in all files.
+    pub fn is_all(&self) -> bool {
+        self.0.is_none()
+    }
+
     pub fn from_ranges(mut ranges: HashMap<FileName, Vec<Range>>) -> FileLines {
         normalize_ranges(&mut ranges);
         FileLines(Some(ranges))

--- a/rustfmt-core/src/chains.rs
+++ b/rustfmt-core/src/chains.rs
@@ -67,8 +67,10 @@ use shape::Shape;
 use utils::{first_line_width, last_line_extendable, last_line_width, mk_sp,
             trimmed_last_line_width, wrap_str};
 
+use std::borrow::Cow;
 use std::cmp::min;
 use std::iter;
+
 use syntax::{ast, ptr};
 use syntax::codemap::Span;
 
@@ -246,13 +248,13 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
 
     let connector = if fits_single_line && !parent_rewrite_contains_newline {
         // Yay, we can put everything on one line.
-        String::new()
+        Cow::from("")
     } else {
         // Use new lines.
         if context.force_one_line_chain {
             return None;
         }
-        format!("\n{}", nested_shape.indent.to_string(context.config))
+        nested_shape.indent.to_string_with_newline(context.config)
     };
 
     let first_connector = if is_small_parent || fits_single_line
@@ -261,7 +263,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
     {
         ""
     } else {
-        connector.as_str()
+        &connector
     };
 
     let result = if is_small_parent && rewrites.len() > 1 {

--- a/rustfmt-core/src/closures.rs
+++ b/rustfmt-core/src/closures.rs
@@ -225,14 +225,14 @@ fn rewrite_closure_fn_decl(
     let ret_str = fn_decl.output.rewrite(context, arg_shape)?;
 
     let arg_items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         fn_decl.inputs.iter(),
         "|",
         ",",
         |arg| span_lo_for_arg(arg),
         |arg| span_hi_for_arg(context, arg),
         |arg| arg.rewrite(context, arg_shape),
-        context.codemap.span_after(span, "|"),
+        context.snippet_provider.span_after(span, "|"),
         body.span.lo(),
         false,
     );

--- a/rustfmt-core/src/codemap.rs
+++ b/rustfmt-core/src/codemap.rs
@@ -68,19 +68,20 @@ impl SpanUtils for CodeMap {
 
 impl LineRangeUtils for CodeMap {
     fn lookup_line_range(&self, span: Span) -> LineRange {
-        let lo = self.lookup_char_pos(span.lo());
-        let hi = self.lookup_char_pos(span.hi());
+        let lo = self.lookup_line(span.lo()).unwrap();
+        let hi = self.lookup_line(span.hi()).unwrap();
 
         assert_eq!(
-            lo.file.name, hi.file.name,
+            lo.fm.name, hi.fm.name,
             "span crossed file boundary: lo: {:?}, hi: {:?}",
             lo, hi
         );
 
+        // Line numbers start at 1
         LineRange {
-            file: lo.file.clone(),
-            lo: lo.line,
-            hi: hi.line,
+            file: lo.fm.clone(),
+            lo: lo.line + 1,
+            hi: hi.line + 1,
         }
     }
 }

--- a/rustfmt-core/src/codemap.rs
+++ b/rustfmt-core/src/codemap.rs
@@ -12,6 +12,7 @@
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
 use config::file_lines::LineRange;
+use visitor::SnippetProvider;
 use syntax::codemap::{BytePos, CodeMap, Span};
 
 use comment::FindUncommented;
@@ -32,7 +33,7 @@ pub trait LineRangeUtils {
     fn lookup_line_range(&self, span: Span) -> LineRange;
 }
 
-impl SpanUtils for CodeMap {
+impl<'a> SpanUtils for SnippetProvider<'a> {
     fn span_after(&self, original: Span, needle: &str) -> BytePos {
         let snippet = self.span_to_snippet(original).expect("Bad snippet");
         let offset = snippet.find_uncommented(needle).expect("Bad offset") + needle.len();
@@ -59,7 +60,7 @@ impl SpanUtils for CodeMap {
     }
 
     fn opt_span_after(&self, original: Span, needle: &str) -> Option<BytePos> {
-        let snippet = self.span_to_snippet(original).ok()?;
+        let snippet = self.span_to_snippet(original)?;
         let offset = snippet.find_uncommented(needle)? + needle.len();
 
         Some(original.lo() + BytePos(offset as u32))

--- a/rustfmt-core/src/codemap.rs
+++ b/rustfmt-core/src/codemap.rs
@@ -71,7 +71,7 @@ impl LineRangeUtils for CodeMap {
         let lo = self.lookup_line(span.lo()).unwrap();
         let hi = self.lookup_line(span.hi()).unwrap();
 
-        assert_eq!(
+        debug_assert_eq!(
             lo.fm.name, hi.fm.name,
             "span crossed file boundary: lo: {:?}, hi: {:?}",
             lo, hi

--- a/rustfmt-core/src/comment.rs
+++ b/rustfmt-core/src/comment.rs
@@ -319,7 +319,7 @@ fn rewrite_comment_inner(
         .width
         .checked_sub(closer.len() + opener.len())
         .unwrap_or(1);
-    let indent_str = shape.indent.to_string(config);
+    let indent_str = shape.indent.to_string_with_newline(config);
     let fmt_indent = shape.indent + (opener.len() - line_start.len());
     let mut fmt = StringFormat {
         opener: "",
@@ -360,7 +360,7 @@ fn rewrite_comment_inner(
     let mut code_block_buffer = String::with_capacity(128);
     let mut is_prev_line_multi_line = false;
     let mut inside_code_block = false;
-    let comment_line_separator = format!("\n{}{}", indent_str, line_start);
+    let comment_line_separator = format!("{}{}", indent_str, line_start);
     let join_code_block_with_comment_line_separator = |s: &str| {
         let mut result = String::with_capacity(s.len() + 128);
         let mut iter = s.lines().peekable();
@@ -408,7 +408,6 @@ fn rewrite_comment_inner(
             } else if is_prev_line_multi_line && !line.is_empty() {
                 result.push(' ')
             } else if is_last && !closer.is_empty() && line.is_empty() {
-                result.push('\n');
                 result.push_str(&indent_str);
             } else {
                 result.push_str(&comment_line_separator);
@@ -520,9 +519,9 @@ pub fn recover_missing_comment_in_span(
         let force_new_line_before_comment =
             missing_snippet[..pos].contains('\n') || total_width > context.config.max_width();
         let sep = if force_new_line_before_comment {
-            format!("\n{}", shape.indent.to_string(context.config))
+            shape.indent.to_string_with_newline(context.config)
         } else {
-            String::from(" ")
+            Cow::from(" ")
         };
         Some(format!("{}{}", sep, missing_comment))
     }
@@ -702,12 +701,6 @@ impl RichChar for char {
 impl RichChar for (usize, char) {
     fn get_char(&self) -> char {
         self.1
-    }
-}
-
-impl RichChar for (char, usize) {
-    fn get_char(&self) -> char {
-        self.0
     }
 }
 

--- a/rustfmt-core/src/imports.rs
+++ b/rustfmt-core/src/imports.rs
@@ -314,14 +314,14 @@ fn rewrite_nested_use_tree(
         // Dummy value, see explanation below.
         let mut items = vec![ListItem::from_str("")];
         let iter = itemize_list(
-            context.codemap,
+            context.snippet_provider,
             trees.iter().map(|tree| &tree.0),
             "}",
             ",",
             |tree| tree.span.lo(),
             |tree| tree.span.hi(),
             |tree| tree.rewrite(context, nested_shape),
-            context.codemap.span_after(span, "{"),
+            context.snippet_provider.span_after(span, "{"),
             span.hi(),
             false,
         );

--- a/rustfmt-core/src/issues.rs
+++ b/rustfmt-core/src/issues.rs
@@ -93,9 +93,17 @@ impl BadIssueSeeker {
         }
     }
 
+    fn is_disabled(&self) -> bool {
+        !is_enabled(self.report_todo) && !is_enabled(self.report_fixme)
+    }
+
     // Check whether or not the current char is conclusive evidence for an
     // unnumbered TO-DO or FIX-ME.
     pub fn inspect(&mut self, c: char) -> Option<Issue> {
+        if self.is_disabled() {
+            return None;
+        }
+
         match self.state {
             Seeking::Issue {
                 todo_idx,

--- a/rustfmt-core/src/issues.rs
+++ b/rustfmt-core/src/issues.rs
@@ -93,17 +93,13 @@ impl BadIssueSeeker {
         }
     }
 
-    fn is_disabled(&self) -> bool {
+    pub fn is_disabled(&self) -> bool {
         !is_enabled(self.report_todo) && !is_enabled(self.report_fixme)
     }
 
     // Check whether or not the current char is conclusive evidence for an
     // unnumbered TO-DO or FIX-ME.
     pub fn inspect(&mut self, c: char) -> Option<Issue> {
-        if self.is_disabled() {
-            return None;
-        }
-
         match self.state {
             Seeking::Issue {
                 todo_idx,

--- a/rustfmt-core/src/lib.rs
+++ b/rustfmt-core/src/lib.rs
@@ -352,7 +352,7 @@ where
             visitor.format_separate_mod(module, &*filemap);
         };
 
-        assert_eq!(
+        debug_assert_eq!(
             visitor.line_number,
             ::utils::count_newlines(&format!("{}", visitor.buffer))
         );
@@ -420,13 +420,14 @@ fn format_lines(
     let mut line_buffer = String::with_capacity(config.max_width() * 2);
     let mut is_string = false; // true if the current line contains a string literal.
     let mut format_line = config.file_lines().contains_line(name, cur_line);
+    let allow_issue_seek = !issue_seeker.is_disabled();
 
     for (kind, (b, c)) in CharClasses::new(text.chars().enumerate()) {
         if c == '\r' {
             continue;
         }
 
-        if format_line {
+        if allow_issue_seek && format_line {
             // Add warnings for bad todos/ fixmes
             if let Some(issue) = issue_seeker.inspect(c) {
                 errors.push(FormattingError {

--- a/rustfmt-core/src/macros.rs
+++ b/rustfmt-core/src/macros.rs
@@ -250,14 +250,14 @@ pub fn rewrite_macro(
                     Some(format!("{}{}{}; {}{}", macro_name, lbr, lhs, rhs, rbr))
                 } else {
                     Some(format!(
-                        "{}{}\n{}{};\n{}{}\n{}{}",
+                        "{}{}{}{};{}{}{}{}",
                         macro_name,
                         lbr,
-                        nested_shape.indent.to_string(context.config),
+                        nested_shape.indent.to_string_with_newline(context.config),
                         lhs,
-                        nested_shape.indent.to_string(context.config),
+                        nested_shape.indent.to_string_with_newline(context.config),
                         rhs,
-                        shape.indent.to_string(context.config),
+                        shape.indent.to_string_with_newline(context.config),
                         rbr
                     ))
                 }
@@ -350,15 +350,14 @@ pub fn rewrite_macro_def(
     };
 
     if multi_branch_style {
-        result += " {\n";
-        result += &arm_shape.indent.to_string(context.config);
+        result += " {";
+        result += &arm_shape.indent.to_string_with_newline(context.config);
     }
 
     result += write_list(&branch_items, &fmt)?.as_str();
 
     if multi_branch_style {
-        result += "\n";
-        result += &indent.to_string(context.config);
+        result += &indent.to_string_with_newline(context.config);
         result += "}";
     }
 

--- a/rustfmt-core/src/macros.rs
+++ b/rustfmt-core/src/macros.rs
@@ -272,7 +272,7 @@ pub fn rewrite_macro(
                 // Convert `MacroArg` into `ast::Expr`, as `rewrite_array` only accepts the latter.
                 let sp = mk_sp(
                     context
-                        .codemap
+                        .snippet_provider
                         .span_after(mac.span, original_style.opener()),
                     mac.span.hi() - BytePos(1),
                 );
@@ -326,14 +326,14 @@ pub fn rewrite_macro_def(
     };
 
     let branch_items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         parsed_def.branches.iter(),
         "}",
         ";",
         |branch| branch.span.lo(),
         |branch| branch.span.hi(),
         |branch| branch.rewrite(context, arm_shape, multi_branch_style),
-        context.codemap.span_after(span, "{"),
+        context.snippet_provider.span_after(span, "{"),
         span.hi(),
         false,
     ).collect::<Vec<_>>();

--- a/rustfmt-core/src/patterns.rs
+++ b/rustfmt-core/src/patterns.rs
@@ -156,14 +156,14 @@ fn rewrite_struct_pat(
         struct_lit_shape(shape, context, path_str.len() + 3, ellipsis_str.len() + 2)?;
 
     let items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         fields.iter(),
         terminator,
         ",",
         |f| f.span.lo(),
         |f| f.span.hi(),
         |f| f.node.rewrite(context, v_shape),
-        context.codemap.span_after(span, "{"),
+        context.snippet_provider.span_after(span, "{"),
         span.hi(),
         false,
     );
@@ -353,14 +353,14 @@ fn count_wildcard_suffix_len(
     let mut suffix_len = 0;
 
     let items: Vec<_> = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         patterns.iter(),
         ")",
         ",",
         |item| item.span().lo(),
         |item| item.span().hi(),
         |item| item.rewrite(context, shape),
-        context.codemap.span_after(span, "("),
+        context.snippet_provider.span_after(span, "("),
         span.hi() - BytePos(1),
         false,
     ).collect();

--- a/rustfmt-core/src/reorder.rs
+++ b/rustfmt-core/src/reorder.rs
@@ -157,7 +157,7 @@ fn rewrite_reorderable_items(
     span: Span,
 ) -> Option<String> {
     let items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         reorderable_items.iter(),
         "",
         ";",

--- a/rustfmt-core/src/shape.rs
+++ b/rustfmt-core/src/shape.rs
@@ -25,7 +25,7 @@ pub struct Indent {
 // INDENT_BUFFER.len() = 80
 const INDENT_BUFFER_LEN: usize = 80;
 const INDENT_BUFFER: &str =
-    "                                                                                ";
+    "\n                                                                               ";
 impl Indent {
     pub fn new(block_indent: usize, alignment: usize) -> Indent {
         Indent {
@@ -74,16 +74,27 @@ impl Indent {
     }
 
     pub fn to_string(&self, config: &Config) -> Cow<'static, str> {
+        self.to_string_inner(config, 1)
+    }
+
+    pub fn to_string_with_newline(&self, config: &Config) -> Cow<'static, str> {
+        self.to_string_inner(config, 0)
+    }
+
+    pub fn to_string_inner(&self, config: &Config, offset: usize) -> Cow<'static, str> {
         let (num_tabs, num_spaces) = if config.hard_tabs() {
             (self.block_indent / config.tab_spaces(), self.alignment)
         } else {
             (0, self.width())
         };
         let num_chars = num_tabs + num_spaces;
-        if num_tabs == 0 && num_chars <= INDENT_BUFFER_LEN {
-            Cow::from(&INDENT_BUFFER[0..num_chars])
+        if num_tabs == 0 && num_chars + offset <= INDENT_BUFFER_LEN {
+            Cow::from(&INDENT_BUFFER[offset..num_chars + 1])
         } else {
-            let mut indent = String::with_capacity(num_chars);
+            let mut indent = String::with_capacity(num_chars + if offset == 0 { 1 } else { 0 });
+            if offset == 0 {
+                indent.push('\n');
+            }
             for _ in 0..num_tabs {
                 indent.push('\t')
             }

--- a/rustfmt-core/src/shape.rs
+++ b/rustfmt-core/src/shape.rs
@@ -81,7 +81,7 @@ impl Indent {
         self.to_string_inner(config, 0)
     }
 
-    pub fn to_string_inner(&self, config: &Config, offset: usize) -> Cow<'static, str> {
+    fn to_string_inner(&self, config: &Config, offset: usize) -> Cow<'static, str> {
         let (num_tabs, num_spaces) = if config.hard_tabs() {
             (self.block_indent / config.tab_spaces(), self.alignment)
         } else {

--- a/rustfmt-core/src/string.rs
+++ b/rustfmt-core/src/string.rs
@@ -55,7 +55,7 @@ pub fn rewrite_string<'a>(
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
     let shape = fmt.shape;
-    let indent = shape.indent.to_string(fmt.config);
+    let indent = shape.indent.to_string_with_newline(fmt.config);
     let punctuation = ":,;.";
 
     // `cur_start` is the position in `orig` of the start of the current line.
@@ -133,7 +133,6 @@ pub fn rewrite_string<'a>(
 
         result.push_str(line);
         result.push_str(fmt.line_end);
-        result.push('\n');
         result.push_str(&indent);
         result.push_str(fmt.line_start);
 

--- a/rustfmt-core/src/types.rs
+++ b/rustfmt-core/src/types.rs
@@ -217,7 +217,9 @@ fn rewrite_segment(
                     .collect::<Vec<_>>();
 
                 let next_span_lo = param_list.last().unwrap().get_span().hi() + BytePos(1);
-                let list_lo = context.codemap.span_after(mk_sp(*span_lo, span_hi), "<");
+                let list_lo = context
+                    .snippet_provider
+                    .span_after(mk_sp(*span_lo, span_hi), "<");
                 let separator = if path_context == PathContext::Expr {
                     "::"
                 } else {
@@ -228,7 +230,7 @@ fn rewrite_segment(
                     generics_shape_from_config(context.config, shape, separator.len())?;
                 let one_line_width = shape.width.checked_sub(separator.len() + 2)?;
                 let items = itemize_list(
-                    context.codemap,
+                    context.snippet_provider,
                     param_list.into_iter(),
                     ">",
                     ",",
@@ -295,7 +297,7 @@ where
     }
 
     let variadic_arg = if variadic {
-        let variadic_start = context.codemap.span_before(span, "...");
+        let variadic_start = context.snippet_provider.span_before(span, "...");
         Some(ArgumentKind::Variadic(variadic_start))
     } else {
         None
@@ -314,9 +316,9 @@ where
         IndentStyle::Visual => shape.indent + 1,
     };
     let list_shape = Shape::legacy(budget, offset);
-    let list_lo = context.codemap.span_after(span, "(");
+    let list_lo = context.snippet_provider.span_after(span, "(");
     let items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         // FIXME Would be nice to avoid this allocation,
         // but I couldn't get the types to work out.
         inputs

--- a/rustfmt-core/src/types.rs
+++ b/rustfmt-core/src/types.rs
@@ -14,7 +14,6 @@ use std::ops::Deref;
 use config::lists::*;
 use syntax::ast::{self, FunctionRetTy, Mutability};
 use syntax::codemap::{self, BytePos, Span};
-use syntax::print::pprust;
 use syntax::symbol::keywords;
 
 use codemap::SpanUtils;
@@ -539,7 +538,7 @@ impl Rewrite for ast::TyParamBound {
 
 impl Rewrite for ast::Lifetime {
     fn rewrite(&self, _: &RewriteContext, _: Shape) -> Option<String> {
-        Some(pprust::lifetime_to_string(self))
+        Some(self.ident.to_string())
     }
 }
 

--- a/rustfmt-core/src/types.rs
+++ b/rustfmt-core/src/types.rs
@@ -784,7 +784,7 @@ pub fn join_bounds(context: &RewriteContext, shape: Shape, type_strs: &[String])
     let result = type_strs.join(joiner);
     if result.contains('\n') || result.len() > shape.width {
         let joiner_indent = shape.indent.block_indent(context.config);
-        let joiner = format!("\n{}+ ", joiner_indent.to_string(context.config));
+        let joiner = format!("{}+ ", joiner_indent.to_string_with_newline(context.config));
         type_strs.join(&joiner)
     } else {
         result

--- a/rustfmt-core/src/utils.rs
+++ b/rustfmt-core/src/utils.rs
@@ -278,10 +278,11 @@ pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
 // Return true if the given span does not intersect with file lines.
 macro_rules! out_of_file_lines_range {
     ($self: ident, $span: expr) => {
-        !$self
-            .config
-            .file_lines()
-            .intersects(&$self.codemap.lookup_line_range($span))
+        !$self.config.file_lines().is_all()
+            && !$self
+                .config
+                .file_lines()
+                .intersects(&$self.codemap.lookup_line_range($span))
     };
 }
 

--- a/rustfmt-core/src/vertical.rs
+++ b/rustfmt-core/src/vertical.rs
@@ -136,7 +136,7 @@ pub fn rewrite_with_alignment<T: AlignedItem>(
         let rest_lo = rest[0].get_span().lo();
         let missing_span = mk_sp(init_hi, rest_lo);
         let missing_span = mk_sp(
-            context.codemap.span_after(missing_span, ","),
+            context.snippet_provider.span_after(missing_span, ","),
             missing_span.hi(),
         );
 
@@ -227,7 +227,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
     }
 
     let items = itemize_list(
-        context.codemap,
+        context.snippet_provider,
         fields.iter(),
         "}",
         ",",

--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -674,8 +674,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         if is_internal {
             match self.config.brace_style() {
                 BraceStyle::AlwaysNextLine => {
-                    let sep_str = format!("\n{}{{", self.block_indent.to_string(self.config));
-                    self.push_str(&sep_str);
+                    let indent_str = self.block_indent.to_string_with_newline(self.config);
+                    self.push_str(&indent_str);
+                    self.push_str("{");
                 }
                 _ => self.push_str(" {"),
             }

--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -680,7 +680,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 _ => self.push_str(" {"),
             }
             // Hackery to account for the closing }.
-            let mod_lo = self.codemap.span_after(source!(self, s), "{");
+            let mod_lo = self.snippet_provider.span_after(source!(self, s), "{");
             let body_snippet =
                 self.snippet(mk_sp(mod_lo, source!(self, m.inner).hi() - BytePos(1)));
             let body_snippet = body_snippet.trim();
@@ -708,7 +708,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     }
 
     pub fn skip_empty_lines(&mut self, end_pos: BytePos) {
-        while let Some(pos) = self.codemap
+        while let Some(pos) = self.snippet_provider
             .opt_span_after(mk_sp(self.last_pos, end_pos), "\n")
         {
             if let Some(snippet) = self.opt_snippet(mk_sp(self.last_pos, pos)) {
@@ -756,7 +756,7 @@ impl Rewrite for ast::MetaItem {
                     .shrink_left(name.len() + 1)
                     .and_then(|s| s.sub_width(2))?;
                 let items = itemize_list(
-                    context.codemap,
+                    context.snippet_provider,
                     list.iter(),
                     ")",
                     ",",


### PR DESCRIPTION
This PR applies some optimizations suggested by `perf` that does not require (I think) fancy modification. 

In total, depending on the code base, this gives 10~30 % speed up compared to the latest master.

rustfmt is already fast enough, so if any of the changes seem to disrupt readability of the code, I am willing to revert them from this PR.