### PR TITLE
Change default newline style to "Native"

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1250,7 +1250,7 @@ fn main() {
 
 Unix or Windows line endings
 
-- **Default value**: `"Unix"`
+- **Default value**: `"Native"`
 - **Possible values**: `"Native"`, `"Unix"`, `"Windows"`
 - **Stable**: Yes
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,7 @@ create_config! {
     max_width: usize, 100, true, "Maximum width of each line";
     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
     tab_spaces: usize, 4, true, "Number of spaces per tab";
-    newline_style: NewlineStyle, NewlineStyle::Unix, true, "Unix or Windows line endings";
+    newline_style: NewlineStyle, NewlineStyle::Native, true, "Unix or Windows line endings";
     use_small_heuristics: Heuristics, Heuristics::Default, true, "Whether to use different \
         formatting for items and expressions if they satisfy a heuristic notion of 'small'.";
     indent_style: IndentStyle, IndentStyle::Block, false, "How do we indent expressions or items.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1038,9 +1038,14 @@ mod unit_tests {
     #[test]
     fn test_format_snippet() {
         let snippet = "fn main() { println!(\"hello, world\"); }";
+        #[cfg(not(windows))]
         let expected = "fn main() {\n    \
                         println!(\"hello, world\");\n\
                         }\n";
+        #[cfg(windows)]
+        let expected = "fn main() {\r\n    \
+                        println!(\"hello, world\");\r\n\
+                        }\r\n";
         assert!(test_format_inner(format_snippet, snippet, expected));
     }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -247,7 +247,10 @@ fn stdin_formatting_smoke_test() {
     let (error_summary, _) = format_input(input, &config, Some(&mut buf)).unwrap();
     assert!(error_summary.has_no_errors());
     //eprintln!("{:?}", );
+    #[cfg(not(windows))]
     assert_eq!(buf, "fn main() {}\n".as_bytes());
+    #[cfg(windows)]
+    assert_eq!(buf, "fn main() {}\r\n".as_bytes());
 }
 
 // FIXME(#1990) restore this test


### PR DESCRIPTION
I tried to fix the tests for AppVeyor, but didn't actually test on Windows before opening this PR. Also, I'm not sure if this is really the best way to do this, but it seemed to be the easiest.

Fixes #2626.