### PR TITLE
Error on outdated Configurations.md

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -579,23 +579,13 @@ Don't reformat anything
 
 ## `error_on_line_overflow`
 
-Error if unable to get all lines within `max_width`
+Error if unable to get all lines within `max_width`, except for comments and string literals.
 
 - **Default value**: `true`
 - **Possible values**: `true`, `false`
 - **Stable**: No
 
 See also [`max_width`](#max_width).
-
-## `error_on_line_overflow_comments`
-
-Error if unable to get all comment lines within `comment_width`.
-
-- **Default value**: `true`
-- **Possible values**: `true`, `false`
-- **Stable**: No
-
-See also [`comment_width`](#comment_width).
 
 ## `fn_args_density`
 
@@ -1378,6 +1368,41 @@ extern crate sit;
 #### `false`:
 
 This value has no influence beyond the effect of the [`reorder_extern_crates`](#reorder_extern_crates) option. Set [`reorder_extern_crates`](#reorder_extern_crates) to `false` if you do not want `extern crate` groups to be collapsed and ordered.
+
+## `reorder_modules`
+
+Reorder `mod` declarations alphabetically in group.
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+#### `true`
+
+```rust
+mod a;
+mod b;
+
+mod dolor;
+mod ipsum;
+mod lorem;
+mod sit;
+```
+
+#### `false`
+
+```rust
+mod b;
+mod a;
+
+mod lorem;
+mod ipsum;
+mod dolor;
+mod sit;
+```
+
+**Note** `mod` with `#[macro_export]` will not be reordered since that could change the semantic
+of the original source code.
 
 ## `report_todo`
 

--- a/rustfmt-core/tests/lib.rs
+++ b/rustfmt-core/tests/lib.rs
@@ -17,7 +17,7 @@ extern crate rustfmt_config as config;
 extern crate rustfmt_core as rustfmt;
 extern crate term;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read};
 use std::iter::{Enumerate, Peekable};
@@ -795,6 +795,7 @@ impl ConfigCodeBlock {
     fn extract<I: Iterator<Item = String>>(
         file: &mut Enumerate<I>,
         prev: Option<&ConfigCodeBlock>,
+        hash_set: &mut HashSet<String>,
     ) -> Option<ConfigCodeBlock> {
         let mut code_block = ConfigCodeBlock::new();
         code_block.config_name = prev.and_then(|cb| cb.config_name.clone());
@@ -806,6 +807,16 @@ impl ConfigCodeBlock {
                     break;
                 }
                 Some(ConfigurationSection::ConfigName(name)) => {
+                    assert!(
+                        Config::is_valid_name(&name),
+                        "an unknown configuration option was found: {}",
+                        name
+                    );
+                    assert!(
+                        hash_set.remove(&name),
+                        "multiple configuration guides found for option {}",
+                        name
+                    );
                     code_block.set_config_name(Some(name));
                 }
                 Some(ConfigurationSection::ConfigValue(value)) => {
@@ -831,9 +842,18 @@ fn configuration_snippet_tests() {
             .map(|l| l.unwrap())
             .enumerate();
         let mut code_blocks: Vec<ConfigCodeBlock> = Vec::new();
+        let mut hash_set = HashSet::new();
 
-        while let Some(cb) = ConfigCodeBlock::extract(&mut file_iter, code_blocks.last()) {
+        while let Some(cb) =
+            ConfigCodeBlock::extract(&mut file_iter, code_blocks.last(), &mut hash_set)
+        {
             code_blocks.push(cb);
+        }
+
+        for name in hash_set {
+            if !Config::is_hidden_option(&name) {
+                panic!("{} does not have a configuration guide", name);
+            }
         }
 
         code_blocks


### PR DESCRIPTION
This PR updates `configuration_snippet_tests` to catch outdated Configurations.md.

1. Error if there is an unknown configuration option in Configuration.md.
2. Error if there are multiple guides for the same configuration option in
   Configuration.md.
3. Error if an user-facing configuration option does not have its guide in
   Configuration.md.

Should prevent issues like #2459.

cc @davidalber, thank you for creating an infrastructure for testing Configurations.md in the first place!