### PR TITLE
Strip leading `|` in match arm patterns

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -68,7 +68,7 @@ impl<'a> Spanned for ArmWrapper<'a> {
 
 impl<'a> Rewrite for ArmWrapper<'a> {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        rewrite_match_arm(context, self.arm, shape, self.is_last, self.beginning_vert)
+        rewrite_match_arm(context, self.arm, shape, self.is_last)
     }
 }
 
@@ -236,7 +236,6 @@ fn rewrite_match_arm(
     arm: &ast::Arm,
     shape: Shape,
     is_last: bool,
-    beginning_vert: Option<BytePos>,
 ) -> Option<String> {
     let (missing_span, attrs_str) = if !arm.attrs.is_empty() {
         if contains_skip(&arm.attrs) {
@@ -256,22 +255,18 @@ fn rewrite_match_arm(
     } else {
         (mk_sp(arm.span().lo(), arm.span().lo()), String::new())
     };
-    let pats_str = rewrite_match_pattern(
-        context,
-        &ptr_vec_to_ref_vec(&arm.pats),
-        &arm.guard,
-        beginning_vert.is_some(),
-        shape,
-    ).and_then(|pats_str| {
-        combine_strs_with_missing_comments(
-            context,
-            &attrs_str,
-            &pats_str,
-            missing_span,
-            shape,
-            false,
-        )
-    })?;
+    let pats_str =
+        rewrite_match_pattern(context, &ptr_vec_to_ref_vec(&arm.pats), &arm.guard, shape)
+            .and_then(|pats_str| {
+                combine_strs_with_missing_comments(
+                    context,
+                    &attrs_str,
+                    &pats_str,
+                    missing_span,
+                    shape,
+                    false,
+                )
+            })?;
     rewrite_match_body(
         context,
         &arm.body,
@@ -286,22 +281,17 @@ fn rewrite_match_pattern(
     context: &RewriteContext,
     pats: &[&ast::Pat],
     guard: &Option<ptr::P<ast::Expr>>,
-    has_beginning_vert: bool,
     shape: Shape,
 ) -> Option<String> {
     // Patterns
     // 5 = ` => {`
-    // 2 = `| `
-    let pat_shape = shape
-        .sub_width(5)?
-        .offset_left(if has_beginning_vert { 2 } else { 0 })?;
+    let pat_shape = shape.sub_width(5)?;
     let pats_str = rewrite_multiple_patterns(context, pats, pat_shape)?;
-    let beginning_vert = if has_beginning_vert { "| " } else { "" };
 
     // Guard
     let guard_str = rewrite_guard(context, guard, shape, trimmed_last_line_width(&pats_str))?;
 
-    Some(format!("{}{}{}", beginning_vert, pats_str, guard_str))
+    Some(format!("{}{}", pats_str, guard_str))
 }
 
 // (extend, body)

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -452,17 +452,6 @@ fn issue_2152() {
     }
 }
 
-// #2462
-// Preserve a `|` at the beginning of a match arm.
-fn match_with_beginning_vert() {
-    let x = Foo::A;
-    match x {
-        | Foo::A
-        | Foo::B => println!("AB"),
-        | Foo::C => println!("C"),
-    }
-}
-
 // #2376
 // Preserve block around expressions with condition.
 fn issue_2376() {
@@ -483,5 +472,22 @@ fn issue_2376() {
                 x = Some(10);
             }
         }
+    }
+}
+
+// #2621
+// Strip leading `|` in match arm patterns
+fn issue_2621() {
+    let x = Foo::A;
+    match x {
+        Foo::A => println!("No vert single condition"),
+        Foo::B | Foo::C => println!("Center vert two conditions"),
+        | Foo::D => println!("Preceding vert single condition"),
+        | Foo::E
+        | Foo::F => println!("Preceding vert over two lines"),
+        Foo::G |
+        Foo::H => println!("Trailing vert over two lines"),
+        // Comment on its own line
+        | Foo::I => println!("With comment"), // Comment after line
     }
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -481,16 +481,6 @@ fn issue_2152() {
     }
 }
 
-// #2462
-// Preserve a `|` at the beginning of a match arm.
-fn match_with_beginning_vert() {
-    let x = Foo::A;
-    match x {
-        | Foo::A | Foo::B => println!("AB"),
-        | Foo::C => println!("C"),
-    }
-}
-
 // #2376
 // Preserve block around expressions with condition.
 fn issue_2376() {
@@ -511,5 +501,20 @@ fn issue_2376() {
                 x = Some(10);
             }
         }
+    }
+}
+
+// #2621
+// Strip leading `|` in match arm patterns
+fn issue_2621() {
+    let x = Foo::A;
+    match x {
+        Foo::A => println!("No vert single condition"),
+        Foo::B | Foo::C => println!("Center vert two conditions"),
+        Foo::D => println!("Preceding vert single condition"),
+        Foo::E | Foo::F => println!("Preceding vert over two lines"),
+        Foo::G | Foo::H => println!("Trailing vert over two lines"),
+        // Comment on its own line
+        Foo::I => println!("With comment"), // Comment after line
     }
 }


### PR DESCRIPTION
This addresses issue #2621

This commit turns out to be a partial revert of
ea3c01e3374143912f048b22fda106ee8d5a1cd8

The rationale is that a `|` character preceding a match pattern is not
semantically relevant and therefore should be considered a
style/formatting choice.

A discussion concluded that the best way to emit consistent formatting
here was to strip the leading `|`

This removes the match_with_beginning_vert test because it was asserting
the old behaviour which has been changed, it adds a new test
(issue_2621) which should be a more comprehensive check of the behavior
of `|` in match arms.

Discussion at https://github.com/rust-lang-nursery/fmt-rfcs/issues/119