### PR TITLE
Ignore checking inexistent .git/HEAD in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,11 +11,16 @@
 use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rerun-if-changed=.git/HEAD");
+    // Only check .git/HEAD dirty status if it exists - doing so when
+    // building dependent crates may lead to false positives and rebuilds
+    if Path::new(".git/HEAD").exists() {
+        println!("cargo:rerun-if-changed=.git/HEAD");
+    }
+
     println!("cargo:rerun-if-env-changed=CFG_RELEASE_CHANNEL");
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
Dependent crates (most notably RLS) don't have .git metadata along with fetched published crate, so they might possibly be considered dirty and rebuilt, even when the file has not changed.

This happened when building RLS manually with `cargo build --release` and then spawning rls using `cargo run --release`. Appropriate error from cargo: `stale: /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-0.6.0/.git/HEAD -- missing`.

With the change Cargo does not unnecessarily rebuild rustfmt-nightly everytime local RLS is spawned by the extension.