### PR TITLE
Overflow the last rhs of a binary expression

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -352,13 +352,15 @@ where
         .and_then(|s| s.sub_width(pp.suffix.len()))
         .and_then(|rhs_shape| rhs.rewrite(context, rhs_shape));
     if let Some(ref rhs_result) = rhs_orig_result {
-        // If the rhs looks like block expression, we allow it to stay on the same line
-        // with the lhs even if it is multi-lined.
-        let allow_same_line = rhs_result
-            .lines()
-            .next()
-            .map(|first_line| first_line.ends_with('{'))
-            .unwrap_or(false);
+        // If the length of the lhs is equal to or shorter than the tab width or
+        // the rhs looks like block expression, we put the rhs on the same
+        // line with the lhs even if the rhs is multi-lined.
+        let allow_same_line = lhs_result.len() <= context.config.tab_spaces()
+            || rhs_result
+                .lines()
+                .next()
+                .map(|first_line| first_line.ends_with('{'))
+                .unwrap_or(false);
         if !rhs_result.contains('\n') || allow_same_line {
             let one_line_width = last_line_width(&lhs_result) + pp.infix.len()
                 + first_line_width(rhs_result) + pp.suffix.len();

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -370,3 +370,17 @@ fn newlines_between_list_like_expr() {
 fn issue2178() {
     Ok(result.iter().map(|item| ls_util::rls_to_location(item)).collect())
 }
+
+// #2493
+impl Foo {
+fn bar(&self) {
+    {
+        let x = match () {
+            () => {
+                let i;
+                i == self.install_config.storage.experimental_compressed_block_size as usize
+            }
+        };
+    }
+}
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -395,3 +395,19 @@ fn issue2178() {
         .map(|item| ls_util::rls_to_location(item))
         .collect())
 }
+
+// #2493
+impl Foo {
+    fn bar(&self) {
+        {
+            let x = match () {
+                () => {
+                    let i;
+                    i == self.install_config
+                        .storage
+                        .experimental_compressed_block_size as usize
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
**EDIT**: this is no longer true.

---

This PR allows the **last** rhs of a binary expression to be overflowed if it is a **chain**. 

We do not want to overflow the rhs of a binary expression that is inside the other binary expression. For example, we do not want to do these:

```diff
-        self.inner_as_ref().contains('\n')
-            || self.pre_comment
-                .as_ref()
-                .map_or(false, |s| s.contains('\n'))
-            || self.post_comment
-                .as_ref()
-                .map_or(false, |s| s.contains('\n'))
+        self.inner_as_ref().contains('\n') || self.pre_comment
+            .as_ref()
+            .map_or(false, |s| s.contains('\n')) || self.post_comment
+            .as_ref()
+            .map_or(false, |s| s.contains('\n'))
```

```diff
-                if !forbid_same_line⏎
-                    && (is_block⏎
-                        || (!body_str.contains('\n') && body_str.len() <= body_shape.width)) =>⏎
+                if !forbid_same_line && (is_block⏎
+                    || (!body_str.contains('\n') && body_str.len() <= body_shape.width)) =>⏎
```

Closes #2493.