### PR TITLE
Remove wrong "(default)" from `Configurations.md`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1928,7 +1928,7 @@ fn bar() {
 }
 ```
 
-#### `2` (default):
+#### `2`:
 ```rust
 fn foo() {
     println!("a");


### PR DESCRIPTION
`blank_lines_upper_bound` has default value `1`, not `2`.