### PR TITLE
Make rewrite_call_inner more generic

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -251,7 +251,7 @@ pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -
         Cow::from("")
     } else {
         // Use new lines.
-        if context.force_one_line_chain {
+        if *context.force_one_line_chain.borrow() {
             return None;
         }
         nested_shape.indent.to_string_with_newline(context.config)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2643,3 +2643,13 @@ impl<'a> ToExpr for MacroArg {
         }
     }
 }
+
+impl ToExpr for ast::GenericParam {
+    fn to_expr(&self) -> Option<&ast::Expr> {
+        None
+    }
+
+    fn can_be_overflowed(&self, _: &RewriteContext, _: usize) -> bool {
+        false
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1936,9 +1936,13 @@ pub fn rewrite_call(
         span,
         context.config.width_heuristics().fn_call_width,
         if context.inside_macro {
-            span_ends_with_comma(context, span)
+            if span_ends_with_comma(context, span) {
+                Some(SeparatorTactic::Always)
+            } else {
+                Some(SeparatorTactic::Never)
+            }
         } else {
-            false
+            None
         },
     )
 }
@@ -2422,10 +2426,18 @@ where
     debug!("rewrite_tuple {:?}", shape);
     if context.use_block_indent() {
         // We use the same rule as function calls for rewriting tuples.
-        let force_trailing_comma = if context.inside_macro {
-            span_ends_with_comma(context, span)
+        let force_tactic = if context.inside_macro {
+            if span_ends_with_comma(context, span) {
+                Some(SeparatorTactic::Always)
+            } else {
+                Some(SeparatorTactic::Never)
+            }
         } else {
-            items.len() == 1
+            if items.len() == 1 {
+                Some(SeparatorTactic::Always)
+            } else {
+                None
+            }
         };
         overflow::rewrite_with_parens(
             context,
@@ -2434,7 +2446,7 @@ where
             shape,
             span,
             context.config.width_heuristics().fn_call_width,
-            force_trailing_comma,
+            force_tactic,
         )
     } else {
         rewrite_tuple_in_visual_indent_style(context, items, span, shape)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -25,6 +25,7 @@ use config::{Config, ControlBraceStyle, IndentStyle};
 use lists::{definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting,
             struct_lit_shape, struct_lit_tactic, write_list, ListFormatting, ListItem, Separator};
 use macros::{rewrite_macro, MacroArg, MacroPosition};
+use overflow;
 use patterns::{can_be_overflowed_pat, TuplePatField};
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
@@ -523,7 +524,7 @@ fn array_tactic<T: Rewrite + Spanned + ToExpr>(
                 None => DefinitiveListTactic::Vertical,
             };
             if tactic == DefinitiveListTactic::Vertical && !has_long_item
-                && is_every_args_simple(exprs)
+                && is_every_expr_simple(exprs)
             {
                 DefinitiveListTactic::Mixed
             } else {
@@ -1872,6 +1873,20 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     )
 }
 
+/// In case special-case style is required, returns an offset from which we start horizontal layout.
+pub fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, usize)> {
+    if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
+        .iter()
+        .find(|&&(s, _)| s == callee_str)
+    {
+        let all_simple = args.len() > num_args_before && is_every_expr_simple(args);
+
+        Some((all_simple, num_args_before))
+    } else {
+        None
+    }
+}
+
 /// A list of `format!`-like macros, that take a long format string and a list of arguments to
 /// format.
 ///
@@ -1913,297 +1928,22 @@ pub fn rewrite_call(
     span: Span,
     shape: Shape,
 ) -> Option<String> {
-    let force_trailing_comma = if context.inside_macro {
-        span_ends_with_comma(context, span)
-    } else {
-        false
-    };
-    rewrite_call_inner(
+    overflow::rewrite_with_parens(
         context,
         callee,
         &ptr_vec_to_ref_vec(args),
-        span,
         shape,
+        span,
         context.config.width_heuristics().fn_call_width,
-        force_trailing_comma,
+        if context.inside_macro {
+            span_ends_with_comma(context, span)
+        } else {
+            false
+        },
     )
 }
 
-pub fn rewrite_call_inner<'a, T>(
-    context: &RewriteContext,
-    callee_str: &str,
-    args: &[&T],
-    span: Span,
-    shape: Shape,
-    args_max_width: usize,
-    force_trailing_comma: bool,
-) -> Option<String>
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
-    // 2 = `( `, 1 = `(`
-    let paren_overhead = if context.config.spaces_within_parens_and_brackets() {
-        2
-    } else {
-        1
-    };
-    let used_width = extra_offset(callee_str, shape);
-    let one_line_width = shape
-        .width
-        .checked_sub(used_width + 2 * paren_overhead)
-        .unwrap_or(0);
-
-    // 1 = "(" or ")"
-    let one_line_shape = shape
-        .offset_left(last_line_width(callee_str) + 1)
-        .and_then(|shape| shape.sub_width(1))
-        .unwrap_or(Shape { width: 0, ..shape });
-    let nested_shape = shape_from_indent_style(
-        context,
-        shape,
-        used_width + 2 * paren_overhead,
-        used_width + paren_overhead,
-    )?;
-
-    let span_lo = context.snippet_provider.span_after(span, "(");
-    let args_span = mk_sp(span_lo, span.hi());
-
-    let (extendable, list_str) = rewrite_call_args(
-        context,
-        args,
-        args_span,
-        one_line_shape,
-        nested_shape,
-        one_line_width,
-        args_max_width,
-        force_trailing_comma,
-        callee_str,
-    )?;
-
-    if !context.use_block_indent() && need_block_indent(&list_str, nested_shape) && !extendable {
-        let mut new_context = context.clone();
-        new_context.use_block = true;
-        return rewrite_call_inner(
-            &new_context,
-            callee_str,
-            args,
-            span,
-            shape,
-            args_max_width,
-            force_trailing_comma,
-        );
-    }
-
-    let args_shape = Shape {
-        width: shape
-            .width
-            .checked_sub(last_line_width(callee_str))
-            .unwrap_or(0),
-        ..shape
-    };
-    Some(format!(
-        "{}{}",
-        callee_str,
-        wrap_args_with_parens(context, &list_str, extendable, args_shape, nested_shape)
-    ))
-}
-
-fn need_block_indent(s: &str, shape: Shape) -> bool {
-    s.lines().skip(1).any(|s| {
-        s.find(|c| !char::is_whitespace(c))
-            .map_or(false, |w| w + 1 < shape.indent.width())
-    })
-}
-
-fn rewrite_call_args<'a, T>(
-    context: &RewriteContext,
-    args: &[&T],
-    span: Span,
-    one_line_shape: Shape,
-    nested_shape: Shape,
-    one_line_width: usize,
-    args_max_width: usize,
-    force_trailing_comma: bool,
-    callee_str: &str,
-) -> Option<(bool, String)>
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
-    let items = itemize_list(
-        context.snippet_provider,
-        args.iter(),
-        ")",
-        ",",
-        |item| item.span().lo(),
-        |item| item.span().hi(),
-        |item| item.rewrite(context, nested_shape),
-        span.lo(),
-        span.hi(),
-        true,
-    );
-    let mut item_vec: Vec<_> = items.collect();
-
-    // Try letting the last argument overflow to the next line with block
-    // indentation. If its first line fits on one line with the other arguments,
-    // we format the function arguments horizontally.
-    let tactic = try_overflow_last_arg(
-        context,
-        &mut item_vec,
-        &args[..],
-        one_line_shape,
-        nested_shape,
-        one_line_width,
-        args_max_width,
-        callee_str,
-    );
-
-    let fmt = ListFormatting {
-        tactic,
-        separator: ",",
-        trailing_separator: if force_trailing_comma {
-            SeparatorTactic::Always
-        } else if context.inside_macro || !context.use_block_indent() {
-            SeparatorTactic::Never
-        } else {
-            context.config.trailing_comma()
-        },
-        separator_place: SeparatorPlace::Back,
-        shape: nested_shape,
-        ends_with_newline: context.use_block_indent() && tactic == DefinitiveListTactic::Vertical,
-        preserve_newline: false,
-        config: context.config,
-    };
-
-    write_list(&item_vec, &fmt)
-        .map(|args_str| (tactic == DefinitiveListTactic::Horizontal, args_str))
-}
-
-fn try_overflow_last_arg<'a, T>(
-    context: &RewriteContext,
-    item_vec: &mut Vec<ListItem>,
-    args: &[&T],
-    one_line_shape: Shape,
-    nested_shape: Shape,
-    one_line_width: usize,
-    args_max_width: usize,
-    callee_str: &str,
-) -> DefinitiveListTactic
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
-    // 1 = "("
-    let combine_arg_with_callee =
-        callee_str.len() + 1 <= context.config.tab_spaces() && args.len() == 1;
-    let overflow_last = combine_arg_with_callee || can_be_overflowed(context, args);
-
-    // Replace the last item with its first line to see if it fits with
-    // first arguments.
-    let placeholder = if overflow_last {
-        let mut context = context.clone();
-        if !combine_arg_with_callee {
-            if let Some(expr) = args[args.len() - 1].to_expr() {
-                if let ast::ExprKind::MethodCall(..) = expr.node {
-                    context.force_one_line_chain = true;
-                }
-            }
-        }
-        last_arg_shape(args, item_vec, one_line_shape, args_max_width).and_then(|arg_shape| {
-            rewrite_last_arg_with_overflow(&context, args, &mut item_vec[args.len() - 1], arg_shape)
-        })
-    } else {
-        None
-    };
-
-    let mut tactic = definitive_tactic(
-        &*item_vec,
-        ListTactic::LimitedHorizontalVertical(args_max_width),
-        Separator::Comma,
-        one_line_width,
-    );
-
-    // Replace the stub with the full overflowing last argument if the rewrite
-    // succeeded and its first line fits with the other arguments.
-    match (overflow_last, tactic, placeholder) {
-        (true, DefinitiveListTactic::Horizontal, Some(ref overflowed)) if args.len() == 1 => {
-            // When we are rewriting a nested function call, we restrict the
-            // bugdet for the inner function to avoid them being deeply nested.
-            // However, when the inner function has a prefix or a suffix
-            // (e.g. `foo() as u32`), this budget reduction may produce poorly
-            // formatted code, where a prefix or a suffix being left on its own
-            // line. Here we explicitlly check those cases.
-            if count_newlines(overflowed) == 1 {
-                let rw = args.last()
-                    .and_then(|last_arg| last_arg.rewrite(context, nested_shape));
-                let no_newline = rw.as_ref().map_or(false, |s| !s.contains('\n'));
-                if no_newline {
-                    item_vec[args.len() - 1].item = rw;
-                } else {
-                    item_vec[args.len() - 1].item = Some(overflowed.to_owned());
-                }
-            } else {
-                item_vec[args.len() - 1].item = Some(overflowed.to_owned());
-            }
-        }
-        (true, DefinitiveListTactic::Horizontal, placeholder @ Some(..)) => {
-            item_vec[args.len() - 1].item = placeholder;
-        }
-        _ if args.len() >= 1 => {
-            item_vec[args.len() - 1].item = args.last()
-                .and_then(|last_arg| last_arg.rewrite(context, nested_shape));
-
-            let default_tactic = || {
-                definitive_tactic(
-                    &*item_vec,
-                    ListTactic::LimitedHorizontalVertical(args_max_width),
-                    Separator::Comma,
-                    one_line_width,
-                )
-            };
-
-            // Use horizontal layout for a function with a single argument as long as
-            // everything fits in a single line.
-            if args.len() == 1
-                && args_max_width != 0 // Vertical layout is forced.
-                && !item_vec[0].has_comment()
-                && !item_vec[0].inner_as_ref().contains('\n')
-                && ::lists::total_item_width(&item_vec[0]) <= one_line_width
-            {
-                tactic = DefinitiveListTactic::Horizontal;
-            } else {
-                tactic = default_tactic();
-
-                if tactic == DefinitiveListTactic::Vertical {
-                    if let Some((all_simple, num_args_before)) =
-                        maybe_get_args_offset(callee_str, args)
-                    {
-                        let one_line = all_simple
-                            && definitive_tactic(
-                                &item_vec[..num_args_before],
-                                ListTactic::HorizontalVertical,
-                                Separator::Comma,
-                                nested_shape.width,
-                            ) == DefinitiveListTactic::Horizontal
-                            && definitive_tactic(
-                                &item_vec[num_args_before + 1..],
-                                ListTactic::HorizontalVertical,
-                                Separator::Comma,
-                                nested_shape.width,
-                            ) == DefinitiveListTactic::Horizontal;
-
-                        if one_line {
-                            tactic = DefinitiveListTactic::SpecialMacro(num_args_before);
-                        };
-                    }
-                }
-            }
-        }
-        _ => (),
-    }
-
-    tactic
-}
-
-fn is_simple_arg(expr: &ast::Expr) -> bool {
+fn is_simple_expr(expr: &ast::Expr) -> bool {
     match expr.node {
         ast::ExprKind::Lit(..) => true,
         ast::ExprKind::Path(ref qself, ref path) => qself.is_none() && path.segments.len() <= 1,
@@ -2213,106 +1953,18 @@ fn is_simple_arg(expr: &ast::Expr) -> bool {
         | ast::ExprKind::Field(ref expr, _)
         | ast::ExprKind::Try(ref expr)
         | ast::ExprKind::TupField(ref expr, _)
-        | ast::ExprKind::Unary(_, ref expr) => is_simple_arg(expr),
+        | ast::ExprKind::Unary(_, ref expr) => is_simple_expr(expr),
         ast::ExprKind::Index(ref lhs, ref rhs) | ast::ExprKind::Repeat(ref lhs, ref rhs) => {
-            is_simple_arg(lhs) && is_simple_arg(rhs)
+            is_simple_expr(lhs) && is_simple_expr(rhs)
         }
         _ => false,
     }
 }
 
-fn is_every_args_simple<T: ToExpr>(lists: &[&T]) -> bool {
+fn is_every_expr_simple<T: ToExpr>(lists: &[&T]) -> bool {
     lists
         .iter()
-        .all(|arg| arg.to_expr().map_or(false, is_simple_arg))
-}
-
-/// In case special-case style is required, returns an offset from which we start horizontal layout.
-fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, usize)> {
-    if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
-        .iter()
-        .find(|&&(s, _)| s == callee_str)
-    {
-        let all_simple = args.len() > num_args_before && is_every_args_simple(args);
-
-        Some((all_simple, num_args_before))
-    } else {
-        None
-    }
-}
-
-/// Returns a shape for the last argument which is going to be overflowed.
-fn last_arg_shape<T>(
-    lists: &[&T],
-    items: &[ListItem],
-    shape: Shape,
-    args_max_width: usize,
-) -> Option<Shape>
-where
-    T: Rewrite + Spanned + ToExpr,
-{
-    let is_nested_call = lists
-        .iter()
-        .next()
-        .and_then(|item| item.to_expr())
-        .map_or(false, is_nested_call);
-    if items.len() == 1 && !is_nested_call {
-        return Some(shape);
-    }
-    let offset = items.iter().rev().skip(1).fold(0, |acc, i| {
-        // 2 = ", "
-        acc + 2 + i.inner_as_ref().len()
-    });
-    Shape {
-        width: min(args_max_width, shape.width),
-        ..shape
-    }.offset_left(offset)
-}
-
-fn rewrite_last_arg_with_overflow<'a, T>(
-    context: &RewriteContext,
-    args: &[&T],
-    last_item: &mut ListItem,
-    shape: Shape,
-) -> Option<String>
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
-    let last_arg = args[args.len() - 1];
-    let rewrite = if let Some(expr) = last_arg.to_expr() {
-        match expr.node {
-            // When overflowing the closure which consists of a single control flow expression,
-            // force to use block if its condition uses multi line.
-            ast::ExprKind::Closure(..) => {
-                // If the argument consists of multiple closures, we do not overflow
-                // the last closure.
-                if closures::args_have_many_closure(args) {
-                    None
-                } else {
-                    closures::rewrite_last_closure(context, expr, shape)
-                }
-            }
-            _ => expr.rewrite(context, shape),
-        }
-    } else {
-        last_arg.rewrite(context, shape)
-    };
-
-    if let Some(rewrite) = rewrite {
-        let rewrite_first_line = Some(rewrite[..first_line_width(&rewrite)].to_owned());
-        last_item.item = rewrite_first_line;
-        Some(rewrite)
-    } else {
-        None
-    }
-}
-
-fn can_be_overflowed<'a, T>(context: &RewriteContext, args: &[&T]) -> bool
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
-    args.last()
-        .map_or(false, |x| x.can_be_overflowed(context, args.len()))
+        .all(|arg| arg.to_expr().map_or(false, is_simple_expr))
 }
 
 pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_len: usize) -> bool {
@@ -2348,7 +2000,7 @@ pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_l
     }
 }
 
