### PR TITLE
Return the original snippet if the attribute contains invalid syntax

### DIFF
--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -813,9 +813,11 @@ impl Rewrite for ast::Attribute {
             }
             // 1 = `[`
             let shape = shape.offset_left(prefix.len() + 1)?;
-            self.meta()?
-                .rewrite(context, shape)
-                .map(|rw| format!("{}[{}]", prefix, rw))
+            Some(
+                self.meta()
+                    .and_then(|meta| meta.rewrite(context, shape))
+                    .map_or_else(|| snippet.to_owned(), |rw| format!("{}[{}]", prefix, rw)),
+            )
         }
     }
 }

--- a/rustfmt-core/tests/source/macro_rules.rs
+++ b/rustfmt-core/tests/source/macro_rules.rs
@@ -77,3 +77,11 @@ macro_rules! m (
 macro_rules! m [
     () => ()
 ];
+
+// #2470
+macro foo($type_name: ident, $docs: expr) {
+    #[allow(non_camel_case_types)]
+    #[doc=$docs]
+    #[derive(Debug, Clone, Copy)]
+    pub struct $type_name;
+}

--- a/rustfmt-core/tests/target/macro_rules.rs
+++ b/rustfmt-core/tests/target/macro_rules.rs
@@ -68,3 +68,11 @@ macro_rules! m (
 macro_rules! m [
     () => ()
 ];
+
+// #2470
+macro foo($type_name: ident, $docs: expr) {
+    #[allow(non_camel_case_types)]
+    #[doc=$docs]
+    #[derive(Debug, Clone, Copy)]
+    pub struct $type_name;
+}


### PR DESCRIPTION
This allows us to keep formatting the macro def with attributes that become
invalid syntax when the `$` is replaced with `z`, e.g. `#[doc = $expr]`.

Closes #2470.