### PR TITLE
Improve `where_single_line` help

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -889,7 +889,7 @@ See also [`control_brace_style`](#control_brace_style).
 
 ## `where_single_line`
 
-To force single line where layout
+Forces the `where` clause to be laid out on a single line.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,7 +61,7 @@ create_config! {
     struct_lit_single_line: bool, true, false,
         "Put small struct literals on a single line";
     fn_single_line: bool, false, false, "Put single-expression functions on a single line";
-    where_single_line: bool, false, false, "To force single line where layout";
+    where_single_line: bool, false, false, "Force where clauses to be on a single line";
 
     // Imports
     imports_indent: IndentStyle, IndentStyle::Visual, false, "Indent of imports";


### PR DESCRIPTION
Amends #2030 (adding option)
Amends #2215 (adding documentation)

Remember that `where` is not just a keyword but an English word, making both the option name and the documentation extremely hard to read without emphasis. I added the emphasis in the markdown, and reworded a little.