### PR TITLE
Fix position of auto in auto trait declaration

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -963,9 +963,9 @@ pub fn format_trait(context: &RewriteContext, item: &ast::Item, offset: Indent) 
         let mut result = String::with_capacity(128);
         let header = format!(
             "{}{}{}trait ",
-            format_auto(is_auto),
             format_visibility(&item.vis),
             format_unsafety(unsafety),
+            format_auto(is_auto),
         );
         result.push_str(&header);
 

--- a/tests/source/trait.rs
+++ b/tests/source/trait.rs
@@ -95,3 +95,5 @@ trait FooBar = Foo
 
 // #2637
 auto trait Example {}
+pub auto trait PubExample {}
+pub unsafe auto trait PubUnsafeExample {}

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -133,3 +133,5 @@ trait FooBar = Foo
 
 // #2637
 auto trait Example {}
+pub auto trait PubExample {}
+pub unsafe auto trait PubUnsafeExample {}


### PR DESCRIPTION
`rustfmt 0.7.0-nightly (b0eb8993 2018-05-18)` changes the following code

```rust
#![feature(optin_builtin_traits)]

pub auto trait Auto {}
```

which compiles cleanly, to

```rust
#![feature(optin_builtin_traits)]

auto pub trait Auto {}
```

which does not compile. This PR fixes the issue and adds tests for it.