### PR TITLE
specify nightly required to install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ rustup component add rustfmt-preview
 
 ## Installing from source
 
-To install from source, first checkout to the tag or branch you want to install, then issue
+To install from source (nightly required), first checkout to the tag or branch you want to install, then issue
 ```
-cargo install --path  .
+cargo install --path .
 ```
 
 This will install `rustfmt` in your `~/.cargo/bin`. Make sure to add `~/.cargo/bin` directory to


### PR DESCRIPTION
when using stable cargo install fails due to #![feature] usage:

    error[E0554]: #![feature] may not be used on the stable release channel
      --> /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-serialize-67.0.0/lib.rs:24:1
       |
    24 | #![feature(rustc_private, box_syntax)]
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    
    error[E0554]: #![feature] may not be used on the stable release channel
      --> /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-serialize-67.0.0/lib.rs:25:1
       |
    25 | #![feature(core_intrinsics)]
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    
    error[E0554]: #![feature] may not be used on the stable release channel
      --> /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-serialize-67.0.0/lib.rs:26:1
       |
    26 | #![feature(i128_type)]
       | ^^^^^^^^^^^^^^^^^^^^^^
    
    error[E0554]: #![feature] may not be used on the stable release channel
      --> /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-serialize-67.0.0/lib.rs:27:1
       |
    27 | #![feature(specialization)]
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    
    error: aborting due to 4 previous errors
    
    error: Could not compile `rustc-ap-serialize`.
    warning: build failed, waiting for other jobs to finish...
    error: failed to compile `rustfmt-nightly v0.4.1 (file:///d/rustfmt)`, intermediate artifacts can be found at `/d/rustfmt/target`