### PR TITLE
Don't index a string with chars().count()/position()

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -167,7 +167,7 @@ impl Rewrite for ast::NestedMetaItem {
 
 fn has_newlines_before_after_comment(comment: &str) -> (&str, &str) {
     // Look at before and after comment and see if there are any empty lines.
-    let comment_begin = comment.chars().position(|c| c == '/');
+    let comment_begin = comment.find('/');
     let len = comment_begin.unwrap_or_else(|| comment.len());
     let mlb = count_newlines(&comment[..len]) > 1;
     let mla = if comment_begin.is_none() {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -173,13 +173,11 @@ fn has_newlines_before_after_comment(comment: &str) -> (&str, &str) {
     let mla = if comment_begin.is_none() {
         mlb
     } else {
-        let comment_end = comment.chars().rev().position(|c| !c.is_whitespace());
-        let len = comment_end.unwrap();
         comment
             .chars()
             .rev()
-            .take(len)
-            .filter(|c| *c == '\n')
+            .take_while(|c| c.is_whitespace())
+            .filter(|&c| c == '\n')
             .count() > 1
     };
     (if mlb { "\n" } else { "" }, if mla { "\n" } else { "" })

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -187,7 +187,7 @@ pub fn combine_strs_with_missing_comments(
     // expression and the second expression or the missing comment. We will preserve the original
     // layout whenever possible.
     let original_snippet = context.snippet(span);
-    let prefer_same_line = if let Some(pos) = original_snippet.chars().position(|c| c == '/') {
+    let prefer_same_line = if let Some(pos) = original_snippet.find('/') {
         !original_snippet[..pos].contains('\n')
     } else {
         !original_snippet.contains('\n')
@@ -523,7 +523,7 @@ pub fn recover_missing_comment_in_span(
         Some(String::new())
     } else {
         let missing_snippet = context.snippet(span);
-        let pos = missing_snippet.chars().position(|c| c == '/').unwrap_or(0);
+        let pos = missing_snippet.find('/').unwrap_or(0);
         // 1 = ` `
         let total_width = missing_comment.len() + used_width + 1;
         let force_new_line_before_comment =

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -227,13 +227,13 @@ fn find_unnumbered_issue() {
         let mut seeker = BadIssueSeeker::new(ReportTactic::Unnumbered, ReportTactic::Unnumbered);
         assert_eq!(
             Some(failing_pos),
-            text.chars().position(|c| seeker.inspect(c).is_some())
+            text.find(|c| seeker.inspect(c).is_some())
         );
     }
 
     fn check_pass(text: &str) {
         let mut seeker = BadIssueSeeker::new(ReportTactic::Unnumbered, ReportTactic::Unnumbered);
-        assert_eq!(None, text.chars().position(|c| seeker.inspect(c).is_some()));
+        assert_eq!(None, text.find(|c| seeker.inspect(c).is_some()));
     }
 
     check_fail("TODO\n", 4);

--- a/src/items.rs
+++ b/src/items.rs
@@ -977,7 +977,7 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
             result.push_str(&where_clause_str);
         } else {
             let item_snippet = context.snippet(item.span);
-            if let Some(lo) = item_snippet.chars().position(|c| c == '/') {
+            if let Some(lo) = item_snippet.find('/') {
                 // 1 = `{`
                 let comment_hi = body_lo - BytePos(1);
                 let comment_lo = item.span.lo() + BytePos(lo as u32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,12 +153,14 @@ impl FormattingError {
         match self.kind {
             ErrorKind::LineOverflow(found, max) => (max, found - max),
             ErrorKind::TrailingWhitespace => {
-                let trailing_ws_len = self.line_buffer
-                    .chars()
-                    .rev()
-                    .take_while(|c| c.is_whitespace())
-                    .count();
-                (self.line_buffer.len() - trailing_ws_len, trailing_ws_len)
+                let trailing_ws_start = self.line_buffer
+                    .rfind(|c: char| !c.is_whitespace())
+                    .map(|pos| pos + 1)
+                    .unwrap_or(0);
+                (
+                    trailing_ws_start,
+                    self.line_buffer.len() - trailing_ws_start,
+                )
             }
             _ => unreachable!(),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -251,7 +251,8 @@ pub fn stmt_expr(stmt: &ast::Stmt) -> Option<&ast::Expr> {
 
 #[inline]
 pub fn count_newlines(input: &str) -> usize {
-    input.chars().filter(|&c| c == '\n').count()
+    // Using `as_bytes` to omit UTF-8 decoding
+    input.as_bytes().iter().filter(|&&c| c == b'\n').count()
 }
 
 macro_rules! msg {


### PR DESCRIPTION
and micro-optimizations I found while grepping with `.chars()`.