### PR TITLE
Fix bugs when rewriting doc comments with code block

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -21,8 +21,6 @@ use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use utils::{count_newlines, mk_sp};
 
-use std::cmp;
-
 /// Returns attributes on the given statement.
 pub fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
     match stmt.node {
@@ -140,7 +138,7 @@ fn rewrite_first_group_attrs(
             .join("\n");
         return Some((
             sugared_docs.len(),
-            rewrite_doc_comment(&snippet, shape, context.config)?,
+            rewrite_doc_comment(&snippet, shape.comment(context.config), context.config)?,
         ));
     }
     // Rewrite `#[derive(..)]`s.
@@ -249,13 +247,7 @@ impl Rewrite for ast::Attribute {
         };
         let snippet = context.snippet(self.span);
         if self.is_sugared_doc {
-            let doc_shape = Shape {
-                width: cmp::min(shape.width, context.config.comment_width())
-                    .checked_sub(shape.indent.width())
-                    .unwrap_or(0),
-                ..shape
-            };
-            rewrite_doc_comment(snippet, doc_shape, context.config)
+            rewrite_doc_comment(snippet, shape.comment(context.config), context.config)
         } else {
             if contains_comment(snippet) {
                 return Some(snippet.to_owned());

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -98,13 +98,16 @@ fn take_while_with_pred<'a, P>(
 where
     P: Fn(&ast::Attribute) -> bool,
 {
-    let mut last_index = 0;
-    let mut iter = attrs.iter().enumerate().peekable();
-    while let Some((i, attr)) = iter.next() {
-        if !pred(attr) {
+    let mut len = 0;
+    let mut iter = attrs.iter().peekable();
+
+    while let Some(attr) = iter.next() {
+        if pred(attr) {
+            len += 1;
+        } else {
             break;
         }
-        if let Some(&(_, next_attr)) = iter.peek() {
+        if let Some(next_attr) = iter.peek() {
             // Extract comments between two attributes.
             let span_between_attr = mk_sp(attr.span.hi(), next_attr.span.lo());
             let snippet = context.snippet(span_between_attr);
@@ -112,13 +115,9 @@ where
                 break;
             }
         }
-        last_index = i;
     }
-    if last_index == 0 {
-        &[]
-    } else {
-        &attrs[..last_index + 1]
-    }
+
+    &attrs[..len]
 }
 
 /// Rewrite the same kind of attributes at the same time. This includes doc

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -391,6 +391,15 @@ fn rewrite_comment_inner(
             } else {
                 code_block_buffer.push_str(line);
                 code_block_buffer.push('\n');
+
+                if is_last {
+                    // There is an code block that is not properly enclosed by backticks.
+                    // We will leave them untouched.
+                    result.push_str(&comment_line_separator);
+                    result.push_str(&join_code_block_with_comment_line_separator(
+                        &code_block_buffer,
+                    ));
+                }
             }
 
             continue;

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::borrow::Cow;
+use std::cmp::min;
 use std::ops::{Add, Sub};
 
 use Config;
@@ -275,6 +276,17 @@ impl Shape {
             .max_width()
             .checked_sub(self.used_width() + self.width)
             .unwrap_or(0)
+    }
+
+    pub fn comment(&self, config: &Config) -> Shape {
+        let width = min(
+            self.width,
+            config
+                .comment_width()
+                .checked_sub(self.indent.width())
+                .unwrap_or(0),
+        );
+        Shape { width, ..*self }
     }
 }
 

--- a/tests/source/issue-2520.rs
+++ b/tests/source/issue-2520.rs
@@ -5,3 +5,8 @@
 //! ```
 
 #![deny( missing_docs )]
+
+//! ```rust
+//! println!("hello, world");
+
+#![deny( missing_docs )]

--- a/tests/source/issue-2520.rs
+++ b/tests/source/issue-2520.rs
@@ -1,0 +1,7 @@
+// rustfmt-normalize_comments: true
+
+//! ```rust
+//! println!( "hello, world" );
+//! ```
+
+#![deny( missing_docs )]

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -145,8 +145,9 @@ pub enum Bencoding<'i> {
     Str(&'i [u8]),
     Int(i64),
     List(Vec<Bencoding<'i>>),
-    /// A bencoded dict value. The first element the slice of bytes in the source that the dict is
-    /// composed of. The second is the dict, decoded into an ordered map.
+    /// A bencoded dict value. The first element the slice of bytes in the
+    /// source that the dict is composed of. The second is the dict,
+    /// decoded into an ordered map.
     // TODO make Dict "structlike" AKA name the two values.
     Dict(&'i [u8], BTreeMap<&'i [u8], Bencoding<'i>>),
 }

--- a/tests/target/issue-2520.rs
+++ b/tests/target/issue-2520.rs
@@ -1,0 +1,7 @@
+// rustfmt-normalize_comments: true
+
+//! ```rust
+//! println!("hello, world");
+//! ```
+
+#![deny(missing_docs)]

--- a/tests/target/issue-2520.rs
+++ b/tests/target/issue-2520.rs
@@ -5,3 +5,8 @@
 //! ```
 
 #![deny(missing_docs)]
+
+//! ```rust
+//! println!("hello, world");
+
+#![deny(missing_docs)]


### PR DESCRIPTION
There was a bug in `take_while_with_pred`, and rustfmt formatted doc comments separately:

```rust
//! ```rust
//! println!( "hello, world" );
```

and

```rust
//! ``` 
```

, this PR fixes the above bug and make sure that the code block that are not enclosed properly will not get removed.

Also in some occasion rustfmt did not take `comment_width` into account when rewriting doc comments. This PR fixes it as well.

Closes #2520.