### PR TITLE
Fix test failing on windows due to crlf

### DIFF
--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -209,9 +209,9 @@ impl FileLines {
         self.file_range_matches(file_name, |r| r.lo <= line && r.hi >= line)
     }
 
-    /// Returns true if any of the lines between `lo` and `hi` from `file_name` are in `self`.
-    pub(crate) fn intersects_range(&self, file_name: &FileName, lo: usize, hi: usize) -> bool {
-        self.file_range_matches(file_name, |r| r.intersects(Range::new(lo, hi)))
+    /// Returns true if all the lines between `lo` and `hi` from `file_name` are in `self`.
+    pub(crate) fn contains_range(&self, file_name: &FileName, lo: usize, hi: usize) -> bool {
+        self.file_range_matches(file_name, |r| r.contains(Range::new(lo, hi)))
     }
 }
 

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -189,7 +189,7 @@ impl<'a> FmtVisitor<'a> {
             debug!("{:?}: {:?}", kind, subslice);
 
             let newline_count = count_newlines(subslice);
-            let within_file_lines_range = self.config.file_lines().intersects_range(
+            let within_file_lines_range = self.config.file_lines().contains_range(
                 file_name,
                 status.cur_line,
                 status.cur_line + newline_count,


### PR DESCRIPTION
fix https://github.com/rust-lang-nursery/rustfmt/issues/2737.

Don't add extra lines if the next lines should be skipped.

I have no idea why this bug seems to appear only on windows with crlf files ¯\_(ツ)_/¯