### PR TITLE
Restore cargo fmt behavior in workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = "0.4"
 env_logger = "0.5"
 getopts = "0.2"
 derive-new = "0.5"
-cargo_metadata = "0.5"
+cargo_metadata = "0.5.1"
 rustc-ap-syntax = "60.0.0"
 rustc-ap-rustc_errors = "60.0.0"
 

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -249,10 +249,16 @@ fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error
 
 fn get_targets_root_only(targets: &mut HashSet<Target>) -> Result<(), io::Error> {
     let metadata = get_cargo_metadata(None)?;
+    let current_dir = env::current_dir()?;
+    let current_dir_manifest = current_dir.join("Cargo.toml");
+    let workspace_root_path = PathBuf::from(&metadata.workspace_root);
+    let in_workspace_root = workspace_root_path == current_dir;
 
     for package in metadata.packages {
-        for target in package.targets {
-            targets.insert(Target::from_target(&target));
+        if in_workspace_root || PathBuf::from(&package.manifest_path) == current_dir_manifest {
+            for target in package.targets {
+                targets.insert(Target::from_target(&target));
+            }
         }
     }
 

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -249,9 +249,9 @@ fn get_targets(strategy: &CargoFmtStrategy) -> Result<HashSet<Target>, io::Error
 
 fn get_targets_root_only(targets: &mut HashSet<Target>) -> Result<(), io::Error> {
     let metadata = get_cargo_metadata(None)?;
-    let current_dir = env::current_dir()?;
+    let current_dir = env::current_dir()?.canonicalize()?;
     let current_dir_manifest = current_dir.join("Cargo.toml");
-    let workspace_root_path = PathBuf::from(&metadata.workspace_root);
+    let workspace_root_path = PathBuf::from(&metadata.workspace_root).canonicalize()?;
     let in_workspace_root = workspace_root_path == current_dir;
 
     for package in metadata.packages {


### PR DESCRIPTION
Previously, cargo fmt  invoked without parameters would
only format the crate in the current directory, even if
the crate was part of a workspace. This patch restores
that behavior.