### PR TITLE
Return the trimmed original snippet when formatting macro def failed

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -411,7 +411,10 @@ pub fn rewrite_macro_def(
         result += &arm_shape.indent.to_string_with_newline(context.config);
     }
 
-    result += write_list(&branch_items, &fmt)?.as_str();
+    match write_list(&branch_items, &fmt) {
+        Some(ref s) => result += s,
+        None => return snippet,
+    }
 
     if multi_branch_style {
         result += &indent.to_string_with_newline(context.config);

--- a/tests/source/macro_rules.rs
+++ b/tests/source/macro_rules.rs
@@ -230,3 +230,35 @@ macro_rules! save_regs {
              :::: "intel", "volatile");
     };
 }
+
+// #2721
+macro_rules! impl_as_byte_slice_arrays {
+    ($n:expr,) => {};
+    ($n:expr, $N:ident, $($NN:ident,)*) => {
+        impl_as_byte_slice_arrays!($n - 1, $($NN,)*);
+        
+        impl<T> AsByteSliceMut for [T; $n] where [T]: AsByteSliceMut {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                self[..].as_byte_slice_mut()
+            }
+
+            fn to_le(&mut self) {
+                self[..].to_le()
+            }
+        }
+    };
+    (!div $n:expr,) => {};
+    (!div $n:expr, $N:ident, $($NN:ident,)*) => {
+        impl_as_byte_slice_arrays!(!div $n / 2, $($NN,)*);
+
+        impl<T> AsByteSliceMut for [T; $n] where [T]: AsByteSliceMut {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                self[..].as_byte_slice_mut()
+            }
+            
+            fn to_le(&mut self) {
+                self[..].to_le()
+            }
+        }
+    };
+}

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -271,3 +271,35 @@ macro_rules! save_regs {
              :::: "intel", "volatile");
     };
 }
+
+// #2721
+macro_rules! impl_as_byte_slice_arrays {
+    ($n:expr,) => {};
+    ($n:expr, $N:ident, $($NN:ident,)*) => {
+        impl_as_byte_slice_arrays!($n - 1, $($NN,)*);
+
+        impl<T> AsByteSliceMut for [T; $n] where [T]: AsByteSliceMut {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                self[..].as_byte_slice_mut()
+            }
+
+            fn to_le(&mut self) {
+                self[..].to_le()
+            }
+        }
+    };
+    (!div $n:expr,) => {};
+    (!div $n:expr, $N:ident, $($NN:ident,)*) => {
+        impl_as_byte_slice_arrays!(!div $n / 2, $($NN,)*);
+
+        impl<T> AsByteSliceMut for [T; $n] where [T]: AsByteSliceMut {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                self[..].as_byte_slice_mut()
+            }
+
+            fn to_le(&mut self) {
+                self[..].to_le()
+            }
+        }
+    };
+}


### PR DESCRIPTION
Closes #2721.