### PR TITLE
Fix help for --help=file-lines

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -137,7 +137,7 @@ fn make_opts() -> Options {
         opts.optopt(
             "",
             "file-lines",
-            "Format specified line ranges. Run with `--help file-lines` for \
+            "Format specified line ranges. Run with `--help=file-lines` for \
              more detail (unstable).",
             "JSON",
         );


### PR DESCRIPTION
Due to the way getopts works, it requires the equals sign.