### PR TITLE
Using shorter example for `struct_lit_single_line` option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1630,7 +1630,9 @@ Put small struct literals on a single line
 #### `true` (default):
 
 ```rust
-let lorem = Lorem { ipsum: dolor, sit: amet };
+fn main() {
+    let lorem = Lorem { foo: bar, baz: ofo };
+}
 ```
 
 #### `false`:
@@ -1638,8 +1640,8 @@ let lorem = Lorem { ipsum: dolor, sit: amet };
 ```rust
 fn main() {
     let lorem = Lorem {
-        ipsum: dolor,
-        sit: amet,
+        foo: bar,
+        baz: ofo,
     };
 }
 ```


### PR DESCRIPTION
This PR modifies the `struct_lit_single_line` option configuration snippet examples to be shorter. The current example is not formatted as claimed by Configurations.md, but as discussed in #2458, shorter examples are. This change eliminates one failure in the configuration_snippet_tests test.

Here is the current output of cargo test -- --ignored on master:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `2`,
 right: `0`: 2 configurations tests failed', rustfmt-core/tests/lib.rs:851:5
```

Here is the output of cargo test -- --ignored on the PR branch:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: 1 configurations tests failed', rustfmt-core/tests/lib.rs:851:5
```

This is part of #1845.