### PR TITLE
Merge imports

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1084,6 +1084,28 @@ use foo::{aaa,
           fff};
 ```
 
+## `merge_imports`
+
+Merge multiple imports into a single nested import.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+#### `false` (default):
+
+```rust
+use foo::{a, c, d};
+use foo::{b, g};
+use foo::{e, f};
+```
+
+#### `true`:
+
+```rust
+use foo::{a, b, c, d, e, f, g};
+```
+
 
 ## `match_block_trailing_comma`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,6 +66,7 @@ create_config! {
     // Imports
     imports_indent: IndentStyle, IndentStyle::Visual, false, "Indent of imports";
     imports_layout: ListTactic, ListTactic::Mixed, false, "Item layout inside a import block";
+    merge_imports: bool, false, false, "Merge imports";
 
     // Ordering
     reorder_extern_crates: bool, true, false, "Reorder extern crate statements alphabetically";

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -446,9 +446,7 @@ impl UseTree {
     }
 
     fn has_comment(&self) -> bool {
-        self.list_item.as_ref().map_or(false, |list_item| {
-            list_item.pre_comment.is_some() || list_item.post_comment.is_some()
-        })
+        self.list_item.as_ref().map_or(false, ListItem::has_comment)
     }
 
     fn same_visibility(&self, other: &UseTree) -> bool {
@@ -526,7 +524,6 @@ impl UseTree {
             if *a == b {
                 len = i + 1;
                 new_path.push(b);
-                continue;
             } else {
                 len = i;
                 break;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -80,6 +80,16 @@ pub struct ListItem {
 }
 
 impl ListItem {
+    pub fn empty() -> ListItem {
+        ListItem {
+            pre_comment: None,
+            pre_comment_style: ListItemCommentStyle::None,
+            item: None,
+            post_comment: None,
+            new_lines: false,
+        }
+    }
+
     pub fn inner_as_ref(&self) -> &str {
         self.item.as_ref().map_or("", |s| s)
     }

--- a/tests/source/merge_imports.rs
+++ b/tests/source/merge_imports.rs
@@ -1,0 +1,26 @@
+// rustfmt-merge_imports: true
+// rustfmt-reorder_imports: true
+// rustfmt-reorder_imported_names: true
+
+use a::{c,d,b};
+use a::{d, e, b, a, f};
+use a::{f, g, c};
+
+#[doc(hidden)]
+use a::b;
+use a::c;
+use a::d;
+
+use a::{c, d, e};
+#[doc(hidden)]
+use a::b;
+use a::d;
+
+pub use foo::bar;
+use foo::{a, b, c};
+pub use foo::foobar;
+
+use a::{b::{c::*}};
+use a::{b::{c::{}}};
+use a::{b::{c::d}};
+use a::{b::{c::{xxx, yyy, zzz}}};

--- a/tests/target/merge_imports.rs
+++ b/tests/target/merge_imports.rs
@@ -1,0 +1,18 @@
+// rustfmt-merge_imports: true
+// rustfmt-reorder_imports: true
+// rustfmt-reorder_imported_names: true
+
+use a::{a, b, c, d, e, f, g};
+
+#[doc(hidden)]
+use a::b;
+use a::{c, d};
+
+#[doc(hidden)]
+use a::b;
+use a::{c, d, e};
+
+use foo::{a, b, c};
+pub use foo::{bar, foobar};
+
+use a::b::c::{d, xxx, yyy, zzz, *};


### PR DESCRIPTION
This PR adds a `merge_imports` config option, which merges multiple imports with the same prefix into a single nested import.

Thoughts:
1. We should not merge imports with different visibility or attributes.
2. In the previous review, @nrc [suggested to use different levels of merging over a simple boolean](https://github.com/rust-lang-nursery/rustfmt/pull/2475#issuecomment-367891258). I tried to use `usize` (0 means no merging, 1 means merging the top level segment, and so on), but it turned out to be kind of counter-intuitive IMO, so came back to true/false. 

Closes #1383. Closes #2452. Closes #2544.