### PR TITLE
Link to official nightly documentation

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -108,7 +108,7 @@ format.
 There are different nodes for every kind of item and expression in Rust. For
 more details see the source code in the compiler -
 [ast.rs](https://dxr.mozilla.org/rust/source/src/libsyntax/ast.rs) - and/or the
-[docs](http://manishearth.github.io/rust-internals-docs/syntax/ast/index.html).
+[docs](https://doc.rust-lang.org/nightly/nightly-rustc/syntax/ast/index.html).
 
 Many nodes in the AST (but not all, annoyingly) have a `Span`. A `Span` is a
 range in the source code, it can easily be converted to a snippet of source


### PR DESCRIPTION
Since https://github.com/rust-lang/rust-central-station/pull/40 has been
merged, we have a stable location for the nightly docs.