### PR TITLE
Update parser initialization to match rust-lang/rust#49387

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,7 +700,8 @@ fn format_input_inner<T: Write>(
         };
         Handler::with_tty_emitter(color_cfg, true, false, Some(codemap.clone()))
     };
-    let mut parse_session = ParseSess::with_span_handler(tty_handler, codemap.clone());
+    let env_sb = Lrc::new(EnvSandbox::default());
+    let mut parse_session = ParseSess::with_span_handler(tty_handler, codemap.clone(), env_sb);
 
     let main_file = match input {
         Input::File(ref file) => FileName::Real(file.clone()),


### PR DESCRIPTION
I changed the API for `ParseSess::with_span_handler()` in rust-lang/rust#49387, but I'm not sure how to coordinate cross-repo changes like this.