### PR TITLE
Rerun build.rs only when .git/HEAD or CFG_RELEASE_CHANNEL is changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-env-changed=CFG_RELEASE_CHANNEL");
+
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     File::create(out_dir.join("commit-info.txt"))


### PR DESCRIPTION
Cargo rebuilds the project (even if source codes are unchanged) when any file in the project directry is changed and `build.rs` is run, which takes 5 seconds on my machine. This PR prevents unnecessary runs of it.