### PR TITLE
Explict version info

### DIFF
--- a/rustfmt-bin/build.rs
+++ b/rustfmt-bin/build.rs
@@ -27,8 +27,16 @@ fn main() {
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
     match (commit_hash(), commit_date()) {
-        (Some(hash), Some(date)) => format!(" ({} {})", hash.trim_right(), date),
+        (Some(hash), Some(date)) => format!("{} ({} {})", channel(), hash.trim_right(), date),
         _ => String::new(),
+    }
+}
+
+fn channel() -> String {
+    if let Ok(channel) = env::var("CFG_RELEASE_CHANNEL") {
+        channel
+    } else {
+        "nightly".to_owned()
     }
 }
 

--- a/rustfmt-bin/build.rs
+++ b/rustfmt-bin/build.rs
@@ -26,8 +26,8 @@ fn main() {
 // Try to get hash and date of the last commit on a best effort basis. If anything goes wrong
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
-    match (commit_hash(), commit_date()) {
-        (Some(hash), Some(date)) => format!("{} ({} {})", channel(), hash.trim_right(), date),
+    match (channel(), commit_hash(), commit_date()) {
+        (channel, Some(hash), Some(date)) => format!("{} ({} {})", channel, hash.trim_right(), date),
         _ => String::new(),
     }
 }

--- a/rustfmt-bin/src/main.rs
+++ b/rustfmt-bin/src/main.rs
@@ -387,10 +387,13 @@ fn print_usage_to_stdout(opts: &Options, reason: &str) {
 
 fn print_version() {
     println!(
-        "{}-nightly{}",
-        option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
-        include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
-    )
+        "rustfmt {}",
+        concat!(
+            env!("CARGO_PKG_VERSION"),
+            "-",
+            include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
+        )
+    );
 }
 
 fn determine_operation(matches: &Matches) -> FmtResult<Operation> {

--- a/rustfmt-bin/src/main.rs
+++ b/rustfmt-bin/src/main.rs
@@ -386,14 +386,14 @@ fn print_usage_to_stdout(opts: &Options, reason: &str) {
 }
 
 fn print_version() {
-    println!(
-        "rustfmt {}",
-        concat!(
-            env!("CARGO_PKG_VERSION"),
-            "-",
-            include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
-        )
+    let version_info = format!(
+        "{}{}{}",
+        option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
+        "-",
+        include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
     );
+
+    println!("rustfmt {}", version_info);
 }
 
 fn determine_operation(matches: &Matches) -> FmtResult<Operation> {


### PR DESCRIPTION
should resolve #2451

before:
```
0.4.0-nightly (383e7e99 2018-02-19)
```
after this commit, `channel(nightly|beta|stable)` will not be hard-coded into version info anymore.
```
rustfmt 0.4.0-nightly (e87c2cae 2018-02-21)
```
