### PR TITLE
Handle Raw identifiers

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -28,7 +28,7 @@ use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use spanned::Spanned;
 use types::{rewrite_path, PathContext};
-use utils::{format_mutability, mk_sp};
+use utils::{format_mutability, mk_sp, rewrite_ident};
 
 /// Returns true if the given pattern is short. A short pattern is defined by the following grammer:
 ///
@@ -74,7 +74,7 @@ impl Rewrite for Pat {
                     BindingMode::ByValue(mutability) => ("", mutability),
                 };
                 let mut_infix = format_mutability(mutability);
-                let id_str = ident.name.to_string();
+                let id_str = rewrite_ident(context, ident);
                 let sub_pat = match *sub_pat {
                     Some(ref p) => {
                         // 3 - ` @ `.
@@ -246,7 +246,7 @@ impl Rewrite for FieldPat {
             pat
         } else {
             let pat_str = pat?;
-            let id_str = self.ident.to_string();
+            let id_str = rewrite_ident(context, self.ident);
             let one_line_width = id_str.len() + 2 + pat_str.len();
             if one_line_width <= shape.width {
                 Some(format!("{}: {}", id_str, pat_str))

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -100,7 +100,7 @@ fn rewrite_reorderable_item(
 
     let item_str = match item.node {
         ast::ItemKind::ExternCrate(..) => rewrite_extern_crate(context, item)?,
-        ast::ItemKind::Mod(..) => rewrite_mod(item),
+        ast::ItemKind::Mod(..) => rewrite_mod(context, item),
         _ => return None,
     };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,10 @@ use shape::Shape;
 pub const DEPR_SKIP_ANNOTATION: &str = "rustfmt_skip";
 pub const SKIP_ANNOTATION: &str = "rustfmt::skip";
 
+pub fn rewrite_ident<'a>(context: &'a RewriteContext, ident: ast::Ident) -> &'a str {
+    context.snippet(ident.span)
+}
+
 // Computes the length of a string's last line, minus offset.
 pub fn extra_offset(text: &str, shape: Shape) -> usize {
     match text.rfind('\n') {
@@ -34,7 +38,7 @@ pub fn extra_offset(text: &str, shape: Shape) -> usize {
 }
 
 // Uses Cow to avoid allocating in the common cases.
-pub fn format_visibility(vis: &Visibility) -> Cow<'static, str> {
+pub fn format_visibility(context: &RewriteContext, vis: &Visibility) -> Cow<'static, str> {
     match vis.node {
         VisibilityKind::Public => Cow::from("pub "),
         VisibilityKind::Inherited => Cow::from(""),
@@ -42,7 +46,7 @@ pub fn format_visibility(vis: &Visibility) -> Cow<'static, str> {
         VisibilityKind::Crate(CrateSugar::JustCrate) => Cow::from("crate "),
         VisibilityKind::Restricted { ref path, .. } => {
             let Path { ref segments, .. } = **path;
-            let mut segments_iter = segments.iter().map(|seg| seg.ident.name.to_string());
+            let mut segments_iter = segments.iter().map(|seg| rewrite_ident(context, seg.ident));
             if path.is_global() {
                 segments_iter
                     .next()

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -24,7 +24,7 @@ use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separat
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
 use spanned::Spanned;
-use utils::{contains_skip, is_attributes_extendable, mk_sp};
+use utils::{contains_skip, is_attributes_extendable, mk_sp, rewrite_ident};
 
 pub trait AlignedItem {
     fn skip(&self) -> bool;
@@ -88,7 +88,7 @@ impl AlignedItem for ast::Field {
 
     fn rewrite_prefix(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let attrs_str = self.attrs.rewrite(context, shape)?;
-        let name = &self.ident.name.to_string();
+        let name = rewrite_ident(context, self.ident);
         let missing_span = if self.attrs.is_empty() {
             mk_sp(self.span.lo(), self.span.lo())
         } else {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -28,7 +28,7 @@ use shape::{Indent, Shape};
 use spanned::Spanned;
 use utils::{
     self, contains_skip, count_newlines, inner_attributes, mk_sp, ptr_vec_to_ref_vec,
-    DEPR_SKIP_ANNOTATION,
+    rewrite_ident, DEPR_SKIP_ANNOTATION,
 };
 use {ErrorKind, FormatReport, FormattingError};
 
@@ -682,9 +682,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         attrs: &[ast::Attribute],
         is_internal: bool,
     ) {
-        self.push_str(&*utils::format_visibility(vis));
+        let vis_str = utils::format_visibility(&self.get_context(), vis);
+        self.push_str(&*vis_str);
         self.push_str("mod ");
-        self.push_str(&ident.to_string());
+        // Calling `to_owned()` to work around borrow checker.
+        let ident_str = rewrite_ident(&self.get_context(), ident).to_owned();
+        self.push_str(&ident_str);
 
         if is_internal {
             match self.config.brace_style() {

--- a/tests/target/raw_identifiers.rs
+++ b/tests/target/raw_identifiers.rs
@@ -1,0 +1,50 @@
+#![feature(custom_attribute)]
+#![feature(raw_identifiers)]
+#![feature(extern_types)]
+#![allow(invalid_type_param_default)]
+#![allow(unused_attributes)]
+
+use r#foo as r#alias_foo;
+
+fn main() {
+    #[r#attr]
+    r#foo::r#bar();
+
+    let r#local = 3;
+    let r#async = r#foo(r#local);
+    r#macro!();
+
+    if let r#sub_pat @ r#Foo(_) = r#Foo(3) {}
+
+    match r#async {
+        r#Foo | r#Bar => r#foo(),
+    }
+}
+
+fn r#bar<'a, r#T>(r#x: &'a r#T) {}
+
+mod r#foo {
+    pub fn r#bar() {}
+}
+
+enum r#Foo {
+    r#Bar {},
+}
+
+trait r#Trait {
+    type r#Type;
+}
+
+impl r#Trait for r#Impl {
+    type r#Type = r#u32;
+    fn r#xxx(r#fjio: r#u32) {}
+}
+
+extern "C" {
+    type r#ccc;
+    static r#static_val: u32;
+}
+
+macro_rules! r#macro {
+    () => {};
+}

--- a/tests/target/raw_identifiers.rs
+++ b/tests/target/raw_identifiers.rs
@@ -31,6 +31,10 @@ enum r#Foo {
     r#Bar {},
 }
 
+struct r#Struct {
+    r#field: r#FieldType,
+}
+
 trait r#Trait {
     type r#Type;
 }
@@ -47,4 +51,11 @@ extern "C" {
 
 macro_rules! r#macro {
     () => {};
+}
+
+macro_rules! foo {
+    ($x:expr) => {
+        let r#catch = $x + 1;
+        println!("{}", r#catch);
+    };
 }


### PR DESCRIPTION
This PR adds `rewrite_ident` (which just looks up for the span of the given ident) to handle raw identifiers and call it everywhere. 