### PR TITLE
Preserve trailing comma on macro in item position 

### DIFF
--- a/rustfmt-core/src/macros.rs
+++ b/rustfmt-core/src/macros.rs
@@ -278,8 +278,12 @@ pub fn rewrite_macro(
                 );
                 let arg_vec = &arg_vec.iter().map(|e| &*e).collect::<Vec<_>>()[..];
                 let rewrite = rewrite_array(arg_vec, sp, context, mac_shape, trailing_comma)?;
+                let comma = match position {
+                    MacroPosition::Item => ";",
+                    _ => "",
+                };
 
-                Some(format!("{}{}", macro_name, rewrite))
+                Some(format!("{}{}{}", macro_name, rewrite, comma))
             }
         }
         MacroStyle::Braces => {

--- a/rustfmt-core/tests/source/macros.rs
+++ b/rustfmt-core/tests/source/macros.rs
@@ -336,3 +336,7 @@ macro foo() {
 macro lex_err($kind: ident $(, $body: expr)*) {
     Err(QlError::LexError(LexError::$kind($($body,)*)))
 }
+
+// Preserve trailing comma on item-level macro with `()` or `[]`.
+methods![ get, post, delete, ];
+methods!( get, post, delete, );

--- a/rustfmt-core/tests/target/macros.rs
+++ b/rustfmt-core/tests/target/macros.rs
@@ -911,3 +911,7 @@ macro foo() {
 macro lex_err($kind: ident $(, $body: expr)*) {
     Err(QlError::LexError(LexError::$kind($($body,)*)))
 }
+
+// Preserve trailing comma on item-level macro with `()` or `[]`.
+methods![get, post, delete,];
+methods!(get, post, delete,);


### PR DESCRIPTION
Closes #2487.