### PR TITLE
Use nightly Rust in Travis CI config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ A minimal Travis setup could look like this (requires Rust 1.24.0 or greater):
 
 ```yaml
 language: rust
+rust:
+- nightly
 before_script:
 - rustup component add rustfmt-preview
 script:


### PR DESCRIPTION
The current stable rustfmt (rustfmt 0.4.1-stable) does not contain the `--check` flag, which is used in the Travis config snippet. Once a new stable version is released, the snippet can be switched
back to stable Rust.

Fixes #2688.