### PR TITLE
Some changes to rewrite_string

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -105,12 +105,12 @@ pub fn rewrite_string<'a>(
                         while !(punctuation.contains(graphemes[cur_end - 1])
                             || graphemes[cur_end - 1].trim().is_empty())
                         {
-                            if cur_end >= graphemes.len() {
+                            cur_end += 1;
+                            if cur_end == graphemes.len() {
                                 let line = &graphemes[cur_start..].join("");
                                 result.push_str(line);
                                 break 'outer;
                             }
-                            cur_end += 1;
                         }
                         break;
                     }


### PR DESCRIPTION
## Motivation
### The changes to `cur_end`
We've already checked if `cur_end >= graphemes.len()` before entering the outer while loop and only need to check if `cur_end == graphemes.len()` as `cur_end` only increments by one.

### The changes to grapheme conditions
I believe separating the checks into functions makes the code clearer. 
The change to `whitespace_at` makes the code easier to understand for anyone reading the code, and I believe more efficient (why would you need to trim both sides of a grapheme and then check if it is empty when you can just check the characters one by one and stop when you find a non-whitespace).
The change to `punctuation_at` makes it clear that we only need to look at a single codepoint to know if a grapheme is a punctuation.