### PR TITLE
Auto-detect newline style by default

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1338,8 +1338,8 @@ fn main() {
 
 Unix or Windows line endings
 
-- **Default value**: `"Native"`
-- **Possible values**: `"Native"`, `"Unix"`, `"Windows"`
+- **Default value**: `"Auto"`
+- **Possible values**: `"Auto"`, `"Native"`, `"Unix"`, `"Windows"`
 - **Stable**: Yes
 
 ## `normalize_comments`

--- a/Configurations.md
+++ b/Configurations.md
@@ -1342,6 +1342,25 @@ Unix or Windows line endings
 - **Possible values**: `"Auto"`, `"Native"`, `"Unix"`, `"Windows"`
 - **Stable**: Yes
 
+#### `Auto` (default):
+
+The newline style is detected automatically on a per-file basis. Files
+with mixed line endings will be converted to the first detected line
+ending style.
+
+#### `Native`
+
+Line endings will be converted to `\r\n` on Windows and `\n` on all
+other platforms.
+
+#### `Unix`
+
+Line endings will be converted to `\n`.
+
+#### `Windows`
+
+Line endings will be converted to `\r\n`.
+
 ## `normalize_comments`
 
 Convert /* */ comments to // comments where possible

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,7 +39,7 @@ create_config! {
     max_width: usize, 100, true, "Maximum width of each line";
     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
     tab_spaces: usize, 4, true, "Number of spaces per tab";
-    newline_style: NewlineStyle, NewlineStyle::Native, true, "Unix or Windows line endings";
+    newline_style: NewlineStyle, NewlineStyle::Auto, true, "Unix or Windows line endings";
     use_small_heuristics: Heuristics, Heuristics::Default, true, "Whether to use different \
         formatting for items and expressions if they satisfy a heuristic notion of 'small'";
     indent_style: IndentStyle, IndentStyle::Block, false, "How do we indent expressions or items";

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -150,7 +150,7 @@ impl NewlineStyle {
         }
         match style {
             Windows => {
-                let mut transformed = String::with_capacity(formatted_text.capacity());
+                let mut transformed = String::with_capacity(2 * formatted_text.capacity());
                 for c in formatted_text.chars() {
                     match c {
                         '\n' => transformed.push_str("\r\n"),

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -105,9 +105,66 @@ macro_rules! configuration_option_enum{
 }
 
 configuration_option_enum! { NewlineStyle:
+    Auto, // Auto-detect based on the raw source input
     Windows, // \r\n
     Unix, // \n
     Native, // \r\n in Windows, \n on other platforms
+}
+
+impl NewlineStyle {
+    fn auto_detect(raw_input_text: &str) -> NewlineStyle {
+        if let Some(pos) = raw_input_text.find('\n') {
+            let pos = pos.saturating_sub(1);
+            if let Some('\r') = raw_input_text.chars().nth(pos) {
+                NewlineStyle::Windows
+            } else {
+                NewlineStyle::Unix
+            }
+        } else {
+            NewlineStyle::Native
+        }
+    }
+
+    fn native() -> NewlineStyle {
+        if cfg!(windows) {
+            NewlineStyle::Windows
+        } else {
+            NewlineStyle::Unix
+        }
+    }
+
+    /// Apply this newline style to the formatted text. When the style is set
+    /// to `Auto`, the `raw_input_text` is used to detect the existing line
+    /// endings.
+    ///
+    /// If the style is set to `Auto` and `raw_input_text` contains no
+    /// newlines, the `Native` style will be used.
+    pub(crate) fn apply(self, formatted_text: &mut String, raw_input_text: &str) {
+        use NewlineStyle::*;
+        let mut style = self;
+        if style == Auto {
+            style = Self::auto_detect(raw_input_text);
+        }
+        if style == Native {
+            style = Self::native();
+        }
+        match style {
+            Windows => {
+                let mut transformed = String::with_capacity(formatted_text.capacity());
+                for c in formatted_text.chars() {
+                    match c {
+                        '\n' => transformed.push_str("\r\n"),
+                        '\r' => continue,
+                        c => transformed.push(c),
+                    }
+                }
+                *formatted_text = transformed;
+            }
+            Unix => return,
+            Native => unreachable!("NewlineStyle::Native"),
+            Auto => unreachable!("NewlineStyle::Auto"),
+        }
+    }
 }
 
 configuration_option_enum! { BraceStyle:
@@ -365,5 +422,61 @@ impl Edition {
             Edition::Edition2015 => syntax_pos::edition::Edition::Edition2015,
             Edition::Edition2018 => syntax_pos::edition::Edition::Edition2018,
         }
+    }
+}
+
+#[test]
+fn test_newline_style_auto_detect() {
+    let lf = "One\nTwo\nThree";
+    let crlf = "One\r\nTwo\r\nThree";
+    let none = "One Two Three";
+
+    assert_eq!(NewlineStyle::Unix, NewlineStyle::auto_detect(lf));
+    assert_eq!(NewlineStyle::Windows, NewlineStyle::auto_detect(crlf));
+    assert_eq!(NewlineStyle::Native, NewlineStyle::auto_detect(none));
+}
+
+#[test]
+fn test_newline_style_auto_apply() {
+    let auto = NewlineStyle::Auto;
+
+    let formatted_text = "One\nTwo\nThree";
+    let raw_input_text = "One\nTwo\nThree";
+
+    let mut out = String::from(formatted_text);
+    auto.apply(&mut out, raw_input_text);
+    assert_eq!("One\nTwo\nThree", &out, "auto should detect 'lf'");
+
+    let formatted_text = "One\nTwo\nThree";
+    let raw_input_text = "One\r\nTwo\r\nThree";
+
+    let mut out = String::from(formatted_text);
+    auto.apply(&mut out, raw_input_text);
+    assert_eq!("One\r\nTwo\r\nThree", &out, "auto should detect 'crlf'");
+
+    #[cfg(not(windows))]
+    {
+        let formatted_text = "One\nTwo\nThree";
+        let raw_input_text = "One Two Three";
+
+        let mut out = String::from(formatted_text);
+        auto.apply(&mut out, raw_input_text);
+        assert_eq!(
+            "One\nTwo\nThree", &out,
+            "auto-native-unix should detect 'lf'"
+        );
+    }
+
+    #[cfg(windows)]
+    {
+        let formatted_text = "One\nTwo\nThree";
+        let raw_input_text = "One Two Three";
+
+        let mut out = String::from(formatted_text);
+        auto.apply(&mut out, raw_input_text);
+        assert_eq!(
+            "One\r\nTwo\r\nThree", &out,
+            "auto-native-windows should detect 'crlf'"
+        );
     }
 }


### PR DESCRIPTION
This changes the default newline style from `Native` to `Auto`. When set to `Auto` the original source input is examined and checked for `CRLF`. 

This prevents situations on windows where the entire project would be are re-formatted when they are using rustfmt defaults (i.e. when there is no `rustfmt.toml`). 