### PR TITLE
Fix check for unstable features

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -459,38 +459,39 @@ impl GetOptsOptions {
         let rust_nightly = option_env!("CFG_RELEASE_CHANNEL")
             .map(|c| c == "nightly")
             .unwrap_or(false);
+
         if rust_nightly {
             options.unstable_features = matches.opt_present("unstable-features");
-        }
 
-        if options.unstable_features {
-            if matches.opt_present("skip-children") {
-                options.skip_children = Some(true);
-            }
-            if matches.opt_present("error-on-unformatted") {
-                options.error_on_unformatted = Some(true);
-            }
-            if let Some(ref file_lines) = matches.opt_str("file-lines") {
-                options.file_lines = file_lines.parse().map_err(err_msg)?;
-            }
-        } else {
-            let mut unstable_options = vec![];
-            if matches.opt_present("skip-children") {
-                unstable_options.push("`--skip-children`");
-            }
-            if matches.opt_present("error-on-unformatted") {
-                unstable_options.push("`--error-on-unformatted`");
-            }
-            if matches.opt_present("file-lines") {
-                unstable_options.push("`--file-lines`");
-            }
-            if !unstable_options.is_empty() {
-                let s = if unstable_options.len() == 1 { "" } else { "s" };
-                return Err(format_err!(
-                    "Unstable option{} ({}) used without `--unstable-features`",
-                    s,
-                    unstable_options.join(", "),
-                ));
+            if options.unstable_features {
+                if matches.opt_present("skip-children") {
+                    options.skip_children = Some(true);
+                }
+                if matches.opt_present("error-on-unformatted") {
+                    options.error_on_unformatted = Some(true);
+                }
+                if let Some(ref file_lines) = matches.opt_str("file-lines") {
+                    options.file_lines = file_lines.parse().map_err(err_msg)?;
+                }
+            } else {
+                let mut unstable_options = vec![];
+                if matches.opt_present("skip-children") {
+                    unstable_options.push("`--skip-children`");
+                }
+                if matches.opt_present("error-on-unformatted") {
+                    unstable_options.push("`--error-on-unformatted`");
+                }
+                if matches.opt_present("file-lines") {
+                    unstable_options.push("`--file-lines`");
+                }
+                if !unstable_options.is_empty() {
+                    let s = if unstable_options.len() == 1 { "" } else { "s" };
+                    return Err(format_err!(
+                        "Unstable option{} ({}) used without `--unstable-features`",
+                        s,
+                        unstable_options.join(", "),
+                    ));
+                }
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -456,9 +456,7 @@ impl GetOptsOptions {
             return Err(format_err!("Can't use both `--verbose` and `--quiet`"));
         }
 
-        let rust_nightly = option_env!("CFG_RELEASE_CHANNEL")
-            .map(|c| c == "nightly")
-            .unwrap_or(false);
+        let rust_nightly = is_nightly();
 
         if rust_nightly {
             options.unstable_features = matches.opt_present("unstable-features");


### PR DESCRIPTION
These features are registered only on Nightly and so matches.opt_present panics when it's called without the is_nightly guard.