### PR TITLE
try harder to print output

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -21,7 +21,7 @@ cargo install --force
 echo "Integration tests for: ${INTEGRATION}"
 
 function check_fmt {
-    cargo fmt --all -v &> rustfmt_output
+    cargo fmt --all -v 2>&1 | tee rustfmt_output
     if [[ $? != 0 ]]; then
         cat rustfmt_output
         return 1


### PR DESCRIPTION
cc @nrc this might print all the output, maybe `cargo fmt --all ...` is interacting with `set -ex` and the function was erroring before the `cat rustfmt_output` was executed.