### PR TITLE
Fixing macOS Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ addons:
 before_script:
 - |
   if [ $TRAVIS_OS_NAME = 'osx' ]; then
-    brew install python3 &&
-    virtualenv env -p python3 &&
+    virtualenv env &&
     source env/bin/activate &&
+    python --version &&
     pip install 'travis-cargo<0.2'
   else
     pip install 'travis-cargo<0.2' --user &&


### PR DESCRIPTION
The macOS Travis build is broken. I believe the cause is [Homebrew changed the `python` formula to be Python 3](https://brew.sh/2018/01/19/homebrew-1.5.0/). Thus, when we try to `brew install python3` we are really trying install the `python` target, which is already (currently) Python 2 in the Travis image.

I first tried fixing this by upgrading the `python` formula. This added a lot of time to the build, and wasn't quite working before I realized that `travis-cargo` does not care whether it's executing in a Python 2 or Python 3 interpreter. Thus, I just dropped the whole "try to get a Python 3 virtual environment" angle. Currently, this is running using Python 2, but I suspect that Travis will update the image sometime and it will then by Python 3.