### PR TITLE
update rustfmt flags that should work without targets

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -147,7 +147,11 @@ fn format_crate(
     strategy: &CargoFmtStrategy,
 ) -> Result<ExitStatus, io::Error> {
     let rustfmt_args = get_fmt_args();
-    let targets = if rustfmt_args.iter().any(|s| s == "--dump-default-config") {
+    let targets = if rustfmt_args
+        .iter()
+        .any(|s| ["--print-config", "-h", "--help", "-V", "--verison"]
+             .contains(&s.as_str()))
+    {
         HashSet::new()
     } else {
         get_targets(strategy)?


### PR DESCRIPTION
1. replace dump-default-config with print-config, should be related to https://github.com/rust-lang-nursery/rustfmt/commit/eca7796fb1cd8866189e273f7e5d1df5585b269e
2. update rustfmt flags that should work without targets

this doesn't work as expected at this moment:
```
cd /tmp && cargo fmt -- -h
`cargo manifest` failed.
```
this PR will enable commands like these without requiring users operating under a certain cargo project path:
```
cargo fmt -- --print-config default
cargo fmt -- -h
cargo fmt -- -V
```

