### PR TITLE
Do not unindent code block in comments with unformattable macro

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3051,6 +3051,7 @@ impl<'a> ToExpr for MacroArg {
             MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
             MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
             MacroArg::Pat(..) => false,
+            MacroArg::Item(..) => len == 1,
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 
 use config::lists::*;
-use syntax::ast;
+use syntax::{ast, ptr};
 use syntax::codemap::{BytePos, Span};
 use syntax::parse::new_parser_from_tts;
 use syntax::parse::parser::Parser;
@@ -38,6 +38,7 @@ use expr::{rewrite_array, rewrite_call_inner};
 use lists::{itemize_list, write_list, ListFormatting};
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
+use spanned::Spanned;
 use utils::{format_visibility, mk_sp, wrap_str};
 
 const FORCED_BRACKET_MACROS: &[&str] = &["vec!"];
@@ -70,9 +71,21 @@ impl MacroStyle {
 
 #[derive(Debug)]
 pub enum MacroArg {
-    Expr(ast::Expr),
-    Ty(ast::Ty),
-    Pat(ast::Pat),
+    Expr(ptr::P<ast::Expr>),
+    Ty(ptr::P<ast::Ty>),
+    Pat(ptr::P<ast::Pat>),
+    // `parse_item` returns `Option<ptr::P<ast::Item>>`.
+    Item(Option<ptr::P<ast::Item>>),
+}
+
+impl Rewrite for ast::Item {
+    fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
+        let mut visitor = ::visitor::FmtVisitor::from_context(context);
+        visitor.block_indent = shape.indent;
+        visitor.last_pos = self.span().lo();
+        visitor.visit_item(self);
+        Some(visitor.buffer)
+    }
 }
 
 impl Rewrite for MacroArg {
@@ -81,6 +94,7 @@ impl Rewrite for MacroArg {
             MacroArg::Expr(ref expr) => expr.rewrite(context, shape),
             MacroArg::Ty(ref ty) => ty.rewrite(context, shape),
             MacroArg::Pat(ref pat) => pat.rewrite(context, shape),
+            MacroArg::Item(ref item) => item.as_ref().and_then(|item| item.rewrite(context, shape)),
         }
     }
 }
@@ -96,7 +110,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
                     } else {
                         // Parsing succeeded.
                         *parser = cloned_parser;
-                        return Some(MacroArg::$macro_arg((*x).clone()));
+                        return Some(MacroArg::$macro_arg(x.clone()));
                     }
                 }
                 Err(mut e) => {
@@ -110,6 +124,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
     parse_macro_arg!(Expr, parse_expr);
     parse_macro_arg!(Ty, parse_ty);
     parse_macro_arg!(Pat, parse_pat);
+    parse_macro_arg!(Item, parse_item);
 
     None
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -187,6 +187,7 @@ impl Spanned for MacroArg {
             MacroArg::Expr(ref expr) => expr.span(),
             MacroArg::Ty(ref ty) => ty.span(),
             MacroArg::Pat(ref pat) => pat.span(),
+            MacroArg::Item(ref item) => item.as_ref().unwrap().span(),
         }
     }
 }

--- a/tests/source/issue-2523.rs
+++ b/tests/source/issue-2523.rs
@@ -1,0 +1,17 @@
+// rustfmt-normalize_comments: true
+
+// Do not unindent macro calls in comment with unformattable syntax.
+//! ```rust
+//! let x = 3  ;
+//! some_macro!(pub fn fn foo() (
+//!     println!("Don't unindent me!");
+//! ));
+//! ```
+
+// Format items that appear as arguments of macro call.
+//! ```rust
+//! let x = 3  ;
+//! some_macro!(pub fn foo() {
+//! println!("Don't unindent me!");
+//! });
+//! ```

--- a/tests/target/issue-2523.rs
+++ b/tests/target/issue-2523.rs
@@ -1,0 +1,17 @@
+// rustfmt-normalize_comments: true
+
+// Do not unindent macro calls in comment with unformattable syntax.
+//! ```rust
+//! let x = 3;
+//! some_macro!(pub fn fn foo() (
+//!     println!("Don't unindent me!");
+//! ));
+//! ```
+
+// Format items that appear as arguments of macro call.
+//! ```rust
+//! let x = 3;
+//! some_macro!(pub fn foo() {
+//!     println!("Don't unindent me!");
+//! });
+//! ```


### PR DESCRIPTION
`format_code_block` formats the given `code_snippet` by enclosing it inside
`fn main` block. Previously we did not add indentation to the `code_snippet`
before formatting it. This works fine as long as we can format the given
`code_snippet`, but when the code block has unformattable macro, they gets
unindented. This PR fixes it by adding proper indentation before formatting
the `code_snippet`.

For example, when formatting the following code block,

```rust
some_macro!(pub fn foo() {
    println!("Don't unindent me!");
});
```

previously we enclosed it like this:

```rust
fn main() {
some_macro!(pub fn foo() {
    println!("Don't unindent me!");
});
}
```

with this PR, we will enclose it like this:

```rust
fn main() {
    some_macro!(pub fn foo() {
        println!("Don't unindent me!");
    });
}
```

Closes #2523.