### PR TITLE
Do not add the beginning vert to the match arm

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -133,13 +133,14 @@ pub fn rewrite_match(
             Some(context.snippet(span).to_owned())
         }
     } else {
+        let span_after_cond = mk_sp(cond.span.hi(), span.hi());
         Some(format!(
             "match {}{}{{\n{}{}{}\n{}}}",
             cond_str,
             block_sep,
             inner_attrs_str,
             nested_indent_str,
-            rewrite_match_arms(context, arms, shape, span, open_brace_pos)?,
+            rewrite_match_arms(context, arms, shape, span_after_cond, open_brace_pos)?,
             shape.indent.to_string(context.config),
         ))
     }

--- a/tests/target/issue-2554.rs
+++ b/tests/target/issue-2554.rs
@@ -1,0 +1,13 @@
+// #2554
+// Do not add the beginning vert to the first match arm's pattern.
+
+fn main() {
+    match foo(|_| {
+        bar(|_| {
+            //
+        })
+    }) {
+        Ok(()) => (),
+        Err(_) => (),
+    }
+}


### PR DESCRIPTION
Pass the span after the match's condition expression.
Closes #2554.