### PR TITLE
update rustc_ap_syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_cratesio_shim"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -329,20 +329,20 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -350,32 +350,32 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "89.0.0"
+version = "91.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,7 +400,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,12 +665,12 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
-"checksum rustc-ap-rustc_cratesio_shim 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a78bda69468474cd71e758ae38e6941e85f836024621134f302d1186c0e8dc24"
-"checksum rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f5888f20a213def17eae391dc1ccc35d45bdafb55a50f6ede64366309928adf"
-"checksum rustc-ap-rustc_errors 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec73f8e6d50d8354f8c73a8933c7247c1da0c83c165e43a6453586ece2f1fc44"
-"checksum rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4c01e2e699c5218cd6a4259d0b361f260300c74b48389a968868e902c7dbc5"
-"checksum rustc-ap-syntax 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb3954b2f98d9c05ea0cbe8d4d72352552ed20f22de7083c04576cdd6f8b432f"
-"checksum rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6efc72a1191597fbaf780158b2bad3922820557606607a26d8088852fc416f5"
+"checksum rustc-ap-rustc_cratesio_shim 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd7571780b3232786f538b4e72f4a8d7fcffbb4a951d3861e18142d3cf2f0ac"
+"checksum rustc-ap-rustc_data_structures 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae9ebbcbe26ea53eb0f3162c109892cd69ebb5efc986f3a21bce4891adf628f"
+"checksum rustc-ap-rustc_errors 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c8385e5cf62344a4c6b2446723da0a82dad7ec97b2988b6494a197f231fc4b9"
+"checksum rustc-ap-serialize 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d08a7e3ce1d87fda88fdf51bdfec5886f42bfd93ce7fcf1d69fcd0a23d1ab4ea"
+"checksum rustc-ap-syntax 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06b7a6da9b99e9a2e31f9325216dc5d477eb5d9bd88c7bb05b5e97e88d06d675"
+"checksum rustc-ap-syntax_pos 91.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "582d30a1308f6598b3636bc244efacd8551c825ed6be2aa594257fbf772d1161"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8674d439c964889e2476f474a3bf198cc9e199e77499960893bac5de7e9218a4"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ env_logger = "0.5"
 getopts = "0.2"
 derive-new = "0.5"
 cargo_metadata = "0.5.1"
