### PR TITLE
Trim unnecessary whitespaces between a macro call and a semicolon

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -46,7 +46,13 @@ impl<'a> FmtVisitor<'a> {
     // TODO these format_missing methods are ugly. Refactor and add unit tests
     // for the central whitespace stripping loop.
     pub fn format_missing(&mut self, end: BytePos) {
-        // HACK
+        // HACK(topecongiro)
+        // We use `format_missing()` to extract a missing comment between a macro
+        // (or alike) and a trailing semicolon. Here we just try to avoid calling
+        // `format_missing_inner` in the common case where there is no such comment.
+        // This is a hack, ideally we should fix a possible bug in `format_missing_inner`
+        // or refactor `visit_mac` and `rewrite_macro`, but this should suffice to fix the
+        // issue (#2727).
         let missing_snippet = self.snippet(mk_sp(self.last_pos, end));
         if missing_snippet.trim() == ";" {
             self.push_str(";");

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -46,6 +46,13 @@ impl<'a> FmtVisitor<'a> {
     // TODO these format_missing methods are ugly. Refactor and add unit tests
     // for the central whitespace stripping loop.
     pub fn format_missing(&mut self, end: BytePos) {
+        // HACK
+        let missing_snippet = self.snippet(mk_sp(self.last_pos, end));
+        if missing_snippet.trim() == ";" {
+            self.push_str(";");
+            self.last_pos = end;
+            return;
+        }
         self.format_missing_inner(end, |this, last_snippet, _| this.push_str(last_snippet))
     }
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -97,6 +97,10 @@ fn main() {
 
     // #1092
     chain!(input, a:take!(max_size), || []);
+
+    // #2727
+    foo!("bar")
+;
 }
 
 impl X {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -124,6 +124,9 @@ fn main() {
 
     // #1092
     chain!(input, a: take!(max_size), || []);
+
+    // #2727
+    foo!("bar");
 }
 
 impl X {


### PR DESCRIPTION
Closes #2727.