### PR TITLE
Put lifetimes after trait when they gets orphaned

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1752,11 +1752,10 @@ pub fn rewrite_associated_impl_type(
     ident: ast::Ident,
     defaultness: ast::Defaultness,
     ty_opt: Option<&ptr::P<ast::Ty>>,
-    generic_bounds_opt: Option<&ast::GenericBounds>,
     context: &RewriteContext,
     indent: Indent,
 ) -> Option<String> {
-    let result = rewrite_associated_type(ident, ty_opt, generic_bounds_opt, context, indent)?;
+    let result = rewrite_associated_type(ident, ty_opt, None, context, indent)?;
 
     match defaultness {
         ast::Defaultness::Default => Some(format!("default {}", result)),

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -515,7 +515,6 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     ii.ident,
                     ii.defaultness,
                     Some(ty),
-                    None,
                     &self.get_context(),
                     self.block_indent,
                 );

--- a/tests/source/type.rs
+++ b/tests/source/type.rs
@@ -38,3 +38,47 @@ impl CombineTypes {
         self.query_callbacks()(&query_id)
     }
 }
+
+// #2859
+pub fn do_something<'a, T: Trait1 + Trait2 + 'a>(&fooo: u32) -> impl Future<
+    Item = (
+        impl Future<Item = (
+        ), Error =   SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+impl Future<Item = (), Error = SomeError > + 'a,
+    ),
+    Error = SomeError,
+    >
+    +
+    'a {
+}
+
+pub fn do_something<'a, T: Trait1 + Trait2 + 'a>(    &fooo: u32,
+) -> impl Future<
+    Item = (
+impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+    >
+    + Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+        >
+    + Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+   impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+        >
+    +
+    'a + 'b +
+    'c {
+}

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -42,3 +42,42 @@ impl CombineTypes {
         self.query_callbacks()(&query_id)
     }
 }
+
+// #2859
+pub fn do_something<'a, T: Trait1 + Trait2 + 'a>(
+    &fooo: u32,
+) -> impl Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+> + 'a {
+}
+
+pub fn do_something<'a, T: Trait1 + Trait2 + 'a>(
+    &fooo: u32,
+) -> impl Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+> + Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+> + Future<
+    Item = (
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+        impl Future<Item = (), Error = SomeError> + 'a,
+    ),
+    Error = SomeError,
+> + 'a + 'b + 'c {
+}


### PR DESCRIPTION
Closes #2859.

This PR only deals with generic bounds that are 'in order', where lifetimes come after traits, as otherwise the ruling becomes quite complicated. 