### PR TITLE
Format chains with comment

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -575,6 +575,9 @@ impl<'a> ChainFormatter for ChainFormatterBlock<'a> {
 
         while root_rewrite.len() <= tab_width && !root_rewrite.contains('\n') {
             let item = &self.shared.children[0];
+            if let ChainItemKind::Comment = item.kind {
+                break;
+            }
             let shape = shape.offset_left(root_rewrite.len())?;
             match &item.rewrite(context, shape) {
                 Some(rewrite) => root_rewrite.push_str(rewrite),
@@ -667,6 +670,10 @@ impl<'a> ChainFormatter for ChainFormatterVisual<'a> {
 
         if !multiline || parent.kind.is_block_like(context, &root_rewrite) {
             let item = &self.shared.children[0];
+            if let ChainItemKind::Comment = item.kind {
+                self.shared.rewrites.push(root_rewrite);
+                return Some(());
+            }
             let child_shape = parent_shape
                 .visual_indent(self.offset)
                 .sub_width(self.offset)?;

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -335,6 +335,7 @@ impl Chain {
             if handle_comment {
                 let pre_comment_span = mk_sp(prev_span_end, chain_item.span.lo());
                 let pre_comment_snippet = context.snippet(pre_comment_span);
+                let pre_comment_snippet = pre_comment_snippet.trim().trim_matches('?');
                 let (pre_comment, _) = extract_pre_comment(pre_comment_snippet);
                 match pre_comment {
                     Some(ref comment) if !comment.is_empty() => {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -209,6 +209,13 @@ impl ChainItem {
         }
     }
 
+    fn is_comment(&self) -> bool {
+        match self.kind {
+            ChainItemKind::Comment => true,
+            _ => false,
+        }
+    }
+
     fn rewrite_method_call(
         method_name: ast::Ident,
         types: &[ast::GenericArg],
@@ -458,7 +465,9 @@ impl<'a> ChainFormatterShared<'a> {
         }.saturating_sub(almost_total);
 
         let all_in_one_line =
-            self.rewrites.iter().all(|s| !s.contains('\n')) && one_line_budget > 0;
+            !self.children.iter().any(ChainItem::is_comment)
+            && self.rewrites.iter().all(|s| !s.contains('\n'))
+            && one_line_budget > 0;
         let last_shape = if all_in_one_line {
             shape.sub_width(last.tries)?
         } else if extendable {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -187,9 +187,12 @@ impl Rewrite for ChainItem {
             ChainItemKind::TupleField(ident, nested) => {
                 format!("{}.{}", if nested { " " } else { "" }, ident.name)
             }
-            ChainItemKind::Comment => {
-                rewrite_comment(context.snippet(self.span).trim(), false, shape, context.config)?
-            }
+            ChainItemKind::Comment => rewrite_comment(
+                context.snippet(self.span).trim(),
+                false,
+                shape,
+                context.config,
+            )?,
         };
         Some(format!("{}{}", rewrite, "?".repeat(self.tries)))
     }
@@ -471,8 +474,7 @@ impl<'a> ChainFormatterShared<'a> {
             min(shape.width, context.config.width_heuristics().chain_width)
         }.saturating_sub(almost_total);
 
-        let all_in_one_line =
-            !self.children.iter().any(ChainItem::is_comment)
+        let all_in_one_line = !self.children.iter().any(ChainItem::is_comment)
             && self.rewrites.iter().all(|s| !s.contains('\n'))
             && one_line_budget > 0;
         let last_shape = if all_in_one_line {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -546,6 +546,9 @@ impl<'a> ChainFormatterShared<'a> {
         for (rewrite, prev_is_block_like) in rewrite_iter.zip(block_like_iter) {
             if !prev_is_block_like {
                 result.push_str(&connector);
+            } else if rewrite.starts_with('/') {
+                // This is comment, add a space before it.
+                result.push(' ');
             }
             result.push_str(&rewrite);
         }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -275,6 +275,7 @@ impl Chain {
         for chain_item in rev_children.into_iter().rev() {
             let comment_span = mk_sp(prev_hi, chain_item.span.lo());
             let comment_snippet = context.snippet(comment_span);
+            // FIXME: Figure out the way to get a correct span when converting `try!` to `?`.
             if !(context.config.use_try_shorthand()
                 || comment_snippet.trim().is_empty()
                 || is_tries(comment_snippet.trim()))

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -262,13 +262,20 @@ impl Chain {
             }
         }
 
+        fn is_tries(s: &str) -> bool {
+            s.chars().all(|c| c == '?')
+        }
+
         let parent = rev_children.pop().unwrap();
         let mut children = vec![];
         let mut prev_hi = parent.span.hi();
         for chain_item in rev_children.into_iter().rev() {
             let comment_span = mk_sp(prev_hi, chain_item.span.lo());
             let comment_snippet = context.snippet(comment_span);
-            if !comment_snippet.trim().is_empty() {
+            if !(context.config.use_try_shorthand()
+                || comment_snippet.trim().is_empty()
+                || is_tries(comment_snippet.trim()))
+            {
                 children.push(ChainItem::comment(comment_span));
             }
             prev_hi = chain_item.span.hi();

--- a/src/codemap.rs
+++ b/src/codemap.rs
@@ -51,7 +51,11 @@ impl<'a> SpanUtils for SnippetProvider<'a> {
     }
 
     fn span_before(&self, original: Span, needle: &str) -> BytePos {
-        self.opt_span_before(original, needle).expect("bad span")
+        self.opt_span_before(original, needle).expect(&format!(
+            "bad span: {}: {}",
+            needle,
+            self.span_to_snippet(original).unwrap()
+        ))
     }
 
     fn opt_span_after(&self, original: Span, needle: &str) -> Option<BytePos> {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -515,6 +515,139 @@ where
     leave_last: bool,
 }
 
+pub fn extract_pre_comment(pre_snippet: &str) -> (Option<String>, ListItemCommentStyle) {
+    let trimmed_pre_snippet = pre_snippet.trim();
+    let has_single_line_comment = trimmed_pre_snippet.starts_with("//");
+    let has_block_comment = trimmed_pre_snippet.starts_with("/*");
+    if has_single_line_comment {
+        (
+            Some(trimmed_pre_snippet.to_owned()),
+            ListItemCommentStyle::DifferentLine,
+        )
+    } else if has_block_comment {
+        let comment_end = pre_snippet.chars().rev().position(|c| c == '/').unwrap();
+        if pre_snippet
+            .chars()
+            .rev()
+            .take(comment_end + 1)
+            .any(|c| c == '\n')
+        {
+            (
+                Some(trimmed_pre_snippet.to_owned()),
+                ListItemCommentStyle::DifferentLine,
+            )
+        } else {
+            (
+                Some(trimmed_pre_snippet.to_owned()),
+                ListItemCommentStyle::SameLine,
+            )
+        }
+    } else {
+        (None, ListItemCommentStyle::None)
+    }
+}
+
+pub fn extract_post_comment(
+    post_snippet: &str,
+    comment_end: usize,
+    separator: &str,
+) -> Option<String> {
+    let white_space: &[_] = &[' ', '\t'];
+
+    // Cleanup post-comment: strip separators and whitespace.
+    let post_snippet = post_snippet[..comment_end].trim();
+    let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
+        post_snippet[1..].trim_matches(white_space)
+    } else if post_snippet.starts_with(separator) {
+        post_snippet[separator.len()..].trim_matches(white_space)
+    } else if post_snippet.ends_with(',') {
+        post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
+    } else {
+        post_snippet
+    };
+
+    if !post_snippet_trimmed.is_empty() {
+        Some(post_snippet_trimmed.to_owned())
+    } else {
+        None
+    }
+}
+
+pub fn get_comment_end(
+    post_snippet: &str,
+    separator: &str,
+    terminator: &str,
+    is_last: bool,
+) -> usize {
+    if is_last {
+        return post_snippet
+            .find_uncommented(terminator)
+            .unwrap_or_else(|| post_snippet.len());
+    }
+
+    let mut block_open_index = post_snippet.find("/*");
+    // check if it really is a block comment (and not `//*` or a nested comment)
+    if let Some(i) = block_open_index {
+        match post_snippet.find('/') {
+            Some(j) if j < i => block_open_index = None,
+            _ if i > 0 && &post_snippet[i - 1..i] == "/" => block_open_index = None,
+            _ => (),
+        }
+    }
+    let newline_index = post_snippet.find('\n');
+    if let Some(separator_index) = post_snippet.find_uncommented(separator) {
+        match (block_open_index, newline_index) {
+            // Separator before comment, with the next item on same line.
+            // Comment belongs to next item.
+            (Some(i), None) if i > separator_index => separator_index + 1,
+            // Block-style post-comment before the separator.
+            (Some(i), None) => cmp::max(
+                find_comment_end(&post_snippet[i..]).unwrap() + i,
+                separator_index + 1,
+            ),
+            // Block-style post-comment. Either before or after the separator.
+            (Some(i), Some(j)) if i < j => cmp::max(
+                find_comment_end(&post_snippet[i..]).unwrap() + i,
+                separator_index + 1,
+            ),
+            // Potential *single* line comment.
+            (_, Some(j)) if j > separator_index => j + 1,
+            _ => post_snippet.len(),
+        }
+    } else if let Some(newline_index) = newline_index {
+        // Match arms may not have trailing comma. In any case, for match arms,
+        // we will assume that the post comment belongs to the next arm if they
+        // do not end with trailing comma.
+        newline_index + 1
+    } else {
+        0
+    }
+}
+
+// Account for extra whitespace between items. This is fiddly
+// because of the way we divide pre- and post- comments.
+fn has_extra_newline(post_snippet: &str, comment_end: usize) -> bool {
+    if post_snippet.is_empty() || comment_end == 0 {
+        return false;
+    }
+
+    // Everything from the separator to the next item.
+    let test_snippet = &post_snippet[comment_end - 1..];
+    let first_newline = test_snippet
+        .find('\n')
+        .unwrap_or_else(|| test_snippet.len());
+    // From the end of the first line of comments.
+    let test_snippet = &test_snippet[first_newline..];
+    let first = test_snippet
+        .find(|c: char| !c.is_whitespace())
+        .unwrap_or_else(|| test_snippet.len());
+    // From the end of the first line of comments to the next non-whitespace char.
+    let test_snippet = &test_snippet[..first];
+
+    // There were multiple line breaks which got trimmed to nothing.
+    count_newlines(test_snippet) > 1
+}
+
 impl<'a, T, I, F1, F2, F3> Iterator for ListItems<'a, I, F1, F2, F3>
 where
     I: Iterator<Item = T>,
@@ -525,44 +658,13 @@ where
     type Item = ListItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let white_space: &[_] = &[' ', '\t'];
-
         self.inner.next().map(|item| {
-            let mut new_lines = false;
             // Pre-comment
             let pre_snippet = self
                 .snippet_provider
                 .span_to_snippet(mk_sp(self.prev_span_end, (self.get_lo)(&item)))
                 .unwrap_or("");
-            let trimmed_pre_snippet = pre_snippet.trim();
-            let has_single_line_comment = trimmed_pre_snippet.starts_with("//");
-            let has_block_comment = trimmed_pre_snippet.starts_with("/*");
-            let (pre_comment, pre_comment_style) = if has_single_line_comment {
-                (
-                    Some(trimmed_pre_snippet.to_owned()),
-                    ListItemCommentStyle::DifferentLine,
-                )
-            } else if has_block_comment {
-                let comment_end = pre_snippet.chars().rev().position(|c| c == '/').unwrap();
-                if pre_snippet
-                    .chars()
-                    .rev()
-                    .take(comment_end + 1)
-                    .any(|c| c == '\n')
-                {
-                    (
-                        Some(trimmed_pre_snippet.to_owned()),
-                        ListItemCommentStyle::DifferentLine,
-                    )
-                } else {
-                    (
-                        Some(trimmed_pre_snippet.to_owned()),
-                        ListItemCommentStyle::SameLine,
-                    )
-                }
-            } else {
-                (None, ListItemCommentStyle::None)
-            };
+            let (pre_comment, pre_comment_style) = extract_pre_comment(pre_snippet);
 
             // Post-comment
             let next_start = match self.inner.peek() {
@@ -573,94 +675,16 @@ where
                 .snippet_provider
                 .span_to_snippet(mk_sp((self.get_hi)(&item), next_start))
                 .unwrap_or("");
+            let comment_end = get_comment_end(
+                post_snippet,
+                self.separator,
+                self.terminator,
+                self.inner.peek().is_none(),
+            );
+            let new_lines = has_extra_newline(post_snippet, comment_end);
+            let post_comment = extract_post_comment(post_snippet, comment_end, self.separator);
 
-            let comment_end = match self.inner.peek() {
-                Some(..) => {
-                    let mut block_open_index = post_snippet.find("/*");
-                    // check if it really is a block comment (and not `//*` or a nested comment)
-                    if let Some(i) = block_open_index {
-                        match post_snippet.find('/') {
-                            Some(j) if j < i => block_open_index = None,
-                            _ if i > 0 && &post_snippet[i - 1..i] == "/" => block_open_index = None,
-                            _ => (),
-                        }
-                    }
-                    let newline_index = post_snippet.find('\n');
-                    if let Some(separator_index) = post_snippet.find_uncommented(self.separator) {
-                        match (block_open_index, newline_index) {
-                            // Separator before comment, with the next item on same line.
-                            // Comment belongs to next item.
-                            (Some(i), None) if i > separator_index => separator_index + 1,
-                            // Block-style post-comment before the separator.
-                            (Some(i), None) => cmp::max(
-                                find_comment_end(&post_snippet[i..]).unwrap() + i,
-                                separator_index + 1,
-                            ),
-                            // Block-style post-comment. Either before or after the separator.
-                            (Some(i), Some(j)) if i < j => cmp::max(
-                                find_comment_end(&post_snippet[i..]).unwrap() + i,
-                                separator_index + 1,
-                            ),
-                            // Potential *single* line comment.
-                            (_, Some(j)) if j > separator_index => j + 1,
-                            _ => post_snippet.len(),
-                        }
-                    } else if let Some(newline_index) = newline_index {
-                        // Match arms may not have trailing comma. In any case, for match arms,
-                        // we will assume that the post comment belongs to the next arm if they
-                        // do not end with trailing comma.
-                        newline_index + 1
-                    } else {
-                        0
-                    }
-                }
-                None => post_snippet
-                    .find_uncommented(self.terminator)
-                    .unwrap_or_else(|| post_snippet.len()),
-            };
-
-            if !post_snippet.is_empty() && comment_end > 0 {
-                // Account for extra whitespace between items. This is fiddly
-                // because of the way we divide pre- and post- comments.
-
-                // Everything from the separator to the next item.
-                let test_snippet = &post_snippet[comment_end - 1..];
-                let first_newline = test_snippet
-                    .find('\n')
-                    .unwrap_or_else(|| test_snippet.len());
-                // From the end of the first line of comments.
-                let test_snippet = &test_snippet[first_newline..];
-                let first = test_snippet
-                    .find(|c: char| !c.is_whitespace())
-                    .unwrap_or_else(|| test_snippet.len());
-                // From the end of the first line of comments to the next non-whitespace char.
-                let test_snippet = &test_snippet[..first];
-
-                if count_newlines(test_snippet) > 1 {
-                    // There were multiple line breaks which got trimmed to nothing.
-                    new_lines = true;
-                }
-            }
-
-            // Cleanup post-comment: strip separators and whitespace.
             self.prev_span_end = (self.get_hi)(&item) + BytePos(comment_end as u32);
-            let post_snippet = post_snippet[..comment_end].trim();
-
-            let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
-                post_snippet[1..].trim_matches(white_space)
-            } else if post_snippet.starts_with(self.separator) {
-                post_snippet[self.separator.len()..].trim_matches(white_space)
-            } else if post_snippet.ends_with(',') {
-                post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
-            } else {
-                post_snippet
-            };
-
-            let post_comment = if !post_snippet_trimmed.is_empty() {
-                Some(post_snippet_trimmed.to_owned())
-            } else {
-                None
-            };
 
             ListItem {
                 pre_comment,

--- a/tests/source/chains_with_comment.rs
+++ b/tests/source/chains_with_comment.rs
@@ -1,0 +1,95 @@
+// Chains with comment.
+
+fn main() {
+    let x = y // comment
+        .z;
+
+    foo // foo
+        // comment after parent
+        .x
+        .y
+        // comment 1
+        .bar() // comment after bar()
+  // comment 2
+        .foobar
+  // comment after
+        // comment 3
+        .baz(x, y, z);
+
+    self.rev_dep_graph
+        .iter()
+       // Remove nodes that are not dirty
+        .filter(|&(unit, _)| dirties.contains(&unit))
+     // Retain only dirty dependencies of the ones that are dirty
+       .map(|(k, deps)| {
+            (
+                k.clone(),
+                deps.iter()
+                .cloned()
+               .filter(|d| dirties.contains(&d))
+              .collect(),
+            )
+        });
+
+    let y = expr /* comment */.kaas()?
+// comment
+       .test();
+    let loooooooooooooooooooooooooooooooooooooooooong = does_this?.look?.good?.should_we_break?.after_the_first_question_mark?;
+    let zzzz = expr?   // comment after parent
+// comment 0
+.another??? // comment 1
+.another????  // comment 2
+.another? // comment 3
+.another?;
+
+    let y = a.very .loooooooooooooooooooooooooooooooooooooong() /* comment */ .chain()
+        .inside()  /* comment */        .weeeeeeeeeeeeeee()? .test()  .0
+        .x;
+
+    parameterized(f,
+                  substs,
+                  def_id,
+                  Ns::Value,
+                  &[],
+                  |tcx| tcx.lookup_item_type(def_id).generics)?;
+    fooooooooooooooooooooooooooo()?.bar()?.baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz()?;
+
+    // #2559
+    App::new("cargo-cache")
+.version(crate_version!())
+.bin_name("cargo")
+.about("Manage cargo cache")
+.author("matthiaskrgr")
+.subcommand(
+SubCommand::with_name("cache")
+.version(crate_version!())
+.bin_name("cargo-cache")
+.about("Manage cargo cache")
+.author("matthiaskrgr")
+.arg(&list_dirs)
+.arg(&remove_dir)
+.arg(&gc_repos)
+.arg(&info)
+.arg(&keep_duplicate_crates)    .arg(&dry_run)
+.arg(&auto_clean)
+.arg(&auto_clean_expensive),
+        ) // subcommand
+        .arg(&list_dirs);
+}
+
+// #2177
+impl Foo {
+    fn dirty_rev_dep_graph(
+        &self,
+        dirties: &HashSet<UnitKey>,
+    ) -> HashMap<UnitKey, HashSet<UnitKey>> {
+        let dirties = self.transitive_dirty_units(dirties);
+        trace!("transitive_dirty_units: {:?}", dirties);
+
+        self.rev_dep_graph.iter()
+        // Remove nodes that are not dirty
+            .filter(|&(unit, _)| dirties.contains(&unit))
+        // Retain only dirty dependencies of the ones that are dirty
+            .map(|(k, deps)| (k.clone(), deps.iter().cloned().filter(|d| dirties.contains(&d)).collect()))
+    }
+}

--- a/tests/target/chains_with_comment.rs
+++ b/tests/target/chains_with_comment.rs
@@ -1,0 +1,118 @@
+// Chains with comment.
+
+fn main() {
+    let x = y // comment
+        .z;
+
+    foo // foo
+        // comment after parent
+        .x
+        .y
+        // comment 1
+        .bar() // comment after bar()
+        // comment 2
+        .foobar
+        // comment after
+        // comment 3
+        .baz(x, y, z);
+
+    self.rev_dep_graph
+        .iter()
+        // Remove nodes that are not dirty
+        .filter(|&(unit, _)| dirties.contains(&unit))
+        // Retain only dirty dependencies of the ones that are dirty
+        .map(|(k, deps)| {
+            (
+                k.clone(),
+                deps.iter()
+                    .cloned()
+                    .filter(|d| dirties.contains(&d))
+                    .collect(),
+            )
+        });
+
+    let y = expr
+        /* comment */
+        .kaas()?
+        // comment
+        .test();
+    let loooooooooooooooooooooooooooooooooooooooooong = does_this?
+        .look?
+        .good?
+        .should_we_break?
+        .after_the_first_question_mark?;
+    let zzzz = expr? // comment after parent
+        // comment 0
+        .another??? // comment 1
+        .another???? // comment 2
+        .another? // comment 3
+        .another?;
+
+    let y = a
+        .very
+        .loooooooooooooooooooooooooooooooooooooong()
+        /* comment */
+        .chain()
+        .inside()
+        /* comment */
+        .weeeeeeeeeeeeeee()?
+        .test()
+        .0
+        .x;
+
+    parameterized(f, substs, def_id, Ns::Value, &[], |tcx| {
+        tcx.lookup_item_type(def_id).generics
+    })?;
+    fooooooooooooooooooooooooooo()?
+        .bar()?
+        .baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz()?;
+
+    // #2559
+    App::new("cargo-cache")
+        .version(crate_version!())
+        .bin_name("cargo")
+        .about("Manage cargo cache")
+        .author("matthiaskrgr")
+        .subcommand(
+            SubCommand::with_name("cache")
+                .version(crate_version!())
+                .bin_name("cargo-cache")
+                .about("Manage cargo cache")
+                .author("matthiaskrgr")
+                .arg(&list_dirs)
+                .arg(&remove_dir)
+                .arg(&gc_repos)
+                .arg(&info)
+                .arg(&keep_duplicate_crates)
+                .arg(&dry_run)
+                .arg(&auto_clean)
+                .arg(&auto_clean_expensive),
+        ) // subcommand
+        .arg(&list_dirs);
+}
+
+// #2177
+impl Foo {
+    fn dirty_rev_dep_graph(
+        &self,
+        dirties: &HashSet<UnitKey>,
+    ) -> HashMap<UnitKey, HashSet<UnitKey>> {
+        let dirties = self.transitive_dirty_units(dirties);
+        trace!("transitive_dirty_units: {:?}", dirties);
+
+        self.rev_dep_graph
+            .iter()
+            // Remove nodes that are not dirty
+            .filter(|&(unit, _)| dirties.contains(&unit))
+            // Retain only dirty dependencies of the ones that are dirty
+            .map(|(k, deps)| {
+                (
+                    k.clone(),
+                    deps.iter()
+                        .cloned()
+                        .filter(|d| dirties.contains(&d))
+                        .collect(),
+                )
+            })
+    }
+}


### PR DESCRIPTION
This PR lets rustfmt handle chains with comment.

r? @nrc

### Limitations

- This PR cannot handle comment within `.` and a chain item (e.g. `foo. /* comment */ bar()`).
- When `use_try_shorthand` is on, comment within chain items are not formatted as we get faulty span when converting `try!(expr)` to `expr?`.

### Note

Closes #2177.