-rustc-ap-syntax = "89.0.0"
+rustc-ap-syntax = "91.0.0"
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -200,9 +200,9 @@ fn allow_mixed_tactic_for_nested_metaitem_list(list: &[ast::NestedMetaItem]) -> 
 impl Rewrite for ast::MetaItem {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         Some(match self.node {
-            ast::MetaItemKind::Word => String::from(&*self.name.as_str()),
+            ast::MetaItemKind::Word => String::from(&*self.ident.name.as_str()),
             ast::MetaItemKind::List(ref list) => {
-                let name = self.name.as_str();
+                let name = self.ident.name.as_str();
                 let item_shape = match context.config.indent_style() {
                     IndentStyle::Block => shape
                         .block_indent(context.config.tab_spaces())
@@ -259,7 +259,7 @@ impl Rewrite for ast::MetaItem {
                 }
             }
             ast::MetaItemKind::NameValue(ref literal) => {
-                let name = self.name.as_str();
+                let name = self.ident.name.as_str();
                 // 3 = ` = `
                 let lit_shape = shape.shrink_left(name.len() + 3)?;
                 // `rewrite_literal` returns `None` when `literal` exceeds max

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -438,9 +438,9 @@ fn rewrite_chain_subexpr(
                 },
                 _ => &[],
             };
-            rewrite_method_call(segment.identifier, types, expressions, span, context, shape)
+            rewrite_method_call(segment.ident, types, expressions, span, context, shape)
         }
-        ast::ExprKind::Field(_, ref field) => rewrite_element(format!(".{}", field.node)),
+        ast::ExprKind::Field(_, ref field) => rewrite_element(format!(".{}", field.name)),
         ast::ExprKind::TupField(ref expr, ref field) => {
             let space = match expr.node {
                 ast::ExprKind::TupField(..) => " ",

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -173,7 +173,13 @@ pub fn format_expr(
         },
         ast::ExprKind::Closure(capture, movability, ref fn_decl, ref body, _) => {
             closures::rewrite_closure(
-                capture, movability, fn_decl, body, expr.span, context, shape,
+                capture,
+                movability,
+                fn_decl,
+                body,
+                expr.span,
+                context,
+                shape,
             )
         }
         ast::ExprKind::Try(..)
@@ -928,7 +934,8 @@ impl<'a> ControlFlow<'a> {
 
         // `for event in event`
         // Do not include label in the span.
-        let lo = self.label.map_or(self.span.lo(), |label| label.span.hi());
+        let lo = self.label
+            .map_or(self.span.lo(), |label| label.ident.span.hi());
         let between_kwd_cond = mk_sp(
             context
                 .snippet_provider
@@ -1702,7 +1709,7 @@ pub fn rewrite_field(
     if !attrs_str.is_empty() {
         attrs_str.push_str(&shape.indent.to_string_with_newline(context.config));
     };
-    let name = field.ident.node.to_string();
+    let name = &field.ident.name.to_string();
     if field.is_shorthand {
         Some(attrs_str + &name)
     } else {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -28,7 +28,7 @@ use std::borrow::Cow;
 /// Returns a name imported by a `use` declaration. e.g. returns `Ordering`
 /// for `std::cmp::Ordering` and `self` for `std::cmp::self`.
 pub fn path_to_imported_ident(path: &ast::Path) -> ast::Ident {
-    path.segments.last().unwrap().identifier
+    path.segments.last().unwrap().ident
 }
 
 impl<'a> FmtVisitor<'a> {
@@ -129,7 +129,7 @@ impl UseSegment {
     }
 
     fn from_path_segment(path_seg: &ast::PathSegment) -> Option<UseSegment> {
-        let name = path_seg.identifier.name.as_str();
+        let name = path_seg.ident.name.as_str();
         if name == "{{root}}" {
             return None;
         }

--- a/src/items.rs
+++ b/src/items.rs
@@ -562,10 +562,10 @@ impl<'a> FmtVisitor<'a> {
             )?,
             ast::VariantData::Unit(..) => {
                 if let Some(ref expr) = field.node.disr_expr {
-                    let lhs = format!("{} =", field.node.name);
+                    let lhs = format!("{} =", field.node.ident.name);
                     rewrite_assign_rhs(&context, lhs, &**expr, shape)?
                 } else {
-                    field.node.name.to_string()
+                    field.node.ident.name.to_string()
                 }
             }
         };
@@ -893,7 +893,7 @@ impl<'a> StructParts<'a> {
     fn from_variant(variant: &'a ast::Variant) -> Self {
         StructParts {
             prefix: "",
-            ident: variant.node.name,
+            ident: variant.node.ident,
             vis: &DEFAULT_VISIBILITY,
             def: &variant.node.data,
             generics: None,
@@ -1794,7 +1794,7 @@ pub fn span_hi_for_arg(context: &RewriteContext, arg: &ast::Arg) -> BytePos {
 
 pub fn is_named_arg(arg: &ast::Arg) -> bool {
     if let ast::PatKind::Ident(_, ident, _) = arg.pat.node {
-        ident.node != symbol::keywords::Invalid.ident()
+        ident != symbol::keywords::Invalid.ident()
     } else {
         true
     }
@@ -2263,7 +2263,7 @@ fn rewrite_args(
 
 fn arg_has_pattern(arg: &ast::Arg) -> bool {
     if let ast::PatKind::Ident(_, ident, _) = arg.pat.node {
-        ident.node != symbol::keywords::Invalid.ident()
+        ident != symbol::keywords::Invalid.ident()
     } else {
         true
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -117,7 +117,7 @@ fn parse_macro_arg(parser: &mut Parser) -> Option<MacroArg> {
 fn rewrite_macro_name(path: &ast::Path, extra_ident: Option<ast::Ident>) -> String {
     let name = if path.segments.len() == 1 {
         // Avoid using pretty-printer in the common case.
-        format!("{}!", path.segments[0].identifier)
+        format!("{}!", path.segments[0].ident)
     } else {
         format!("{}!", path)
     };

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -71,7 +71,7 @@ impl Rewrite for Pat {
                     BindingMode::ByValue(mutability) => ("", mutability),
                 };
                 let mut_infix = format_mutability(mutability);
-                let id_str = ident.node.to_string();
+                let id_str = ident.name.to_string();
                 let sub_pat = match *sub_pat {
                     Some(ref p) => {
                         // 3 - ` @ `.

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -146,7 +146,7 @@ impl Spanned for ast::TyParam {
     fn span(&self) -> Span {
         // Note that ty.span is the span for ty.ident, not the whole item.
         let lo = if self.attrs.is_empty() {
-            self.span.lo()
+            self.ident.span.lo()
         } else {
             self.attrs[0].span.lo()
         };
@@ -154,7 +154,7 @@ impl Spanned for ast::TyParam {
             return mk_sp(lo, def.span.hi());
         }
         if self.bounds.is_empty() {
-            return mk_sp(lo, self.span.hi());
+            return mk_sp(lo, self.ident.span.hi());
         }
         let hi = self.bounds[self.bounds.len() - 1].span().hi();
         mk_sp(lo, hi)
@@ -165,7 +165,7 @@ impl Spanned for ast::TyParamBound {
     fn span(&self) -> Span {
         match *self {
             ast::TyParamBound::TraitTyParamBound(ref ptr, _) => ptr.span,
-            ast::TyParamBound::RegionTyParamBound(ref l) => l.span,
+            ast::TyParamBound::RegionTyParamBound(ref l) => l.ident.span,
         }
     }
 }
@@ -173,11 +173,11 @@ impl Spanned for ast::TyParamBound {
 impl Spanned for ast::LifetimeDef {
     fn span(&self) -> Span {
         let hi = if self.bounds.is_empty() {
-            self.lifetime.span.hi()
+            self.lifetime.ident.span.hi()
         } else {
-            self.bounds[self.bounds.len() - 1].span.hi()
+            self.bounds[self.bounds.len() - 1].ident.span.hi()
         };
-        mk_sp(self.lifetime.span.lo(), hi)
+        mk_sp(self.lifetime.ident.span.lo(), hi)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,7 +119,7 @@ where
 
     for segment in iter {
         // Indicates a global path, shouldn't be rendered.
-        if segment.identifier.name == keywords::CrateRoot.name() {
+        if segment.ident.name == keywords::CrateRoot.name() {
             continue;
         }
         if first {
@@ -155,7 +155,7 @@ enum SegmentParam<'a> {
 impl<'a> Spanned for SegmentParam<'a> {
     fn span(&self) -> Span {
         match *self {
-            SegmentParam::LifeTime(lt) => lt.span,
+            SegmentParam::LifeTime(lt) => lt.ident.span,
             SegmentParam::Type(ty) => ty.span,
             SegmentParam::Binding(binding) => binding.span,
         }
@@ -215,7 +215,7 @@ fn rewrite_segment(
     shape: Shape,
 ) -> Option<String> {
     let mut result = String::with_capacity(128);
-    result.push_str(&segment.identifier.name.as_str());
+    result.push_str(&segment.ident.name.as_str());
 
     let ident_len = result.len();
     let shape = if context.use_block_indent() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,7 @@ pub fn format_visibility(vis: &Visibility) -> Cow<'static, str> {
         VisibilityKind::Crate(CrateSugar::JustCrate) => Cow::from("crate "),
         VisibilityKind::Restricted { ref path, .. } => {
             let Path { ref segments, .. } = **path;
-            let mut segments_iter = segments.iter().map(|seg| seg.identifier.name.to_string());
+            let mut segments_iter = segments.iter().map(|seg| seg.ident.name.to_string());
             if path.is_global() {
                 segments_iter
                     .next()
@@ -190,9 +190,9 @@ pub fn last_line_extendable(s: &str) -> bool {
 #[inline]
 fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.node {
-        MetaItemKind::Word => meta_item.name == SKIP_ANNOTATION,
+        MetaItemKind::Word => meta_item.ident.name == SKIP_ANNOTATION,
         MetaItemKind::List(ref l) => {
-            meta_item.name == "cfg_attr" && l.len() == 2 && is_skip_nested(&l[1])
+            meta_item.ident.name == "cfg_attr" && l.len() == 2 && is_skip_nested(&l[1])
         }
         _ => false,
     }

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -88,7 +88,7 @@ impl AlignedItem for ast::Field {
 
     fn rewrite_prefix(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let attrs_str = self.attrs.rewrite(context, shape)?;
-        let name = &self.ident.node.to_string();
+        let name = &self.ident.name.to_string();
         let missing_span = if self.attrs.is_empty() {
             mk_sp(self.span.lo(), self.span.lo())
         } else {


### PR DESCRIPTION
Fixes #2604 
update from `rustc_ap_syntax 89.0.0` to `91.0.0`