### PR TITLE
Removing ignore attribute

### DIFF
--- a/rustfmt-core/tests/lib.rs
+++ b/rustfmt-core/tests/lib.rs
@@ -820,7 +820,6 @@ impl ConfigCodeBlock {
 }
 
 #[test]
-#[ignore]
 fn configuration_snippet_tests() {
     // Read Configurations.md and build a `Vec` of `ConfigCodeBlock` structs with one
     // entry for each Rust code block found.


### PR DESCRIPTION
With #2472 closed, all configuration snippet tests are passing. This PR removes the `#[ignore]` attribute from the test to turn it on for everyone and closes #1845. :shipit: