### PR TITLE
Fix breaking code block with `#` in doc comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -390,8 +390,10 @@ fn rewrite_comment_inner(
                 let code_block = {
                     let mut config = config.clone();
                     config.set().wrap_comments(false);
-                    ::format_code_block(&code_block_buffer, &config)
-                        .map_or_else(|| code_block_buffer.to_owned(), trim_custom_comment_prefix)
+                    match ::format_code_block(&code_block_buffer, &config) {
+                        Some(ref s) => trim_custom_comment_prefix(s),
+                        None => trim_custom_comment_prefix(&code_block_buffer),
+                    }
                 };
                 result.push_str(&join_code_block_with_comment_line_separator(&code_block));
                 code_block_buffer.clear();

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -406,7 +406,7 @@ fn rewrite_comment_inner(
                     // We will leave them untouched.
                     result.push_str(&comment_line_separator);
                     result.push_str(&join_code_block_with_comment_line_separator(
-                        &code_block_buffer,
+                        &trim_custom_comment_prefix(&code_block_buffer),
                     ));
                 }
             }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -505,9 +505,16 @@ fn hide_sharp_behind_comment<'a>(s: &'a str) -> Cow<'a, str> {
     }
 }
 
-fn trim_custom_comment_prefix(s: String) -> String {
+fn trim_custom_comment_prefix(s: &str) -> String {
     s.lines()
-        .map(|line| line.trim_left_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX))
+        .map(|line| {
+            let left_trimmed = line.trim_left();
+            if left_trimmed.starts_with(RUSTFMT_CUSTOM_COMMENT_PREFIX) {
+                left_trimmed.trim_left_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX)
+            } else {
+                line
+            }
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/tests/target/issue-2759.rs
+++ b/tests/target/issue-2759.rs
@@ -1,0 +1,64 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 89
+
+// Code block in doc comments that will exceed max width.
+/// ```rust
+/// extern crate actix_web;
+/// use actix_web::{actix, server, App, HttpResponse};
+///
+/// fn main() {
+///     // Run actix system, this method actually starts all async processes
+///     actix::System::run(|| {
+///         server::new(|| App::new().resource("/", |r| r.h(|_| HttpResponse::Ok())))
+///             .bind("127.0.0.1:0")
+///             .expect("Can not bind to 127.0.0.1:0")
+///             .start();
+/// #           actix::Arbiter::system().do_send(actix::msgs::SystemExit(0));
+///     });
+/// }
+/// ```
+fn foo() {}
+
+// Code block in doc comments without the closing '```'.
+/// ```rust
+/// # extern crate actix_web;
+/// use actix_web::{App, HttpResponse, http};
+///
+/// fn main() {
+///     let app = App::new()
+///         .resource(
+///             "/", |r| r.method(http::Method::GET).f(|r| HttpResponse::Ok()))
+///         .finish();
+/// }
+fn bar() {}
+
+// `#` with indent.
+/// ```rust
+/// # use std::thread;
+/// # extern crate actix_web;
+/// use actix_web::{server, App, HttpResponse};
+///
+/// struct State1;
+///
+/// struct State2;
+///
+/// fn main() {
+///     # thread::spawn(|| {
+///     server::new(|| {
+///         vec![
+///             App::with_state(State1)
+///                 .prefix("/app1")
+///                 .resource("/", |r| r.f(|r| HttpResponse::Ok()))
+///                 .boxed(),
+///             App::with_state(State2)
+///                 .prefix("/app2")
+///                 .resource("/", |r| r.f(|r| HttpResponse::Ok()))
+///                 .boxed(),
+///         ]
+///     }).bind("127.0.0.1:8080")
+///         .unwrap()
+///         .run()
+///     # });
+/// }
+/// ```
+fn foobar() {}


### PR DESCRIPTION
This PR is a followup of #2732, where I first added the support for formatting code block in doc comments with `#`. I have forgot to handle errors in the original PR:

1. When we have failed to format the code block.
2. When the code block does not have the trailing ` ``` `.
3. When the `#` is indented.

This PR fixes #2732 and handle the above cases.

Closes #2759.