### PR TITLE
[WIP] Merge imports from the same module

### DIFF
--- a/rustfmt-config/src/lib.rs
+++ b/rustfmt-config/src/lib.rs
@@ -69,6 +69,7 @@ create_config! {
     // Imports
     imports_indent: IndentStyle, IndentStyle::Visual, false, "Indent of imports";
     imports_layout: ListTactic, ListTactic::Mixed, false, "Item layout inside a import block";
+    merge_imports: bool, false, false, "Merge imports from the same module";
 
     // Ordering
     reorder_extern_crates: bool, true, false, "Reorder extern crate statements alphabetically";

--- a/rustfmt-core/src/chains.rs
+++ b/rustfmt-core/src/chains.rs
@@ -67,12 +67,9 @@ use shape::Shape;
 use utils::{first_line_width, last_line_extendable, last_line_width, mk_sp,
             trimmed_last_line_width, wrap_str};
 
-use std::borrow::Cow;
-use std::cmp::min;
-use std::iter;
+use std::{iter, borrow::Cow, cmp::min};
 
-use syntax::{ast, ptr};
-use syntax::codemap::Span;
+use syntax::{ast, ptr, codemap::Span};
 
 pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -> Option<String> {
     debug!("rewrite_chain {:?}", shape);

--- a/rustfmt-core/src/checkstyle.rs
+++ b/rustfmt-core/src/checkstyle.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::{self, Write};
-use std::path::Path;
+use std::{io::{self, Write}, path::Path};
 
 use config::WriteMode;
 use rustfmt_diff::{DiffLine, Mismatch};

--- a/rustfmt-core/src/closures.rs
+++ b/rustfmt-core/src/closures.rs
@@ -9,9 +9,7 @@
 // except according to those terms.
 
 use config::lists::*;
-use syntax::{ast, ptr};
-use syntax::codemap::Span;
-use syntax::parse::classify;
+use syntax::{ast, ptr, codemap::Span, parse::classify};
 
 use codemap::SpanUtils;
 use expr::{block_contains_comment, is_simple_block, is_unsafe_block, rewrite_cond, ToExpr};

--- a/rustfmt-core/src/codemap.rs
+++ b/rustfmt-core/src/codemap.rs
@@ -12,8 +12,8 @@
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
 use config::file_lines::LineRange;
-use visitor::SnippetProvider;
 use syntax::codemap::{BytePos, CodeMap, Span};
+use visitor::SnippetProvider;
 
 use comment::FindUncommented;
 

--- a/rustfmt-core/src/comment.rs
+++ b/rustfmt-core/src/comment.rs
@@ -1117,9 +1117,14 @@ fn remove_comment_header(comment: &str) -> &str {
 
 #[cfg(test)]
 mod test {
-    use super::{contains_comment, rewrite_comment, CharClasses, CodeCharKind, CommentCodeSlices,
-                FindUncommented, FullCodeCharKind};
-    use shape::{Indent, Shape};
+    use CharClasses;
+use CodeCharKind;
+use CommentCodeSlices;
+use FindUncommented;
+use FullCodeCharKind;
+use contains_comment;
+use rewrite_comment;
+use shape::{Indent, Shape};
 
     #[test]
     fn char_classes() {

--- a/rustfmt-core/src/expr.rs
+++ b/rustfmt-core/src/expr.rs
@@ -8,13 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Cow;
-use std::cmp::min;
-use std::iter::repeat;
+use std::{borrow::Cow, cmp::min, iter::repeat};
 
 use config::lists::*;
-use syntax::{ast, ptr};
-use syntax::codemap::{BytePos, CodeMap, Span};
+use syntax::{ast, ptr, codemap::{BytePos, CodeMap, Span}};
 
 use chains::rewrite_chain;
 use closures;
@@ -23,7 +20,8 @@ use comment::{combine_strs_with_missing_comments, contains_comment, recover_comm
               rewrite_comment, rewrite_missing_comment, FindUncommented};
 use config::{Config, ControlBraceStyle, IndentStyle};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
-            struct_lit_shape, struct_lit_tactic, write_list, ListFormatting, ListItem, Separator};
+            struct_lit_shape, struct_lit_tactic, write_list, ListFormatting, ListItem,
+            Separator};
 use macros::{rewrite_macro, MacroArg, MacroPosition};
 use patterns::{can_be_overflowed_pat, TuplePatField};
 use rewrite::{Rewrite, RewriteContext};

--- a/rustfmt-core/src/filemap.rs
+++ b/rustfmt-core/src/filemap.rs
@@ -10,9 +10,7 @@
 
 // TODO: add tests
 
-use std::fs::{self, File};
-use std::io::{self, BufWriter, Read, Write};
-use std::path::Path;
+use std::{fs::{self, File}, io::{self, BufWriter, Read, Write}, path::Path};
 
 use checkstyle::{output_checkstyle_file, output_footer, output_header};
 use config::{Config, NewlineStyle, WriteMode};

--- a/rustfmt-core/src/imports.rs
+++ b/rustfmt-core/src/imports.rs
@@ -11,8 +11,7 @@
 use std::cmp::Ordering;
 
 use config::lists::*;
-use syntax::ast;
-use syntax::codemap::{BytePos, Span};
+use syntax::{ast, codemap::{BytePos, Span}};
 
 use codemap::SpanUtils;
 use config::IndentStyle;

--- a/rustfmt-core/src/items.rs
+++ b/rustfmt-core/src/items.rs
@@ -10,14 +10,11 @@
 
 // Formatting top-level items - functions, structs, enums, traits, impls.
 
-use std::borrow::Cow;
-use std::cmp::min;
+use std::{borrow::Cow, cmp::min};
 
 use config::lists::*;
-use syntax::{abi, ast, ptr, symbol};
-use syntax::ast::{CrateSugar, ImplItem};
-use syntax::codemap::{BytePos, Span};
-use syntax::visit;
+use syntax::{abi, ptr, symbol, visit, ast::{self, CrateSugar, ImplItem},
+             codemap::{BytePos, Span}};
 
 use codemap::{LineRangeUtils, SpanUtils};
 use comment::{combine_strs_with_missing_comments, contains_comment, recover_comment_removed,

--- a/rustfmt-core/src/lib.rs
+++ b/rustfmt-core/src/lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
+#![feature(box_syntax)]
 #![feature(custom_attribute)]
 #![feature(decl_macro)]
 #![feature(match_default_bindings)]

--- a/rustfmt-core/src/lib.rs
+++ b/rustfmt-core/src/lib.rs
@@ -27,20 +27,11 @@ extern crate syntax;
 extern crate term;
 extern crate unicode_segmentation;
 
-use std::collections::HashMap;
-use std::fmt;
-use std::io::{self, stdout, BufRead, Write};
-use std::iter::repeat;
-use std::path::PathBuf;
-use std::rc::Rc;
-use std::time::Duration;
+use std::{fmt, collections::HashMap, io::{self, stdout, BufRead, Write}, iter::repeat,
+          path::PathBuf, rc::Rc, time::Duration};
 
-use errors::{DiagnosticBuilder, Handler};
-use errors::emitter::{ColorConfig, EmitterWriter};
-use syntax::ast;
-use syntax::codemap::{CodeMap, FilePathMapping};
-pub use syntax::codemap::FileName;
-use syntax::parse::{self, ParseSess};
+use errors::{DiagnosticBuilder, Handler, emitter::{ColorConfig, EmitterWriter}};
+use syntax::{ast, codemap::{CodeMap, FileName, FilePathMapping}, parse::{self, ParseSess}};
 
 use checkstyle::{output_footer, output_header};
 use comment::{CharClasses, FullCodeCharKind};
@@ -49,8 +40,7 @@ use shape::Indent;
 use utils::use_colored_tty;
 use visitor::{FmtVisitor, SnippetProvider};
 
-pub use config::Config;
-pub use config::summary::Summary;
+use config::{Config, summary::Summary};
 
 #[macro_use]
 mod utils;
@@ -849,7 +839,9 @@ pub fn run(input: Input, config: &Config) -> Summary {
 
 #[cfg(test)]
 mod test {
-    use super::{format_code_block, format_snippet, Config};
+    use Config;
+use format_code_block;
+use format_snippet;
 
     #[test]
     fn test_no_panic_on_format_snippet_and_format_code_block() {

--- a/rustfmt-core/src/lists.rs
+++ b/rustfmt-core/src/lists.rs
@@ -10,8 +10,7 @@
 
 //! Format list-like expressions and items.
 
-use std::cmp;
-use std::iter::Peekable;
+use std::{cmp, iter::Peekable};
 
 use config::lists::*;
 use syntax::codemap::BytePos;

--- a/rustfmt-core/src/macros.rs
+++ b/rustfmt-core/src/macros.rs
@@ -22,15 +22,11 @@
 use std::collections::HashMap;
 
 use config::lists::*;
-use syntax::ast;
-use syntax::codemap::{BytePos, Span};
-use syntax::parse::new_parser_from_tts;
-use syntax::parse::parser::Parser;
-use syntax::parse::token::{BinOpToken, DelimToken, Token};
-use syntax::print::pprust;
-use syntax::symbol;
-use syntax::tokenstream::{Cursor, ThinTokenStream, TokenStream, TokenTree};
-use syntax::util::ThinVec;
+use syntax::{ast, symbol, codemap::{BytePos, Span},
+             parse::{new_parser_from_tts, parser::Parser,
+                     token::{BinOpToken, DelimToken, Token}},
+             print::pprust, tokenstream::{Cursor, ThinTokenStream, TokenStream, TokenTree},
+             util::ThinVec};
 
 use codemap::SpanUtils;
 use comment::{contains_comment, remove_trailing_white_spaces, FindUncommented};

--- a/rustfmt-core/src/missed_spans.rs
+++ b/rustfmt-core/src/missed_spans.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Cow;
-use std::iter::repeat;
+use std::{borrow::Cow, iter::repeat};
 
 use syntax::codemap::{BytePos, FileName, Pos, Span};
 

--- a/rustfmt-core/src/modules.rs
+++ b/rustfmt-core/src/modules.rs
@@ -8,13 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::BTreeMap;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{io, collections::BTreeMap, path::{Path, PathBuf}};
 
-use syntax::ast;
-use syntax::codemap::{self, FileName};
-use syntax::parse::parser;
+use syntax::{ast, codemap::{self, FileName}, parse::parser};
 
 use utils::contains_skip;
 

--- a/rustfmt-core/src/patterns.rs
+++ b/rustfmt-core/src/patterns.rs
@@ -9,9 +9,8 @@
 // except according to those terms.
 
 use config::lists::*;
-use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
-use syntax::codemap::{self, BytePos, Span};
-use syntax::ptr;
+use syntax::{ptr, ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax},
+             codemap::{self, BytePos, Span}};
 
 use codemap::SpanUtils;
 use comment::FindUncommented;

--- a/rustfmt-core/src/reorder.rs
+++ b/rustfmt-core/src/reorder.rs
@@ -19,9 +19,9 @@
 use config::{Config, lists::*};
 use syntax::{ast, attr, codemap::Span};
 
-use format_code_block;
 use codemap::LineRangeUtils;
 use comment::{combine_strs_with_missing_comments, contains_comment};
+use format_code_block;
 use imports::{path_to_imported_ident, rewrite_import};
 use items::rewrite_mod;
 use lists::{itemize_list, write_list, ListFormatting};
@@ -31,8 +31,7 @@ use spanned::Spanned;
 use utils::mk_sp;
 use visitor::{filter_inline_attrs, is_use_item, rewrite_extern_crate, FmtVisitor};
 
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::{cmp::Ordering, collections::BTreeMap};
 
 fn compare_path_segments(a: &ast::PathSegment, b: &ast::PathSegment) -> Ordering {
     a.identifier.name.as_str().cmp(&b.identifier.name.as_str())

--- a/rustfmt-core/src/reorder.rs
+++ b/rustfmt-core/src/reorder.rs
@@ -19,8 +19,9 @@
 use config::{Config, lists::*};
 use syntax::{ast, attr, codemap::Span};
 
+use format_code_block;
 use codemap::LineRangeUtils;
-use comment::combine_strs_with_missing_comments;
+use comment::{combine_strs_with_missing_comments, contains_comment};
 use imports::{path_to_imported_ident, rewrite_import};
 use items::rewrite_mod;
 use lists::{itemize_list, write_list, ListFormatting};
@@ -28,9 +29,10 @@ use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use spanned::Spanned;
 use utils::mk_sp;
-use visitor::{filter_inline_attrs, rewrite_extern_crate, FmtVisitor};
+use visitor::{filter_inline_attrs, is_use_item, rewrite_extern_crate, FmtVisitor};
 
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 
 fn compare_path_segments(a: &ast::PathSegment, b: &ast::PathSegment) -> Ordering {
     a.identifier.name.as_str().cmp(&b.identifier.name.as_str())
@@ -146,6 +148,116 @@ fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {
     }
 }
 
+/// Collect names in `use` declarations so that we can merge them which come
+/// from the same module.
+#[derive(Debug)]
+struct UseNameTree {
+    subtree: BTreeMap<String, Box<Option<UseNameTree>>>,
+}
+
+impl UseNameTree {
+    pub fn new() -> UseNameTree {
+        UseNameTree {
+            subtree: BTreeMap::new(),
+        }
+    }
+
+    /// Add names that appear in the given `UseTree`.
+    pub fn add_use_tree(&mut self, use_tree: &ast::UseTree) {
+        // 1 = skip root.
+        self.add_use_tree_inner(use_tree, 1)
+    }
+
+    fn add_use_tree_inner(&mut self, use_tree: &ast::UseTree, depth: usize) {
+        if use_tree.prefix.segments.len() == depth {
+            match use_tree.kind {
+                ast::UseTreeKind::Glob => {
+                    self.subtree.insert("*".to_owned(), box None);
+                }
+                ast::UseTreeKind::Simple(_) => {
+                    self.subtree.insert("self".to_owned(), box None);
+                }
+                ast::UseTreeKind::Nested(ref nested_use_trees) => {
+                    for (nested_use_tree, _) in nested_use_trees {
+                        self.add_use_tree_inner(nested_use_tree, 0);
+                    }
+                }
+            };
+            return;
+        }
+        let identifier = use_tree.prefix.segments[depth].identifier.name.to_string();
+        if let Some(box Some(ref mut map)) = self.subtree.get_mut(&identifier) {
+            map.add_use_tree_inner(use_tree, depth + 1);
+            return;
+        }
+        let mut map = UseNameTree::new();
+        map.add_use_tree_inner(use_tree, depth + 1);
+        self.subtree.insert(identifier, box Some(map));
+    }
+
+    fn to_string_simple_inner(
+        &self,
+        shape: Shape,
+        context: &RewriteContext,
+        mut result: &mut String,
+    ) {
+        for (seg, map) in &self.subtree {
+            result.push_str(seg);
+            if let box Some(ref map) = map {
+                result.push_str("::{");
+                let nested_shape = shape.block_indent(context.config.tab_spaces());
+                result.push_str(&nested_shape.indent.to_string_with_newline(context.config));
+                map.to_string_simple_inner(nested_shape, context, &mut result);
+                result.push_str(&shape.indent.to_string_with_newline(context.config));
+                result.push('}');
+            }
+            result.push_str(", ");
+        }
+    }
+
+    /// Converts this `UseNameTree` to merged `use` declarations. The produced
+    /// string is syntactically correct, but is not properly formatted.
+    // FIXME: Currently we call `format_code_block` after creating a string with
+    // this method. Instead, it would be nice if this method can format the
+    // string by itself.
+    pub fn to_string_simple(&self, shape: Shape, context: &RewriteContext) -> String {
+        let mut result = String::with_capacity(256);
+        for (seg, map) in &self.subtree {
+            result.push_str("use ");
+            let nested_shape = shape.block_indent(context.config.tab_spaces());
+            result.push_str(seg);
+            result.push_str("::{");
+            result.push_str(&nested_shape.indent.to_string_with_newline(context.config));
+            if let box Some(ref map) = map {
+                map.to_string_simple_inner(nested_shape, context, &mut result);
+            }
+            result.push_str(&shape.indent.to_string_with_newline(context.config));
+            result.push_str("};\n");
+        }
+        result
+    }
+}
+
+/// Format `use` declarations. If two or more `use` declarations are from the same module,
+/// those will be merged into a single declaration.
+///
+/// Before calling this function, make sure that there are no comments
+/// among/within any `use` declarations.
+fn rewrite_use_items_with_merge(
+    context: &RewriteContext,
+    use_items: Vec<&ast::UseTree>,
+    shape: Shape,
+) -> Option<String> {
+    let mut use_name_tree = UseNameTree::new();
+    for use_item in use_items {
+        use_name_tree.add_use_tree(use_item);
+    }
+    let snippet = use_name_tree.to_string_simple(shape, context);
+    let mut config = context.config.clone();
+    config.set().merge_imports(false);
+    format_code_block(&snippet, &config)
+}
+
 /// Rewrite a list of items with reordering. Every item in `items` must have
 /// the same `ast::ItemKind`.
 // TODO (some day) remove unused imports, expand globs, compress many single
@@ -156,6 +268,28 @@ fn rewrite_reorderable_items(
     shape: Shape,
     span: Span,
 ) -> Option<String> {
+    // Try to merge `use` declarations from the same module if there are no
+    // comments among declarations.
+    if context.config.merge_imports() && !contains_comment(context.snippet(span))
+        && is_use_item(reorderable_items[0])
+    {
+        fn get_use_tree<'a>(item: &&'a ast::Item) -> &'a ast::UseTree {
+            match item.node {
+                ast::ItemKind::Use(ref use_tree) => use_tree,
+                _ => unreachable!(),
+            }
+        }
+
+        return rewrite_use_items_with_merge(
+            context,
+            reorderable_items
+                .iter()
+                .map(get_use_tree)
+                .collect::<Vec<_>>(),
+            shape,
+        );
+    }
+
     let items = itemize_list(
         context.snippet_provider,
         reorderable_items.iter(),

--- a/rustfmt-core/src/rewrite.rs
+++ b/rustfmt-core/src/rewrite.rs
@@ -10,8 +10,7 @@
 
 // A generic trait to abstract the rewriting of an element (of the AST).
 
-use syntax::codemap::{CodeMap, Span};
-use syntax::parse::ParseSess;
+use syntax::{codemap::{CodeMap, Span}, parse::ParseSess};
 
 use config::{Config, IndentStyle};
 use shape::Shape;

--- a/rustfmt-core/src/rustfmt_diff.rs
+++ b/rustfmt-core/src/rustfmt_diff.rs
@@ -10,10 +10,8 @@
 
 use config::Color;
 use diff;
-use std::collections::VecDeque;
-use std::io;
+use std::{collections::VecDeque, io::{self, Write}};
 use term;
-use std::io::Write;
 use utils::use_colored_tty;
 
 #[derive(Debug, PartialEq)]
@@ -211,8 +209,9 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{make_diff, Mismatch};
-    use super::DiffLine::*;
+    use DiffLine::*;
+use Mismatch;
+use make_diff;
 
     #[test]
     fn diff_simple() {

--- a/rustfmt-core/src/shape.rs
+++ b/rustfmt-core/src/shape.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Cow;
-use std::ops::{Add, Sub};
+use std::{borrow::Cow, ops::{Add, Sub}};
 
 use Config;
 

--- a/rustfmt-core/src/spanned.rs
+++ b/rustfmt-core/src/spanned.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syntax::ast;
-use syntax::codemap::Span;
+use syntax::{ast, codemap::Span};
 
 use macros::MacroArg;
 use utils::{mk_sp, outer_attributes};

--- a/rustfmt-core/src/string.rs
+++ b/rustfmt-core/src/string.rs
@@ -150,8 +150,9 @@ pub fn rewrite_string<'a>(
 
 #[cfg(test)]
 mod test {
-    use super::{rewrite_string, StringFormat};
-    use shape::{Indent, Shape};
+    use StringFormat;
+use rewrite_string;
+use shape::{Indent, Shape};
 
     #[test]
     fn issue343() {

--- a/rustfmt-core/src/types.rs
+++ b/rustfmt-core/src/types.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::iter::ExactSizeIterator;
-use std::ops::Deref;
+use std::{iter::ExactSizeIterator, ops::Deref};
 
 use config::lists::*;
-use syntax::ast::{self, FunctionRetTy, Mutability};
-use syntax::codemap::{self, BytePos, Span};
-use syntax::symbol::keywords;
+use syntax::{ast::{self, FunctionRetTy, Mutability}, codemap::{self, BytePos, Span},
+             symbol::keywords};
 
 use codemap::SpanUtils;
 use config::{IndentStyle, TypeDensity};

--- a/rustfmt-core/src/utils.rs
+++ b/rustfmt-core/src/utils.rs
@@ -10,10 +10,10 @@
 
 use std::borrow::Cow;
 
-use syntax::{abi, ptr};
-use syntax::ast::{self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem,
-                  NestedMetaItemKind, Path, Visibility};
-use syntax::codemap::{BytePos, Span, NO_EXPANSION};
+use syntax::{abi, ptr,
+             ast::{self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem,
+                   NestedMetaItemKind, Path, Visibility},
+             codemap::{BytePos, Span, NO_EXPANSION}};
 
 use config::Color;
 use rewrite::RewriteContext;

--- a/rustfmt-core/src/vertical.rs
+++ b/rustfmt-core/src/vertical.rs
@@ -13,8 +13,7 @@
 use std::cmp;
 
 use config::lists::*;
-use syntax::ast;
-use syntax::codemap::{BytePos, Span};
+use syntax::{ast, codemap::{BytePos, Span}};
 
 use codemap::SpanUtils;
 use comment::{combine_strs_with_missing_comments, contains_comment};

--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -49,7 +49,7 @@ fn is_mod_decl(item: &ast::Item) -> bool {
     }
 }
 
-fn is_use_item(item: &ast::Item) -> bool {
+pub fn is_use_item(item: &ast::Item) -> bool {
     match item.node {
         ast::ItemKind::Use(_) => true,
         _ => false,

--- a/rustfmt-core/src/visitor.rs
+++ b/rustfmt-core/src/visitor.rs
@@ -11,15 +11,12 @@
 use std::cmp;
 
 use config::lists::*;
-use syntax::{ast, visit};
-use syntax::attr::HasAttrs;
-use syntax::codemap::{self, BytePos, CodeMap, Pos, Span};
-use syntax::parse::ParseSess;
+use syntax::{ast, visit, attr::HasAttrs, codemap::{self, BytePos, CodeMap, Pos, Span},
+             parse::ParseSess};
 
 use codemap::{LineRangeUtils, SpanUtils};
-use comment::{combine_strs_with_missing_comments, contains_comment, CodeCharKind,
-              CommentCodeSlices, FindUncommented};
-use comment::rewrite_doc_comment;
+use comment::{combine_strs_with_missing_comments, contains_comment, rewrite_doc_comment,
+              CodeCharKind, CommentCodeSlices, FindUncommented};
 use config::{BraceStyle, Config};
 use expr::rewrite_literal;
 use items::{format_impl, format_trait, format_trait_alias, rewrite_associated_impl_type,

--- a/rustfmt-core/tests/source/configs/merge_imports/false.rs
+++ b/rustfmt-core/tests/source/configs/merge_imports/false.rs
@@ -1,0 +1,8 @@
+// rustfmt-merge_imports: false
+
+use std::time::Duration;
+use foo::{a::b::c::{self, *}, a::b::{d, e, f}};
+use foo::bar;
+use foo::bar::foo;
+use foo::bar::yoo;
+use std::time::Instant;

--- a/rustfmt-core/tests/source/configs/merge_imports/true.rs
+++ b/rustfmt-core/tests/source/configs/merge_imports/true.rs
@@ -1,0 +1,9 @@
+// rustfmt-merge_imports: true
+// rustfmt-reorder_imports: true
+
+use std::time::Duration;
+use foo::{a::b::c::{self, *}, a::b::{d, e, f}};
+use foo::bar;
+use foo::bar::foo;
+use foo::bar::yoo;
+use std::time::Instant;

--- a/rustfmt-core/tests/target/configs/merge_imports/false.rs
+++ b/rustfmt-core/tests/target/configs/merge_imports/false.rs
@@ -1,0 +1,8 @@
+// rustfmt-merge_imports: false
+
+use std::time::Duration;
+use foo::{a::b::c::{self, *}, a::b::{d, e, f}};
+use foo::bar;
+use foo::bar::foo;
+use foo::bar::yoo;
+use std::time::Instant;

--- a/rustfmt-core/tests/target/configs/merge_imports/true.rs
+++ b/rustfmt-core/tests/target/configs/merge_imports/true.rs
@@ -1,0 +1,5 @@
+// rustfmt-merge_imports: true
+// rustfmt-reorder_imports: true
+
+use foo::{a::b::{d, e, f, c::{self, *}}, bar::{self, foo, yoo}};
+use std::time::{Duration, Instant};


### PR DESCRIPTION
This PR adds a `merge_imports` config option. 
When this option is enabled, rustfmt will merge `use` declarations from the same module.

The implementation is limited in several ways:
1. It does not merge imports if there are comments within or among them.
2. ~The `merge_imports` only works when `reorder_imports` is set to `ture`.~

Closes #1383.
Closes #2452.

**EDIT**: `merge_imports` does take effect on its own, but still need some work and more tests.