### PR TITLE
Add config option to control spaces around colon in macro def

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -97,7 +97,7 @@ fn execute() -> i32 {
 }
 
 macro_rules! print_usage {
-    ($print: ident, $opts: ident, $reason: expr) => {{
+    ($print:ident, $opts:ident, $reason:expr) => {{
         let msg = format!("{}\nusage: cargo fmt [options]", $reason);
         $print!(
             "{}\nThis utility formats all bin and lib files of the current crate using rustfmt. \

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -103,7 +103,7 @@ impl Rewrite for MacroArg {
 
 fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
     macro_rules! parse_macro_arg {
-        ($macro_arg: ident, $parser: ident) => {
+        ($macro_arg:ident, $parser:ident) => {
             let mut cloned_parser = (*parser).clone();
             match cloned_parser.$parser() {
                 Ok(x) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -568,7 +568,7 @@ impl MacroArgKind {
 
         match *self {
             MacroArgKind::MetaVariable(ty, ref name) => {
-                Some(format!("${}: {}", name, ty.name.as_str()))
+                Some(format!("${}:{}", name, ty.name.as_str()))
             }
             MacroArgKind::Repeat(ref delim_tok, ref args, ref another, ref tok) => {
                 let (lhs, inner, rhs) = rewrite_delimited_inner(delim_tok, args)?;

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -20,7 +20,7 @@ pub trait Spanned {
 }
 
 macro_rules! span_with_attrs_lo_hi {
-    ($this: ident, $lo: expr, $hi: expr) => {{
+    ($this:ident, $lo:expr, $hi:expr) => {{
         let attrs = outer_attributes(&$this.attrs);
         if attrs.is_empty() {
             mk_sp($lo, $hi)
@@ -31,13 +31,13 @@ macro_rules! span_with_attrs_lo_hi {
 }
 
 macro_rules! span_with_attrs {
-    ($this: ident) => {
+    ($this:ident) => {
         span_with_attrs_lo_hi!($this, $this.span.lo(), $this.span.hi())
     };
 }
 
 macro_rules! implement_spanned {
-    ($this: ty) => {
+    ($this:ty) => {
         impl Spanned for $this {
             fn span(&self) -> Span {
                 span_with_attrs!(self)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -266,7 +266,7 @@ macro_rules! msg {
 // For format_missing and last_pos, need to use the source callsite (if applicable).
 // Required as generated code spans aren't guaranteed to follow on from the last span.
 macro_rules! source {
-    ($this: ident, $sp: expr) => {
+    ($this:ident, $sp:expr) => {
         $sp.source_callsite()
     };
 }
@@ -277,7 +277,7 @@ pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
 
 // Return true if the given span does not intersect with file lines.
 macro_rules! out_of_file_lines_range {
-    ($self: ident, $span: expr) => {
+    ($self:ident, $span:expr) => {
         !$self.config.file_lines().is_all()
             && !$self
                 .config
@@ -287,7 +287,7 @@ macro_rules! out_of_file_lines_range {
 }
 
 macro_rules! skip_out_of_file_lines_range {
-    ($self: ident, $span: expr) => {
+    ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {
             return None;
         }
@@ -295,7 +295,7 @@ macro_rules! skip_out_of_file_lines_range {
 }
 
 macro_rules! skip_out_of_file_lines_range_visitor {
-    ($self: ident, $span: expr) => {
+    ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {
             $self.push_rewrite($span, None);
             return;

--- a/tests/target/macro_not_expr.rs
+++ b/tests/target/macro_not_expr.rs
@@ -1,5 +1,5 @@
 macro_rules! test {
-    ($($t: tt)*) => {};
+    ($($t:tt)*) => {};
 }
 
 fn main() {

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -2,33 +2,33 @@
 
 macro_rules! m {
     () => {};
-    ($x: ident) => {};
-    ($m1: ident, $m2: ident, $x: ident) => {};
-    ($($beginning: ident),*; $middle: ident; $($end: ident),*) => {};
+    ($x:ident) => {};
+    ($m1:ident, $m2:ident, $x:ident) => {};
+    ($($beginning:ident),*; $middle:ident; $($end:ident),*) => {};
     (
-        $($beginning: ident),*;
-        $middle: ident;
-        $($end: ident),*;
-        $($beginning: ident),*;
-        $middle: ident;
-        $($end: ident),*
+        $($beginning:ident),*;
+        $middle:ident;
+        $($end:ident),*;
+        $($beginning:ident),*;
+        $middle:ident;
+        $($end:ident),*
     ) => {};
-    ($name: ident($($dol: tt $var: ident)*) $($body: tt)*) => {};
+    ($name:ident($($dol:tt $var:ident)*) $($body:tt)*) => {};
     (
-        $($i: ident : $ty: ty, $def: expr, $stb: expr, $($dstring: tt),+);+ $(;)*
-        $($i: ident : $ty: ty, $def: expr, $stb: expr, $($dstring: tt),+);+ $(;)*
+        $($i:ident : $ty:ty, $def:expr, $stb:expr, $($dstring:tt),+);+ $(;)*
+        $($i:ident : $ty:ty, $def:expr, $stb:expr, $($dstring:tt),+);+ $(;)*
     ) => {};
-    ($foo: tt foo[$attr: meta] $name: ident) => {};
-    ($foo: tt[$attr: meta] $name: ident) => {};
-    ($foo: tt &'a[$attr: meta] $name: ident) => {};
-    ($foo: tt foo #[$attr: meta] $name: ident) => {};
-    ($foo: tt #[$attr: meta] $name: ident) => {};
-    ($foo: tt &'a #[$attr: meta] $name: ident) => {};
-    ($x: tt foo bar foo bar foo bar $y: tt => x * y * z $z: tt, $($a: tt),*) => {};
+    ($foo:tt foo[$attr:meta] $name:ident) => {};
+    ($foo:tt[$attr:meta] $name:ident) => {};
+    ($foo:tt &'a[$attr:meta] $name:ident) => {};
+    ($foo:tt foo #[$attr:meta] $name:ident) => {};
+    ($foo:tt #[$attr:meta] $name:ident) => {};
+    ($foo:tt &'a #[$attr:meta] $name:ident) => {};
+    ($x:tt foo bar foo bar foo bar $y:tt => x * y * z $z:tt, $($a:tt),*) => {};
 }
 
 macro_rules! impl_a_method {
-    ($n: ident($a: ident : $ta: ty) -> $ret: ty { $body: expr }) => {
+    ($n:ident($a:ident : $ta:ty) -> $ret:ty { $body:expr }) => {
         fn $n($a: $ta) -> $ret {
             $body
         }
@@ -38,7 +38,7 @@ macro_rules! impl_a_method {
             };
         }
     };
-    ($n: ident($a: ident : $ta: ty, $b: ident : $tb: ty) -> $ret: ty { $body: expr }) => {
+    ($n:ident($a:ident : $ta:ty, $b:ident : $tb:ty) -> $ret:ty { $body:expr }) => {
         fn $n($a: $ta, $b: $tb) -> $ret {
             $body
         }
@@ -49,8 +49,7 @@ macro_rules! impl_a_method {
         }
     };
     (
-        $n: ident($a: ident : $ta: ty, $b: ident : $tb: ty, $c: ident : $tc: ty) ->
-        $ret: ty { $body: expr }
+        $n:ident($a:ident : $ta:ty, $b:ident : $tb:ty, $c:ident : $tc:ty) -> $ret:ty { $body:expr }
     ) => {
         fn $n($a: $ta, $b: $tb, $c: $tc) -> $ret {
             $body
@@ -62,8 +61,8 @@ macro_rules! impl_a_method {
         }
     };
     (
-        $n: ident($a: ident : $ta: ty, $b: ident : $tb: ty, $c: ident : $tc: ty, $d: ident : $td: ty) ->
-        $ret: ty { $body: expr }
+        $n:ident($a:ident : $ta:ty, $b:ident : $tb:ty, $c:ident : $tc:ty, $d:ident : $td:ty) ->
+        $ret:ty { $body:expr }
     ) => {
         fn $n($a: $ta, $b: $tb, $c: $tc, $d: $td) -> $ret {
             $body
@@ -78,7 +77,7 @@ macro_rules! impl_a_method {
 
 macro_rules! m {
     // a
-    ($expr: expr, $($func: ident)*) => {{
+    ($expr:expr, $($func:ident)*) => {{
         let x = $expr;
         $func(x)
     }};
@@ -91,7 +90,7 @@ macro_rules! m {
     (@tag) => {};
 
     // d
-    ($item: ident) => {
+    ($item:ident) => {
         mod macro_item {
             struct $item;
         }
@@ -100,7 +99,7 @@ macro_rules! m {
 
 macro m2 {
     // a
-    ($expr: expr, $($func: ident)*) => {{
+    ($expr:expr, $($func:ident)*) => {{
         let x = $expr;
         $func(x)
     }}
@@ -113,7 +112,7 @@ macro m2 {
     (@tag) => {}
 
     // d
-    ($item: ident) => {
+    ($item:ident) => {
         mod macro_item {
             struct $item;
         }
@@ -156,10 +155,10 @@ macro_rules! m {
 // #2439
 macro_rules! m {
     (
-        $line0_xxxxxxxxxxxxxxxxx: expr,
-        $line1_xxxxxxxxxxxxxxxxx: expr,
-        $line2_xxxxxxxxxxxxxxxxx: expr,
-        $line3_xxxxxxxxxxxxxxxxx: expr,
+        $line0_xxxxxxxxxxxxxxxxx:expr,
+        $line1_xxxxxxxxxxxxxxxxx:expr,
+        $line2_xxxxxxxxxxxxxxxxx:expr,
+        $line3_xxxxxxxxxxxxxxxxx:expr,
     ) => {};
 }
 
@@ -173,7 +172,7 @@ macro_rules! m [
 ];
 
 // #2470
-macro foo($type_name: ident, $docs: expr) {
+macro foo($type_name:ident, $docs:expr) {
     #[allow(non_camel_case_types)]
     #[doc=$docs]
     #[derive(Debug, Clone, Copy)]
@@ -182,13 +181,13 @@ macro foo($type_name: ident, $docs: expr) {
 
 // #2534
 macro_rules! foo {
-    ($a: ident : $b: ty) => {};
-    ($a: ident $b: ident $c: ident) => {};
+    ($a:ident : $b:ty) => {};
+    ($a:ident $b:ident $c:ident) => {};
 }
 
 // #2538
 macro_rules! add_message_to_notes {
-    ($msg: expr) => {{
+    ($msg:expr) => {{
         let mut lines = message.lines();
         notes.push_str(&format!("\n{}: {}", level, lines.next().unwrap()));
         for line in lines {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -141,7 +141,7 @@ fn issue_1555() {
 
 fn issue1178() {
     macro_rules! foo {
-        (#[$attr: meta] $name: ident) => {};
+        (#[$attr:meta] $name:ident) => {};
     }
 
     foo!(
@@ -246,7 +246,7 @@ fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
 
 // #878
 macro_rules! try_opt {
-    ($expr: expr) => {
+    ($expr:expr) => {
         match $expr {
             Some(val) => val,
 
@@ -891,7 +891,7 @@ fn macro_in_pattern_position() {
 
 macro foo() {}
 
-pub macro bar($x: ident + $y: expr;) {
+pub macro bar($x:ident + $y:expr;) {
     fn foo($x: Foo) {
         long_function(
             a_long_argument_to_a_long_function_is_what_this_is(AAAAAAAAAAAAAAAAAAAAAAAAAAAA),


### PR DESCRIPTION
This PR adds two config options `space_after_colon_macro_def` and `space_before_colon_macro_def` which control spaces around a colon of metavariable definitions in macro def.

Also this PR changes the default format to **not** to put a space after a colon. I think that the formatting without a space is more popular in the wild, and incurs less conflicts with users.

Alternatively we could decide whether we should add a space or not based on what kind of separator is used in the definition: if arguments are separated by `,`, then we add a space after each colon, but if weird separators, like `=>`, `:` or even just a space, are used, then we do not add a space. However this seems too complex and error-prone, so I would rather keep the rule simple and consistent.

@nrc Do you have any thoughts on this?

--- 

Do we need two options? I think that we do not need to add `space_before_colon_macro_def`, I just added it for consistency with other options.