### PR TITLE
Remove cargo-fmt and rustfmt-bin from self_tests()

### DIFF
--- a/rustfmt-core/tests/lib.rs
+++ b/rustfmt-core/tests/lib.rs
@@ -211,12 +211,7 @@ fn idempotence_tests() {
 #[test]
 fn self_tests() {
     let mut files = get_test_files(Path::new("tests"), false);
-    let bin_directories = vec![
-        "cargo-fmt",
-        "git-rustfmt",
-        "rustfmt-bin",
-        "rustfmt-format-diff",
-    ];
+    let bin_directories = vec!["git-rustfmt", "rustfmt-format-diff"];
     for dir in bin_directories {
         let mut path = PathBuf::from("..");
         path.push(dir);


### PR DESCRIPTION
`cargo test` currently fails with:

```
---- self_tests stdout ----
	thread 'self_tests' panicked at 'Couldn't read file ../cargo-bin/src/main.rs: Os { code: 2, kind: NotFound, message: "No such file or directory" }', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

and

```
---- self_tests stdout ----
	thread 'self_tests' panicked at 'Couldn't read file ../rustfmt-bin/src/main.rs: Os { code: 2, kind: NotFound, message: "No such file or directory" }', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

I suppose in light of 9d2229f2fdf59b1cc80aea8851e14db81c55c82f, `self_tests()` should be updated?