### PR TITLE
Modify the rule for reordering impl items

### DIFF
--- a/tests/source/issue-2863.rs
+++ b/tests/source/issue-2863.rs
@@ -1,0 +1,25 @@
+// rustfmt-reorder_impl_items: true
+
+impl<T> IntoIterator for SafeVec<T> {
+    existential type F: Trait;
+    type IntoIter = self::IntoIter<T>;
+    type Item = T;
+    // comment on foo()
+    fn foo() {println!("hello, world");}
+    type Bar = u32;
+    fn foo1() {println!("hello, world");}
+    type FooBar = u32;
+    fn foo2() {println!("hello, world");}
+    fn foo3() {println!("hello, world");}
+    const SomeConst: i32 = 100;
+    fn foo4() {println!("hello, world");}
+    fn foo5() {println!("hello, world");}
+    // comment on FoooooBar
+    type FoooooBar = u32;
+    fn foo6() {println!("hello, world");}
+    fn foo7() {println!("hello, world");}
+    type BarFoo = u32;
+    existential type E: Trait;
+    const AnotherConst: i32 = 100;
+    fn foo8() {println!("hello, world");}
+}

--- a/tests/target/issue-2863.rs
+++ b/tests/target/issue-2863.rs
@@ -1,0 +1,54 @@
+// rustfmt-reorder_impl_items: true
+
+impl<T> IntoIterator for SafeVec<T> {
+    type Bar = u32;
+    type BarFoo = u32;
+    type FooBar = u32;
+    // comment on FoooooBar
+    type FoooooBar = u32;
+    type IntoIter = self::IntoIter<T>;
+    type Item = T;
+
+    existential type E: Trait;
+    existential type F: Trait;
+
+    const AnotherConst: i32 = 100;
+    const SomeConst: i32 = 100;
+
+    // comment on foo()
+    fn foo() {
+        println!("hello, world");
+    }
+
+    fn foo1() {
+        println!("hello, world");
+    }
+
+    fn foo2() {
+        println!("hello, world");
+    }
+
+    fn foo3() {
+        println!("hello, world");
+    }
+
+    fn foo4() {
+        println!("hello, world");
+    }
+
+    fn foo5() {
+        println!("hello, world");
+    }
+
+    fn foo6() {
+        println!("hello, world");
+    }
+
+    fn foo7() {
+        println!("hello, world");
+    }
+
+    fn foo8() {
+        println!("hello, world");
+    }
+}


### PR DESCRIPTION
1. If two items have the same kind, then reorder them based on its ident.
2. Handle existential type.

Closes #2863.