### PR TITLE
Fix print_version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,9 +26,19 @@ fn main() {
 // Try to get hash and date of the last commit on a best effort basis. If anything goes wrong
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
-    match (commit_hash(), commit_date()) {
-        (Some(hash), Some(date)) => format!(" ({} {})", hash.trim_right(), date),
+    match (channel(), commit_hash(), commit_date()) {
+        (channel, Some(hash), Some(date)) => {
+            format!("{} ({} {})", channel, hash.trim_right(), date)
+        }
         _ => String::new(),
+    }
+}
+
+fn channel() -> String {
+    if let Ok(channel) = env::var("CFG_RELEASE_CHANNEL") {
+        channel
+    } else {
+        "nightly".to_owned()
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -385,9 +385,8 @@ fn print_usage_to_stdout(opts: &Options, reason: &str) {
 
 fn print_version() {
     let version_info = format!(
-        "{}{}{}",
+        "{}-{}",
         option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
-        "-",
         include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
     );
 


### PR DESCRIPTION
On the current master `rustfmt --version` emits `rustfmt 0.4.1- (87180d90 2018-03-16)`. Looks like the change from #2478 to build.rs got removed. This PR fixes it.

With this PR `rustfmt --version` emits `rustfmt 0.4.1-nightly (ca6fc67e 2018-03-17)`.