### PR TITLE
Avoid panicking on macro call with a single comma

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -76,8 +76,7 @@ pub enum MacroArg {
     Expr(ptr::P<ast::Expr>),
     Ty(ptr::P<ast::Ty>),
     Pat(ptr::P<ast::Pat>),
-    // `parse_item` returns `Option<ptr::P<ast::Item>>`.
-    Item(Option<ptr::P<ast::Item>>),
+    Item(ptr::P<ast::Item>),
 }
 
 impl Rewrite for ast::Item {
@@ -96,14 +95,14 @@ impl Rewrite for MacroArg {
             MacroArg::Expr(ref expr) => expr.rewrite(context, shape),
             MacroArg::Ty(ref ty) => ty.rewrite(context, shape),
             MacroArg::Pat(ref pat) => pat.rewrite(context, shape),
-            MacroArg::Item(ref item) => item.as_ref().and_then(|item| item.rewrite(context, shape)),
+            MacroArg::Item(ref item) => item.rewrite(context, shape),
         }
     }
 }
 
 fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
     macro_rules! parse_macro_arg {
-        ($macro_arg:ident, $parser:ident) => {
+        ($macro_arg:ident, $parser:ident, $f:expr) => {
             let mut cloned_parser = (*parser).clone();
             match cloned_parser.$parser() {
                 Ok(x) => {
@@ -112,7 +111,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
                     } else {
                         // Parsing succeeded.
                         *parser = cloned_parser;
-                        return Some(MacroArg::$macro_arg(x.clone()));
+                        return Some(MacroArg::$macro_arg($f(x)?));
                     }
                 }
                 Err(mut e) => {
@@ -123,10 +122,11 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
         };
     }
 
-    parse_macro_arg!(Expr, parse_expr);
-    parse_macro_arg!(Ty, parse_ty);
-    parse_macro_arg!(Pat, parse_pat);
-    parse_macro_arg!(Item, parse_item);
+    parse_macro_arg!(Expr, parse_expr, |x: ptr::P<ast::Expr>| Some(x));
+    parse_macro_arg!(Ty, parse_ty, |x: ptr::P<ast::Ty>| Some(x));
+    parse_macro_arg!(Pat, parse_pat, |x: ptr::P<ast::Pat>| Some(x));
+    // `parse_item` returns `Option<ptr::P<ast::Item>>`.
+    parse_macro_arg!(Item, parse_item, |x: Option<ptr::P<ast::Item>>| x);
 
     None
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -187,7 +187,7 @@ impl Spanned for MacroArg {
             MacroArg::Expr(ref expr) => expr.span(),
             MacroArg::Ty(ref ty) => ty.span(),
             MacroArg::Pat(ref pat) => pat.span(),
-            MacroArg::Item(ref item) => item.as_ref().unwrap().span(),
+            MacroArg::Item(ref item) => item.span(),
         }
     }
 }

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -10,6 +10,8 @@ peg_file!   modname  ("mygrammarfile.rustpeg");
 fn main() {
     foo! ( );
 
+    foo!(,);
+
     bar!( a , b , c );
 
     bar!( a , b , c , );

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -15,6 +15,8 @@ peg_file! modname("mygrammarfile.rustpeg");
 fn main() {
     foo!();
 
+    foo!(,);
+
     bar!(a, b, c);
 
     bar!(a, b, c,);


### PR DESCRIPTION
`parse_item` from libsyntax may return `None`, so we need to discard
the result in that case.

Closes #2569.