### PR TITLE
output the result of rustfmt on ci

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -23,6 +23,7 @@ echo "Integration tests for: ${INTEGRATION}"
 function check_fmt {
     cargo fmt --all -v -- --error-on-unformatted &> rustfmt_output
     if [[ $? != 0 ]]; then
+        cat rustfmt_output
         return 1
     fi
     cat rustfmt_output


### PR DESCRIPTION
The current ci exits on error without outputting the result of running `cargo fmt` which makes issues harder to debug than necessary.

This PR changes that to always output the result of `cargo fmt`. 