### PR TITLE
Enable doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ license = "Apache-2.0/MIT"
 build = "build.rs"
 categories = ["development-tools"]
 
-[lib]
-doctest = false
-
 [[bin]]
 name = "rustfmt"
 path = "src/bin/main.rs"

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -25,7 +25,8 @@
 //! E.g., `let foo = { aaaa; bbb; ccc }.bar.baz();`, we would layout for the
 //! following values of `chain_indent`:
 //! Block:
-//! ```
+//!
+//! ```ignore
 //! let foo = {
 //!     aaaa;
 //!     bbb;
@@ -33,8 +34,10 @@
 //! }.bar
 //!     .baz();
 //! ```
+//!
 //! Visual:
-//! ```
+//!
+//! ```ignore
 //! let foo = {
 //!               aaaa;
 //!               bbb;
@@ -47,13 +50,16 @@
 //! If the first item in the chain is a block expression, we align the dots with
 //! the braces.
 //! Block:
-//! ```
+//!
+//! ```ignore
 //! let a = foo.bar
 //!     .baz()
 //!     .qux
 //! ```
+//!
 //! Visual:
-//! ```
+//!
+//! ```ignore
 //! let a = foo.bar
 //!            .baz()
 //!            .qux

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -621,7 +621,8 @@ fn macro_style(mac: &ast::Mac, context: &RewriteContext) -> MacroStyle {
 
 /// Indent each line according to the specified `indent`.
 /// e.g.
-/// ```rust
+///
+/// ```rust,ignore
 /// foo!{
 /// x,
 /// y,
@@ -632,8 +633,10 @@ fn macro_style(mac: &ast::Mac, context: &RewriteContext) -> MacroStyle {
 /// ),
 /// }
 /// ```
+///
 /// will become
-/// ```rust
+///
+/// ```rust,ignore
 /// foo!{
 ///     x,
 ///     y,
@@ -864,7 +867,7 @@ impl MacroBranch {
 ///
 /// # Expected syntax
 ///
-/// ```
+/// ```ignore
 /// lazy_static! {
 ///     [pub] static ref NAME_1: TYPE_1 = EXPR_1;
 ///     [pub] static ref NAME_2: TYPE_2 = EXPR_2;


### PR DESCRIPTION
Doctests were disabled globally because up until #2456, they were just
formatting examples which were not supposed to compile. Now that there
is one runnable doctest, I disabled the other ones individually (by
adding the ignore directive).

I also added some empty lines around the code blocks to avoid the
following warning and instead ignore the code blocks cleanly:

```
WARNING: ... Code block is not currently run as a test, but will in future versions of rustdoc. Please ensure this code block is a runnable test, or use the `ignore` directive.
```
See rust-lang/rust#28712 for further details.