### PR TITLE
Add test and fix for #2794

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -247,6 +247,7 @@ impl Rewrite for ast::MetaItem {
                     shape: item_shape,
                     ends_with_newline: false,
                     preserve_newline: false,
+                    nested: false,
                     config: context.config,
                 };
                 let item_str = write_list(&item_vec, &fmt)?;

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -260,6 +260,7 @@ fn rewrite_closure_fn_decl(
         shape: arg_shape,
         ends_with_newline: false,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
     let list_str = write_list(&item_vec, &fmt)?;

--- a/src/config/lists.rs
+++ b/src/config/lists.rs
@@ -19,8 +19,6 @@ pub enum DefinitiveListTactic {
     Vertical,
     Horizontal,
     Mixed,
-    /// Tactic for nested import.
-    NestedImport,
     /// Special case tactic for `format!()`, `write!()` style macros.
     SpecialMacro(usize),
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1338,6 +1338,7 @@ pub fn rewrite_multiple_patterns(
         shape,
         ends_with_newline: false,
         preserve_newline: false,
+        nested: false,
         config: context.config,
     };
     write_list(&items, &fmt)
@@ -1902,6 +1903,7 @@ where
         shape,
         ends_with_newline: false,
         preserve_newline: false,
+        nested: false,
         config: context.config,
     };
     let list_str = write_list(&item_vec, &fmt)?;

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -727,6 +727,7 @@ fn rewrite_nested_use_tree(
         shape: nested_shape,
         ends_with_newline,
         preserve_newline: true,
+        nested: has_nested_list,
         config: context.config,
     };
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -706,16 +706,12 @@ fn rewrite_nested_use_tree(
         shape.width.saturating_sub(2)
     };
 
-    let tactic = if has_nested_list {
-        DefinitiveListTactic::NestedImport
-    } else {
-        definitive_tactic(
-            &list_items,
-            context.config.imports_layout(),
-            Separator::Comma,
-            remaining_width,
-        )
-    };
+    let tactic = definitive_tactic(
+        &list_items,
+        context.config.imports_layout(),
+        Separator::Comma,
+        remaining_width,
+    );
 
     let ends_with_newline = context.config.imports_indent() == IndentStyle::Block
         && tactic != DefinitiveListTactic::Horizontal;

--- a/src/items.rs
+++ b/src/items.rs
@@ -533,6 +533,7 @@ impl<'a> FmtVisitor<'a> {
             shape,
             ends_with_newline: true,
             preserve_newline: true,
+            nested: false,
             config: self.config,
         };
 
@@ -2307,6 +2308,7 @@ fn rewrite_args(
         shape: Shape::legacy(budget, indent),
         ends_with_newline: tactic.ends_with_newline(context.config.indent_style()),
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
 
@@ -2494,6 +2496,7 @@ fn rewrite_where_clause_rfc_style(
         shape: clause_shape,
         ends_with_newline: true,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
     let preds_str = write_list(&items.collect::<Vec<_>>(), &fmt)?;
@@ -2607,6 +2610,7 @@ fn rewrite_where_clause(
         shape: Shape::legacy(budget, offset),
         ends_with_newline: tactic.ends_with_newline(context.config.indent_style()),
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
     let preds_str = write_list(&item_vec, &fmt)?;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -282,14 +282,13 @@ where
                 result.push('\n');
                 result.push_str(indent_str);
             }
-            DefinitiveListTactic::Mixed | DefinitiveListTactic::NestedImport => {
+            DefinitiveListTactic::Mixed => {
                 let total_width = total_item_width(item) + item_sep_len;
 
                 // 1 is space between separator and item.
                 if (line_len > 0 && line_len + 1 + total_width > formatting.shape.width)
                     || prev_item_had_post_comment
-                    || (tactic == DefinitiveListTactic::NestedImport
-                        && (prev_item_is_nested_import || (!first && inner_item.contains("::"))))
+                    || (prev_item_is_nested_import || (!first && inner_item.contains("::")))
                 {
                     result.push('\n');
                     result.push_str(indent_str);

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -34,6 +34,8 @@ pub struct ListFormatting<'a> {
     pub ends_with_newline: bool,
     // Remove newlines between list elements for expressions.
     pub preserve_newline: bool,
+    // Nested import lists get some special handling for the "Mixed" list type
+    pub nested: bool,
     pub config: &'a Config,
 }
 
@@ -288,7 +290,8 @@ where
                 // 1 is space between separator and item.
                 if (line_len > 0 && line_len + 1 + total_width > formatting.shape.width)
                     || prev_item_had_post_comment
-                    || (prev_item_is_nested_import || (!first && inner_item.contains("::")))
+                    || (formatting.nested
+                        && (prev_item_is_nested_import || (!first && inner_item.contains("::"))))
                 {
                     result.push('\n');
                     result.push_str(indent_str);
@@ -824,6 +827,7 @@ pub fn struct_lit_formatting<'a>(
         shape,
         ends_with_newline,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -399,6 +399,7 @@ pub fn rewrite_macro_def(
         shape: arm_shape,
         ends_with_newline: true,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
 

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -224,6 +224,7 @@ fn rewrite_match_arms(
         shape: arm_shape,
         ends_with_newline: true,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
 

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -388,6 +388,7 @@ impl<'a, T: 'a + Rewrite + ToExpr + Spanned> Context<'a, T> {
                 _ => false,
             },
             preserve_newline: false,
+            nested: false,
             config: self.context.config,
         };
 

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -77,6 +77,7 @@ fn wrap_reorderable_items(
         shape,
         ends_with_newline: true,
         preserve_newline: false,
+        nested: false,
         config: context.config,
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -366,6 +366,7 @@ where
         shape: list_shape,
         ends_with_newline: tactic.ends_with_newline(context.config.indent_style()),
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
 

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -252,6 +252,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         shape: item_shape,
         ends_with_newline: true,
         preserve_newline: true,
+        nested: false,
         config: context.config,
     };
     write_list(&items, &fmt)

--- a/tests/config/issue-2794.toml
+++ b/tests/config/issue-2794.toml
@@ -1,3 +1,0 @@
-indent_style = "Block"
-imports_indent = "Block"
-imports_layout = "Vertical"

--- a/tests/config/issue-2794.toml
+++ b/tests/config/issue-2794.toml
@@ -1,0 +1,3 @@
+indent_style = "Block"
+imports_indent = "Block"
+imports_layout = "Vertical"

--- a/tests/source/issue-2794.rs
+++ b/tests/source/issue-2794.rs
@@ -1,3 +1,7 @@
+// rustfmt-indent_style: Block
+// rustfmt-imports_indent: Block
+// rustfmt-imports_layout: Vertical
+
 use std::{
     env, fs, io::{Read, Write},
 };

--- a/tests/source/issue-2794.rs
+++ b/tests/source/issue-2794.rs
@@ -1,0 +1,3 @@
+use std::{
+    env, fs, io::{Read, Write},
+};

--- a/tests/target/issue-2794.rs
+++ b/tests/target/issue-2794.rs
@@ -1,0 +1,8 @@
+use std::{
+    env,
+    fs,
+    io::{
+        Read,
+        Write,
+    },
+};

--- a/tests/target/issue-2794.rs
+++ b/tests/target/issue-2794.rs
@@ -1,3 +1,7 @@
+// rustfmt-indent_style: Block
+// rustfmt-imports_indent: Block
+// rustfmt-imports_layout: Vertical
+
 use std::{
     env,
     fs,


### PR DESCRIPTION
Adds a test for the regression in the `Vertical` imports layout reported in #2794.