### PR TITLE
Update `reorder_extern_crates*` Configuration.md snippets

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1346,6 +1346,7 @@ extern crate sit;
 ```rust
 extern crate lorem;
 extern crate ipsum;
+
 extern crate dolor;
 extern crate sit;
 ```

--- a/Configurations.md
+++ b/Configurations.md
@@ -1360,9 +1360,9 @@ Reorder `extern crate` statements in group
 - **Possible values**: `true`, `false`
 - **Stable**: No
 
-**Note:** This option takes effect only when [`reorder_imports`](#reorder_imports) is set to `true`.
-
 #### `true` (default):
+
+**Note:** This only takes effect when [`reorder_extern_crates`](#reorder_extern_crates) is set to `true`.
 
 ```rust
 extern crate a;
@@ -1376,17 +1376,7 @@ extern crate sit;
 
 #### `false`:
 
-```rust
-extern crate b;
-extern crate a;
-
-extern crate lorem;
-extern crate ipsum;
-extern crate dolor;
-extern crate sit;
-```
-
-See also [`reorder_extern_crates`](#reorder_extern_crates).
+This value has no influence beyond the effect of the [`reorder_extern_crates`](#reorder_extern_crates) option. Set [`reorder_extern_crates`](#reorder_extern_crates) to `false` if you do not want `extern crate` groups to be collapsed and ordered.
 
 ## `report_todo`
 


### PR DESCRIPTION
This PR updates the Configurations.md documentation for the `reorder_extern_crates` and `reorder_extern_crates_in_group` options.

- For `reorder_extern_crates = false` the snippet is updated to demonstrate that `extern crate` groups are not collapsed.
- For `reorder_extern_crates_in_group` the references to `reorder_imports` needing to be `true` is removed because it is not true.
- For `reorder_extern_crates_in_group = true` the need for `reorder_extern_crates` to also be `true` is documented.
- The snippet for `reorder_extern_crates_in_group = false` has been removed and replaced with text explaining that the `false` value for that option has no effect beyond whatever the `reorder_extern_crates` option is set to.

You can see the live version of these changes [here](https://github.com/davidalber/rustfmt/blob/fix-reorder-extern-crates-in-group-examples/Configurations.md#false-5) and [here](https://github.com/davidalber/rustfmt/blob/fix-reorder-extern-crates-in-group-examples/Configurations.md#reorder_extern_crates_in_group).

These changes reduce the number of failing configuration snippets to zero. Here is the current output of cargo test -- --ignored on master:
```
---- configuration_snippet_tests stdout ----
        Ran 106 configurations tests.
thread 'configuration_snippet_tests' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: 1 configurations tests failed', rustfmt-core/tests/lib.rs:851:5
```

Here is the output of cargo test -- --ignored on the PR branch:
```
running 1 test
test configuration_snippet_tests ... ok
```

This is part of #1845.