### PR TITLE
add integration test rust-lang-nursery/packed_simd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
     - env: INTEGRATION=glob
     - env: INTEGRATION=log
     - env: INTEGRATION=mdbook
+    - env: INTEGRATION=packed_simd
     - env: INTEGRATION=rand
     - env: INTEGRATION=rust-clippy
     - env: INTEGRATION=rust-semverver


### PR DESCRIPTION
Now that `packed_simd` has been from `stdsimd` it is probably worth it to keep it around as an integration test since it uses a lot of macros which has caught rustfmt issues in the past.