### PR TITLE
Only format code blocks in comments with rust syntax notation

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -395,7 +395,7 @@ fn rewrite_comment_inner(
 
             continue;
         } else {
-            inside_code_block = line.starts_with("```");
+            inside_code_block = line.starts_with("```rust");
 
             if result == opener {
                 let force_leading_whitespace = opener == "/* " && count_newlines(orig) == 0;


### PR DESCRIPTION
Closes #2494.

I am not sure how to test this, so no tests are included in this PR :disappointed:  