### PR TITLE
Clean Up code where last whitspace tracking isn't used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,7 +517,7 @@ fn format_lines(
     report: &FormatReport,
 ) {
     let mut trims = vec![];
-    let mut last_wspace: Option<usize> = None;
+    let mut last_was_space = false;
     let mut line_len = 0;
     let mut cur_line = 1;
     let mut newline_count = 0;
@@ -542,7 +542,7 @@ fn format_lines(
     }
 
     // Iterate over the chars in the file map.
-    for (kind, (b, c)) in CharClasses::new(text.chars().enumerate()) {
+    for (kind, c) in CharClasses::new(text.chars()) {
         if c == '\r' {
             continue;
         }
@@ -563,7 +563,7 @@ fn format_lines(
         if c == '\n' {
             if format_line {
                 // Check for (and record) trailing whitespace.
-                if let Some(..) = last_wspace {
+                if last_was_space {
                     if should_report_error(config, kind, is_string, &ErrorKind::TrailingWhitespace)
                     {
                         trims.push((cur_line, kind, line_buffer.clone()));
@@ -591,19 +591,13 @@ fn format_lines(
             cur_line += 1;
             format_line = config.file_lines().contains_line(name, cur_line);
             newline_count += 1;
-            last_wspace = None;
+            last_was_space = false;
             line_buffer.clear();
             is_string = false;
         } else {
             newline_count = 0;
             line_len += if c == '\t' { config.tab_spaces() } else { 1 };
-            if c.is_whitespace() {
-                if last_wspace.is_none() {
-                    last_wspace = Some(b);
-                }
-            } else {
-                last_wspace = None;
-            }
+            last_was_space = c.is_whitespace();
             line_buffer.push(c);
             if kind.is_string() {
                 is_string = true;


### PR DESCRIPTION
 * Clean up code as it took me a while to understand what variable `b` was to finally realize it wasn't used.
 * Simplify how trailing whitespace are reported ( it was using an intermediate buffer, in the current state it doesn't make sense anymore)