### PR TITLE
Use vertical layout for complex attributes

### DIFF
--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -1,5 +1,9 @@
 // rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_playground_url = "https://play.rust-lang.org/", test(attr(deny(warnings))))]
 
 //! Doc comment
 

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -1,5 +1,10 @@
 // rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 
 //! Doc comment
 

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -1,10 +1,12 @@
 // rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/",
-       test(attr(deny(warnings))))]
+#![doc(
+    html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+    html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+    html_root_url = "https://doc.rust-lang.org/nightly/",
+    html_playground_url = "https://play.rust-lang.org/",
+    test(attr(deny(warnings)))
+)]
 
 //! Doc comment
 

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -156,8 +156,10 @@ pub enum Bencoding<'i> {
 pub enum CoreResourceMsg {
     SetCookieForUrl(
         ServoUrl,
-        #[serde(deserialize_with = "::hyper_serde::deserialize",
-                serialize_with = "::hyper_serde::serialize")]
+        #[serde(
+            deserialize_with = "::hyper_serde::deserialize",
+            serialize_with = "::hyper_serde::serialize"
+        )]
         Cookie,
         CookieSource,
     ),
@@ -221,7 +223,9 @@ enum State {
 // #2190
 #[derive(Debug, Fail)]
 enum AnError {
-    #[fail(display = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    #[fail(
+        display = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )]
     UnexpectedSingleToken { token: syn::Token },
 }
 


### PR DESCRIPTION
Currently rustfmt forces mixed layout when formatting attributes. This is suboptimal when the attribute has complex inner items. This PR fixes it by disallowing mixed layout when every item in the attribute is either list or assignment.