### PR TITLE
Add max_width option for all heuristics.

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -276,7 +276,7 @@ fn lorem<Ipsum, Dolor, Sit, Amet>() -> T
 Whether to use different formatting for items and expressions if they satisfy a heuristic notion of 'small'.
 
 - **Default value**: `Default`
-- **Possible values**: `Default`, `Off`
+- **Possible values**: `Default`, `Off`, `Max`
 - **Stable**: Yes
 
 #### `Default` (default):
@@ -334,6 +334,24 @@ fn main() {
     } else {
         sit
     };
+}
+```
+
+#### `Max`:
+
+```rust
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit { amet: Consectetur, adipiscing: Elit },
+}
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing");
+
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+
+    let lorem = if ipsum { dolor } else { sit };
 }
 ```
 

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -403,6 +403,9 @@ macro_rules! create_config {
                 if self.use_small_heuristics.2 == Heuristics::Default {
                     let max_width = self.max_width.2;
                     self.set().width_heuristics(WidthHeuristics::scaled(max_width));
+                } else if self.use_small_heuristics.2 == Heuristics::Max {
+                    let max_width = self.max_width.2;
+                    self.set().width_heuristics(WidthHeuristics::set(max_width));
                 } else {
                     self.set().width_heuristics(WidthHeuristics::null());
                 }

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -154,6 +154,8 @@ configuration_option_enum! { TypeDensity:
 configuration_option_enum! { Heuristics:
     // Turn off any heuristics
     Off,
+    // Turn on max heuristics
+    Max,
     // Use Rustfmt's defaults
     Default,
 }
@@ -254,6 +256,17 @@ impl WidthHeuristics {
             array_width: usize::max_value(),
             chain_width: usize::max_value(),
             single_line_if_else_max_width: 0,
+        }
+    }
+
+    pub fn set(max_width: usize) -> WidthHeuristics {
+        WidthHeuristics {
+            fn_call_width: max_width,
+            struct_lit_width: max_width,
+            struct_variant_width: max_width,
+            array_width: max_width,
+            chain_width: max_width,
+            single_line_if_else_max_width: max_width,
         }
     }
 

--- a/tests/source/configs/use_small_heuristics/max.rs
+++ b/tests/source/configs/use_small_heuristics/max.rs
@@ -1,0 +1,25 @@
+// rustfmt-use_small_heuristics: Max
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit {
+        amet: Consectetur,
+        adipiscing: Elit,
+    },
+}
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing");
+
+    let lorem = Lorem {
+        ipsum: dolor,
+        sit: amet,
+    };
+
+    let lorem = if ipsum {
+        dolor
+    } else {
+        sit
+    };
+}

--- a/tests/target/configs/use_small_heuristics/max.rs
+++ b/tests/target/configs/use_small_heuristics/max.rs
@@ -1,0 +1,15 @@
+// rustfmt-use_small_heuristics: Max
+
+enum Lorem {
+    Ipsum,
+    Dolor(bool),
+    Sit { amet: Consectetur, adipiscing: Elit },
+}
+
+fn main() {
+    lorem("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing");
+
+    let lorem = Lorem { ipsum: dolor, sit: amet };
+
+    let lorem = if ipsum { dolor } else { sit };
+}


### PR DESCRIPTION
This is useful when working with very small max_widths like 79 chars. I agree with this [comment](https://github.com/rust-lang-nursery/rustfmt/issues/2636#issuecomment-382844133) but rustfmt's heuristics generate a lot of vertical space in https://github.com/xiph/rav1e project, which uses  a max_width of 79 chars.