### PR TITLE
Do not indent or unindent inside string literal 

### DIFF
--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -348,6 +348,20 @@ macro lex_err($kind: ident $(, $body: expr)*) {
 methods![ get, post, delete, ];
 methods!( get, post, delete, );
 
+// #2588
+macro_rules! m {
+    () => {
+        r#"
+            test
+        "#
+    };
+}
+fn foo() {
+    f!{r#"
+            test
+       "#};
+}
+
 // #2591
 fn foo() {
     match 0u32 {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -923,6 +923,20 @@ macro lex_err($kind: ident $(, $body: expr)*) {
 methods![get, post, delete,];
 methods!(get, post, delete,);
 
+// #2588
+macro_rules! m {
+    () => {
+        r#"
+            test
+        "#
+    };
+}
+fn foo() {
+    f!{r#"
+            test
+       "#};
+}
+
 // #2591
 fn foo() {
     match 0u32 {


### PR DESCRIPTION
We manually indent/unindent code block when formatting macros or doc comments, but these modifications should not applied to string literals (except when the line of string literal ends with `\`).

Closes #2588.