### PR TITLE
Fix poor formatting of impls

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2143,7 +2143,7 @@ impl WhereClauseOption {
     pub fn snuggled(current: &str) -> WhereClauseOption {
         WhereClauseOption {
             suppress_comma: false,
-            snuggle: trimmed_last_line_width(current) == 1,
+            snuggle: last_line_width(current) == 1,
             compress_where: false,
         }
     }

--- a/src/items.rs
+++ b/src/items.rs
@@ -750,7 +750,7 @@ pub fn format_impl(
             result.push_str(&outer_indent_str);
         }
 
-        if result.ends_with('{') {
+        if result.ends_with('{') && !context.config.empty_item_single_line() {
             result.push_str(&sep);
         }
         result.push('}');

--- a/src/items.rs
+++ b/src/items.rs
@@ -709,11 +709,6 @@ pub fn format_impl(
             return Some(result);
         }
 
-        if !where_clause_str.is_empty() && !where_clause_str.contains('\n') {
-            let width = offset.block_indent + context.config.tab_spaces() - 1;
-            let where_indent = Indent::new(0, width);
-            result.push_str(&where_indent.to_string_with_newline(context.config));
-        }
         result.push_str(&where_clause_str);
 
         let need_newline = last_line_contains_single_line_comment(&result) || result.contains('\n');

--- a/src/items.rs
+++ b/src/items.rs
@@ -656,6 +656,7 @@ pub fn format_impl(
         if !contains_comment(&snippet[open_pos..])
             && items.is_empty()
             && generics.where_clause.predicates.len() == 1
+            && !result.contains('\n')
         {
             option.suppress_comma();
             option.snuggle();

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -157,3 +157,6 @@ impl Foo {
 impl<'a, 'b, 'c> SomeThing<Something> for (&'a mut SomethingLong, &'b mut SomethingLong, &'c mut SomethingLong) {
     fn foo() {}
 }
+
+// #2746
+impl<'seq1, 'seq2, 'body, 'scope, Channel> Adc12< Dual, MasterRunningDma<'seq1, 'body, 'scope, Channel>, SlaveRunningDma<'seq2, 'body, 'scope>, > where Channel: DmaChannel, {}

--- a/tests/target/big-impl-block.rs
+++ b/tests/target/big-impl-block.rs
@@ -80,5 +80,4 @@ where
     S: event::Stream,
     F: for<'t> FnMut(transform::Api<'t, Stream<ContentStream<S>>>) -> transform::Api<'t, X>,
     X: event::Stream,
-{
-}
+{}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -222,3 +222,14 @@ impl<'a, 'b, 'c> SomeThing<Something>
 {
     fn foo() {}
 }
+
+// #2746
+impl<'seq1, 'seq2, 'body, 'scope, Channel>
+    Adc12<
+        Dual,
+        MasterRunningDma<'seq1, 'body, 'scope, Channel>,
+        SlaveRunningDma<'seq2, 'body, 'scope>,
+    >
+where
+    Channel: DmaChannel,
+{}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -134,13 +134,11 @@ mod m {
 
 impl<BorrowType, K, V, NodeType, HandleType>
     Handle<NodeRef<BorrowType, K, V, NodeType>, HandleType>
-{
-}
+{}
 
 impl<BorrowType, K, V, NodeType, HandleType> PartialEq
     for Handle<NodeRef<BorrowType, K, V, NodeType>, HandleType>
-{
-}
+{}
 
 mod x {
     impl<A, B, C, D> Foo
@@ -149,8 +147,7 @@ mod x {
         B: 'static,
         C: 'static,
         D: 'static,
-    {
-    }
+    {}
 }
 
 impl<ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNodeFoo>


### PR DESCRIPTION
This PR fixes two minor formatting bugs w.r. impls:

1. Currently rustfmt does not respect `empty_item_single_line` config option when formatting empty impls.
2. Putting the `where` on the same line with the indented closing bracket, which makes the following where clauses hard to read (#2746).

Closes #2746.