-fn is_nested_call(expr: &ast::Expr) -> bool {
+pub fn is_nested_call(expr: &ast::Expr) -> bool {
     match expr.node {
         ast::ExprKind::Call(..) | ast::ExprKind::Mac(..) => true,
         ast::ExprKind::AddrOf(_, ref expr)
@@ -2360,55 +2012,10 @@ fn is_nested_call(expr: &ast::Expr) -> bool {
     }
 }
 
-pub fn wrap_args_with_parens(
-    context: &RewriteContext,
-    args_str: &str,
-    is_extendable: bool,
-    shape: Shape,
-    nested_shape: Shape,
-) -> String {
-    let paren_overhead = paren_overhead(context);
-    let fits_one_line = args_str.len() + paren_overhead <= shape.width;
-    let extend_width = if args_str.is_empty() {
-        paren_overhead
-    } else {
-        paren_overhead / 2
-    };
-    if !context.use_block_indent()
-        || (context.inside_macro && !args_str.contains('\n') && fits_one_line)
-        || (is_extendable && extend_width <= shape.width)
-    {
-        let mut result = String::with_capacity(args_str.len() + 4);
-        if context.config.spaces_within_parens_and_brackets() && !args_str.is_empty() {
-            result.push_str("( ");
-            result.push_str(args_str);
-            result.push_str(" )");
-        } else {
-            result.push_str("(");
-            result.push_str(args_str);
-            result.push_str(")");
-        }
-        result
-    } else {
-        let nested_indent_str = nested_shape.indent.to_string_with_newline(context.config);
-        let indent_str = shape.block().indent.to_string_with_newline(context.config);
-        let mut result =
-            String::with_capacity(args_str.len() + 2 + indent_str.len() + nested_indent_str.len());
-        result.push_str("(");
-        if !args_str.is_empty() {
-            result.push_str(&nested_indent_str);
-            result.push_str(args_str);
-        }
-        result.push_str(&indent_str);
-        result.push_str(")");
-        result
-    }
-}
-
 /// Return true if a function call or a method call represented by the given span ends with a
 /// trailing comma. This function is used when rewriting macro, as adding or removing a trailing
 /// comma from macro can potentially break the code.
-fn span_ends_with_comma(context: &RewriteContext, span: Span) -> bool {
+pub fn span_ends_with_comma(context: &RewriteContext, span: Span) -> bool {
     let mut result: bool = Default::default();
     let mut prev_char: char = Default::default();
 
@@ -2735,24 +2342,6 @@ pub fn rewrite_field(
     }
 }
 
-fn shape_from_indent_style(
-    context: &RewriteContext,
-    shape: Shape,
-    overhead: usize,
-    offset: usize,
-) -> Option<Shape> {
-    if context.use_block_indent() {
-        // 1 = ","
-        shape
-            .block()
-            .block_indent(context.config.tab_spaces())
-            .with_max_width(context.config)
-            .sub_width(1)
-    } else {
-        shape.visual_indent(offset).sub_width(overhead)
-    }
-}
-
 fn rewrite_tuple_in_visual_indent_style<'a, T>(
     context: &RewriteContext,
     items: &[&T],
@@ -2838,12 +2427,12 @@ where
         } else {
             items.len() == 1
         };
-        rewrite_call_inner(
+        overflow::rewrite_with_parens(
             context,
-            &String::new(),
+            "",
             items,
-            span,
             shape,
+            span,
             context.config.width_heuristics().fn_call_width,
             force_trailing_comma,
         )

--- a/src/items.rs
+++ b/src/items.rs
@@ -1290,7 +1290,7 @@ fn format_tuple_struct(
             shape,
             span,
             context.config.width_heuristics().fn_call_width,
-            false,
+            None,
         )?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod lists;
 mod macros;
 mod missed_spans;
 pub mod modules;
+mod overflow;
 mod patterns;
 mod reorder;
 mod rewrite;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,8 +34,9 @@ use syntax::util::ThinVec;
 
 use codemap::SpanUtils;
 use comment::{contains_comment, remove_trailing_white_spaces, FindUncommented};
-use expr::{rewrite_array, rewrite_call_inner};
+use expr::rewrite_array;
 use lists::{itemize_list, write_list, ListFormatting};
+use overflow;
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
 use utils::{format_visibility, mk_sp, wrap_str};
@@ -223,14 +224,14 @@ pub fn rewrite_macro(
 
     match style {
         MacroStyle::Parens => {
-            // Format macro invocation as function call, forcing no trailing
+            // Format macro invocation as function call, preserve the trailing
             // comma because not all macros support them.
-            rewrite_call_inner(
+            overflow::rewrite_with_parens(
                 context,
                 &macro_name,
                 &arg_vec.iter().map(|e| &*e).collect::<Vec<_>>()[..],
-                mac.span,
                 shape,
+                mac.span,
                 context.config.width_heuristics().fn_call_width,
                 trailing_comma,
             ).map(|rw| match position {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -233,7 +233,11 @@ pub fn rewrite_macro(
                 shape,
                 mac.span,
                 context.config.width_heuristics().fn_call_width,
-                trailing_comma,
+                if trailing_comma {
+                    Some(SeparatorTactic::Always)
+                } else {
+                    Some(SeparatorTactic::Never)
+                },
             ).map(|rw| match position {
                 MacroPosition::Item => format!("{};", rw),
                 _ => rw,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -343,7 +343,11 @@ fn rewrite_tuple_pat(
         shape,
         span,
         context.config.max_width(),
-        add_comma,
+        if add_comma {
+            Some(SeparatorTactic::Always)
+        } else {
+            None
+        },
     )
 }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -15,11 +15,12 @@ use syntax::ptr;
 
 use codemap::SpanUtils;
 use comment::FindUncommented;
-use expr::{can_be_overflowed_expr, rewrite_call_inner, rewrite_pair, rewrite_unary_prefix,
-           wrap_struct_field, PairParts};
+use expr::{can_be_overflowed_expr, rewrite_pair, rewrite_unary_prefix, wrap_struct_field,
+           PairParts};
 use lists::{itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
             struct_lit_tactic, write_list};
 use macros::{rewrite_macro, MacroPosition};
+use overflow;
 use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use spanned::Spanned;
@@ -335,13 +336,13 @@ fn rewrite_tuple_pat(
         pat_ref_vec.push(pat);
     }
 
-    rewrite_call_inner(
+    overflow::rewrite_with_parens(
         &context,
         &path_str,
         &pat_ref_vec[..],
-        span,
         shape,
-        shape.width,
+        span,
+        context.config.max_width(),
         add_comma,
     )
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -17,6 +17,8 @@ use config::{Config, IndentStyle};
 use shape::Shape;
 use visitor::SnippetProvider;
 
+use std::cell::RefCell;
+
 pub trait Rewrite {
     /// Rewrite self into shape.
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String>;
@@ -29,12 +31,12 @@ pub struct RewriteContext<'a> {
     pub config: &'a Config,
     pub inside_macro: bool,
     // Force block indent style even if we are using visual indent style.
-    pub use_block: bool,
+    pub use_block: RefCell<bool>,
     // When `format_if_else_cond_comment` is true, unindent the comment on top
     // of the `else` or `else if`.
     pub is_if_else_block: bool,
     // When rewriting chain, veto going multi line except the last element
-    pub force_one_line_chain: bool,
+    pub force_one_line_chain: RefCell<bool>,
     pub snippet_provider: &'a SnippetProvider<'a>,
 }
 
@@ -45,7 +47,7 @@ impl<'a> RewriteContext<'a> {
 
     /// Return true if we should use block indent style for rewriting function call.
     pub fn use_block_indent(&self) -> bool {
-        self.config.indent_style() == IndentStyle::Block || self.use_block
+        self.config.indent_style() == IndentStyle::Block || *self.use_block.borrow()
     }
 
     pub fn budget(&self, used_width: usize) -> usize {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -23,10 +23,10 @@ pub struct Indent {
     pub alignment: usize,
 }
 
-// INDENT_BUFFER.len() = 80
+// INDENT_BUFFER.len() = 81
 const INDENT_BUFFER_LEN: usize = 80;
 const INDENT_BUFFER: &str =
-    "\n                                                                               ";
+    "\n                                                                                ";
 impl Indent {
     pub fn new(block_indent: usize, alignment: usize) -> Indent {
         Indent {

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,10 +18,10 @@ use syntax::symbol::keywords;
 
 use codemap::SpanUtils;
 use config::{IndentStyle, TypeDensity};
-use expr::{rewrite_pair, rewrite_tuple, rewrite_unary_prefix, wrap_args_with_parens, PairParts};
-use items::{format_generics_item_list, generics_shape_from_config};
+use expr::{rewrite_pair, rewrite_tuple, rewrite_unary_prefix, PairParts, ToExpr};
 use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
 use macros::{rewrite_macro, MacroPosition};
+use overflow;
 use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use spanned::Spanned;
@@ -151,12 +151,25 @@ enum SegmentParam<'a> {
     Binding(&'a ast::TypeBinding),
 }
 
-impl<'a> SegmentParam<'a> {
-    fn get_span(&self) -> Span {
+impl<'a> Spanned for SegmentParam<'a> {
+    fn span(&self) -> Span {
         match *self {
             SegmentParam::LifeTime(lt) => lt.span,
             SegmentParam::Type(ty) => ty.span,
             SegmentParam::Binding(binding) => binding.span,
+        }
+    }
+}
+
+impl<'a> ToExpr for SegmentParam<'a> {
+    fn to_expr(&self) -> Option<&ast::Expr> {
+        None
+    }
+
+    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
+        match *self {
+            SegmentParam::Type(ty) => ty.can_be_overflowed(context, len),
+            _ => false,
         }
     }
 }
@@ -204,7 +217,11 @@ fn rewrite_segment(
     result.push_str(&segment.identifier.name.as_str());
 
     let ident_len = result.len();
-    let shape = shape.shrink_left(ident_len)?;
+    let shape = if context.use_block_indent() {
+        shape.offset_left(ident_len)?
+    } else {
+        shape.shrink_left(ident_len)?
+    };
 
     if let Some(ref params) = segment.parameters {
         match **params {
@@ -219,10 +236,6 @@ fn rewrite_segment(
                     .chain(data.bindings.iter().map(|x| SegmentParam::Binding(&*x)))
                     .collect::<Vec<_>>();
 
-                let next_span_lo = param_list.last().unwrap().get_span().hi() + BytePos(1);
-                let list_lo = context
-                    .snippet_provider
-                    .span_after(mk_sp(*span_lo, span_hi), "<");
                 let separator = if path_context == PathContext::Expr {
                     "::"
                 } else {
@@ -230,26 +243,18 @@ fn rewrite_segment(
                 };
                 result.push_str(separator);
 
-                let generics_shape =
-                    generics_shape_from_config(context.config, shape, separator.len())?;
-                let one_line_width = shape.width.checked_sub(separator.len() + 2)?;
-                let items = itemize_list(
-                    context.snippet_provider,
-                    param_list.into_iter(),
-                    ">",
-                    ",",
-                    |param| param.get_span().lo(),
-                    |param| param.get_span().hi(),
-                    |seg| seg.rewrite(context, generics_shape),
-                    list_lo,
-                    span_hi,
-                    false,
-                );
-                let generics_str =
-                    format_generics_item_list(context, items, generics_shape, one_line_width)?;
+                let generics_str = overflow::rewrite_with_angle_brackets(
+                    context,
+                    "",
+                    &param_list.iter().map(|e| &*e).collect::<Vec<_>>()[..],
+                    shape,
+                    mk_sp(*span_lo, span_hi),
+                )?;
 
                 // Update position of last bracket.
-                *span_lo = next_span_lo;
+                *span_lo = context
+                    .snippet_provider
+                    .span_after(mk_sp(*span_lo, span_hi), "<");
 
                 result.push_str(&generics_str)
             }
@@ -807,7 +812,7 @@ pub fn join_bounds(context: &RewriteContext, shape: Shape, type_strs: &[String])
 
 pub fn can_be_overflowed_type(context: &RewriteContext, ty: &ast::Ty, len: usize) -> bool {
     match ty.node {
-        ast::TyKind::Path(..) | ast::TyKind::Tup(..) => context.use_block_indent() && len == 1,
+        ast::TyKind::Tup(..) => context.use_block_indent() && len == 1,
         ast::TyKind::Rptr(_, ref mutty) | ast::TyKind::Ptr(ref mutty) => {
             can_be_overflowed_type(context, &*mutty.ty, len)
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -384,14 +384,18 @@ where
         FunctionRetTy::Default(..) => String::new(),
     };
 
-    let extendable = (!list_str.contains('\n') || list_str.is_empty()) && !output.contains('\n');
-    let args = wrap_args_with_parens(
-        context,
-        &list_str,
-        extendable,
-        shape.sub_width(first_line_width(&output))?,
-        Shape::indented(offset, context.config),
-    );
+    let args = if (!list_str.contains('\n') || list_str.is_empty()) && !output.contains('\n')
+        || !context.use_block_indent()
+    {
+        format!("({})", list_str)
+    } else {
+        format!(
+            "({}{}{})",
+            offset.to_string_with_newline(context.config),
+            list_str,
+            shape.block().indent.to_string_with_newline(context.config),
+        )
+    };
     if last_line_width(&args) + first_line_width(&output) <= shape.width {
         Some(format!("{}{}", args, output))
     } else {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -26,6 +26,8 @@ use shape::{Indent, Shape};
 use spanned::Spanned;
 use utils::{self, contains_skip, count_newlines, inner_attributes, mk_sp, ptr_vec_to_ref_vec};
 
+use std::cell::RefCell;
+
 /// Creates a string slice corresponding to the specified span.
 pub struct SnippetProvider<'a> {
     /// A pointer to the content of the file we are formatting.
@@ -691,9 +693,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             codemap: self.codemap,
             config: self.config,
             inside_macro: false,
-            use_block: false,
+            use_block: RefCell::new(false),
             is_if_else_block: false,
-            force_one_line_chain: false,
+            force_one_line_chain: RefCell::new(false),
             snippet_provider: self.snippet_provider,
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -330,26 +330,28 @@ fn check_files(files: Vec<PathBuf>) -> (Vec<FormatReport>, u32, u32) {
 }
 
 fn print_mismatches_default_message(result: HashMap<PathBuf, Vec<Mismatch>>) {
-    let mut t = term::stdout().unwrap();
     for (file_name, diff) in result {
         let mismatch_msg_formatter =
             |line_num| format!("\nMismatch at {}:{}:", file_name.display(), line_num);
         print_diff(diff, &mismatch_msg_formatter, Color::Auto);
     }
 
-    t.reset().unwrap();
+    if let Some(mut t) = term::stdout() {
+        t.reset().unwrap_or(());
+    }
 }
 
 fn print_mismatches<T: Fn(u32) -> String>(
     result: HashMap<PathBuf, Vec<Mismatch>>,
     mismatch_msg_formatter: T,
 ) {
-    let mut t = term::stdout().unwrap();
     for (_file_name, diff) in result {
         print_diff(diff, &mismatch_msg_formatter, Color::Auto);
     }
 
-    t.reset().unwrap();
+    if let Some(mut t) = term::stdout() {
+        t.reset().unwrap_or(());
+    }
 }
 
 fn read_config(filename: &Path) -> Config {

--- a/tests/source/type.rs
+++ b/tests/source/type.rs
@@ -23,3 +23,18 @@ fn impl_trait_fn_2<E>() -> impl Future<Item=&'a i64,Error=E> {}
 fn issue_1234() {
     do_parse!(name: take_while1!(is_token) >> (Header))
 }
+
+// #2510
+impl CombineTypes {
+    pub fn pop_callback(
+        &self,
+        query_id: Uuid,
+    ) -> Option<
+        (
+            ProjectId,
+            Box<FnMut(&ProjectState, serde_json::Value, bool) -> () + Sync + Send>,
+        ),
+    > {
+        self.query_callbacks()(&query_id)
+    }
+}

--- a/tests/target/big-impl-block.rs
+++ b/tests/target/big-impl-block.rs
@@ -38,11 +38,8 @@ impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessiv
 {
     fn foo() {}
 }
-impl<
-    ExcessivelyLongGenericName,
-    ExcessivelyLongGenericName,
-    AnotherExcessivelyLongGenericName,
-> Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
     for Bar
 {
     fn foo() {}
@@ -65,11 +62,8 @@ impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessiv
 {
     fn foo() {}
 }
-impl<
-    ExcessivelyLongGenericName,
-    ExcessivelyLongGenericName,
-    AnotherExcessivelyLongGenericName,
-> Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
     for Bar<
         ExcessivelyLongGenericName,
         ExcessivelyLongGenericName,

--- a/tests/target/big-impl-visual.rs
+++ b/tests/target/big-impl-visual.rs
@@ -25,9 +25,8 @@ impl<'a, Select, From, Distinct, Where, Order, Limit, Offset, Groupby, DB> Inter
 }
 
 // #1369
-impl<ExcessivelyLongGenericName,
-     ExcessivelyLongGenericName,
-     AnotherExcessivelyLongGenericName> Foo for Bar
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
+    for Bar
 {
     fn foo() {}
 }
@@ -36,17 +35,13 @@ impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessiv
 {
     fn foo() {}
 }
-impl<ExcessivelyLongGenericName,
-     ExcessivelyLongGenericName,
-     AnotherExcessivelyLongGenericName> Foo<ExcessivelyLongGenericName,
-                                            ExcessivelyLongGenericName,
-                                            AnotherExcessivelyLongGenericName> for Bar
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    for Bar
 {
     fn foo() {}
 }
-impl<ExcessivelyLongGenericName,
-     ExcessivelyLongGenericName,
-     AnotherExcessivelyLongGenericName> Foo
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName> Foo
     for Bar<ExcessivelyLongGenericName,
             ExcessivelyLongGenericName,
             AnotherExcessivelyLongGenericName>
@@ -60,11 +55,8 @@ impl Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessiv
 {
     fn foo() {}
 }
-impl<ExcessivelyLongGenericName,
-     ExcessivelyLongGenericName,
-     AnotherExcessivelyLongGenericName> Foo<ExcessivelyLongGenericName,
-                                            ExcessivelyLongGenericName,
-                                            AnotherExcessivelyLongGenericName>
+impl<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
+    Foo<ExcessivelyLongGenericName, ExcessivelyLongGenericName, AnotherExcessivelyLongGenericName>
     for Bar<ExcessivelyLongGenericName,
             ExcessivelyLongGenericName,
             AnotherExcessivelyLongGenericName>

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -82,8 +82,7 @@ fn some_fn3() // some comment some comment some comment some comment some commen
 }
 
 fn some_fn4()
-// some comment some comment some comment some comment some comment some comment
-// some comment
+// some comment some comment some comment some comment some comment some comment some comment
 {
 }
 

--- a/tests/target/trailing_commas.rs
+++ b/tests/target/trailing_commas.rs
@@ -11,12 +11,7 @@ fn main() {
     }
 }
 
-fn f<
-    S, T,
->(
-    x: T,
-    y: S,
-) -> T
+fn f<S, T,>(x: T, y: S,) -> T
 where
     T: P,
     S: Q,
@@ -36,9 +31,8 @@ where
     }
 }
 
-struct Pair<
-    S, T,
-> where
+struct Pair<S, T,>
+where
     T: P,
     S: P + Q,
 {
@@ -46,57 +40,38 @@ struct Pair<
     b: S,
 }
 
-struct TupPair<
-    S, T,
->(S, T,)
+struct TupPair<S, T,>(S, T,)
 where
     T: P,
     S: P + Q;
 
-enum E<
-    S, T,
-> where
+enum E<S, T,>
+where
     S: P,
     T: P,
 {
     A { a: T, },
 }
 
-type Double<
-    T,
-> where
+type Double<T,>
+where
     T: P,
     T: Q,
-= Pair<
-    T, T,
->;
+= Pair<T, T,>;
 
 extern "C" {
-    fn f<
-        S, T,
-    >(
-        x: T,
-        y: S,
-    ) -> T
+    fn f<S, T,>(x: T, y: S,) -> T
     where
         T: P,
         S: Q;
 }
 
-trait Q<
-    S, T,
-> where
+trait Q<S, T,>
+where
     T: P,
     S: R,
 {
-    fn f<
-        U, V,
-    >(
-        self,
-        x: T,
-        y: S,
-        z: U,
-    ) -> Self
+    fn f<U, V,>(self, x: T, y: S, z: U,) -> Self
     where
         U: P,
         V: P;

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -29,3 +29,16 @@ fn impl_trait_fn_2<E>() -> impl Future<Item = &'a i64, Error = E> {}
 fn issue_1234() {
     do_parse!(name: take_while1!(is_token) >> (Header))
 }
+
+// #2510
+impl CombineTypes {
+    pub fn pop_callback(
+        &self,
+        query_id: Uuid,
+    ) -> Option<(
+        ProjectId,
+        Box<FnMut(&ProjectState, serde_json::Value, bool) -> () + Sync + Send>,
+    )> {
+        self.query_callbacks()(&query_id)
+    }
+}


### PR DESCRIPTION
This PR modifies `rewrite_call_inner` to  handle a list of items which is surrounded by `<>`, like genercis or types.

Since keep calling it `rewrite_call_inner` is counterintuitive, I created a new module `overflow` and put related funtions there. I am open to bikesheding on better name. I kind of gave up to come up with a better one.

Closes #2510.