### PR TITLE
Explicitly handle semicolon after the item in statement position

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -90,6 +90,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         match stmt.node {
             ast::StmtKind::Item(ref item) => {
                 self.visit_item(item);
+                // Handle potential `;` after the item.
+                self.format_missing(stmt.span.hi());
             }
             ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 if contains_skip(get_attrs_from_stmt(stmt)) {

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -60,6 +60,9 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
         // Check subformatting
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
+
+    // #2884
+    let _ = [0; {struct Foo; impl Foo {const fn get(&self) -> usize {5}}; Foo.get()}];
 }
 
 fn bar() {

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -88,6 +88,17 @@ fn foo() -> bool {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
+
+    // #2884
+    let _ = [0; {
+        struct Foo;
+        impl Foo {
+            const fn get(&self) -> usize {
+                5
+            }
+        };
+        Foo.get()
+    }];
 }
 
 fn bar() {


### PR DESCRIPTION
Implicitly handling it in the next `push_stmt` makes `format_missing` unhappy.

Closes #2884.