### PR TITLE
Add ignore config option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2135,3 +2135,32 @@ Copyright 2018 The Rust Project Developers.`, etc.:
 ```
 
 `\{`, `\}` and `\\` match literal braces / backslashes.
+
+## `ignore`
+
+Skip formatting the specified files and directories.
+
+- **Default value**: format every files
+- **Possible values**: See an example below
+- **Stable**: No
+
+### Example
+
+If you want to ignore specific files, put the following to your config file:
+
+```toml
+[ignore]
+files = [
+    "src/types.rs",
+    "src/foo/bar.rs",
+]
+```
+
+If you want to ignore every file under `examples/`, put the following to your config file:
+
+```toml
+[ignore]
+directories = [
+    "examples",
+]
+```

--- a/Configurations.md
+++ b/Configurations.md
@@ -2149,8 +2149,7 @@ Skip formatting the specified files and directories.
 If you want to ignore specific files, put the following to your config file:
 
 ```toml
-[ignore]
-files = [
+ignore = [
     "src/types.rs",
     "src/foo/bar.rs",
 ]
@@ -2159,8 +2158,7 @@ files = [
 If you want to ignore every file under `examples/`, put the following to your config file:
 
 ```toml
-[ignore]
-directories = [
+ignore [
     "examples",
 ]
 ```

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,14 +18,13 @@ use std::{env, error};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use getopts::{Matches, Options};
 
 use rustfmt::config::{get_toml_path, Color, Config, WriteMode};
 use rustfmt::config::file_lines::FileLines;
 use rustfmt::{run, FileName, Input, Summary};
-
-use std::str::FromStr;
 
 type FmtError = Box<error::Error + Send + Sync>;
 type FmtResult<T> = std::result::Result<T, FmtError>;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -141,6 +141,8 @@ create_config! {
         "Report all, none or unnumbered occurrences of TODO in source file comments";
     report_fixme: ReportTactic, ReportTactic::Never, false,
         "Report all, none or unnumbered occurrences of FIXME in source file comments";
+    ignore: IgnoreList, IgnoreList::default(), false,
+        "Skip formatting the specified files and directories.";
 
     // Not user-facing.
     verbose: bool, false, false, "Use verbose output";
@@ -208,7 +210,8 @@ mod test {
 
     #[test]
     fn test_was_set() {
-        let config = Config::from_toml("hard_tabs = true").unwrap();
+        use std::path::Path;
+        let config = Config::from_toml("hard_tabs = true", Path::new("")).unwrap();
 
         assert_eq!(config.was_set().hard_tabs(), true);
         assert_eq!(config.was_set().verbose(), false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ where
     // nothing to distinguish the nested module contents.
     let skip_children = config.skip_children() || config.write_mode() == config::WriteMode::Plain;
     for (path, module) in modules::list_files(krate, parse_session.codemap())? {
-        if skip_children && path != *main_file {
+        if (skip_children && path != *main_file) || config.ignore().skip_file(&path) {
             continue;
         }
         should_emit_verbose(&path, config, || println!("Formatting {}", path));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -293,7 +293,7 @@ fn format_lines_errors_are_reported() {
 fn format_lines_errors_are_reported_with_tabs() {
     let long_identifier = String::from_utf8(vec![b'a'; 97]).unwrap();
     let input = Input::Text(format!("fn a() {{\n\t{}\n}}", long_identifier));
-    let config = Config::from_toml("hard_tabs = true").unwrap();
+    let config = Config::from_toml("hard_tabs = true", Path::new("")).unwrap();
     let (error_summary, _file_map, _report) =
         format_input::<io::Stdout>(input, &config, None).unwrap();
     assert!(error_summary.has_formatting_errors());
@@ -433,7 +433,7 @@ fn get_config(config_file: Option<&Path>) -> Config {
         .read_to_string(&mut def_config)
         .expect("Couldn't read config");
 
-    Config::from_toml(&def_config).expect("Invalid toml")
+    Config::from_toml(&def_config, Path::new("tests/config/")).expect("Invalid toml")
 }
 
 // Reads significant comments of the form: // rustfmt-key: value


### PR DESCRIPTION
This PR adds `ignore` config option, which lets users to tell rustfmt to skip formatting the specified files and directories. The current implementation is not as smart as `.gitignore`, but should get the job done.

For example, with the following config file, rustfmt will ignore `src/types.rs`,
`src/foo/bar.rs` and every file under `examples/` directory.

```toml
[ignore]
files = [
    "src/types.rs",
    "src/foo/bar.rs",
]
directories = [
    "examples",
]
```

Closes #705.
Closes #2444.