### PR TITLE
Fix Issue with ellipsis matching in pattern.rs

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -369,7 +369,9 @@ fn rewrite_tuple_pat(
         shape,
         span,
         context.config.max_width(),
-        if add_comma {
+        if dotdot_pos.is_some() {
+            Some(SeparatorTactic::Never)
+        } else if add_comma {
             Some(SeparatorTactic::Always)
         } else {
             None

--- a/tests/source/issue-2936.rs
+++ b/tests/source/issue-2936.rs
@@ -1,0 +1,19 @@
+struct AStruct {
+    A: u32,
+    B: u32,
+    C: u32,
+}
+
+impl Something for AStruct {
+    fn a_func() {
+        match a_val {
+            ContextualParseError::InvalidMediaRule(ref err) => {
+                let err: &CStr = match err.kind {
+                    ParseErrorKind::Custom(StyleParseErrorKind::MediaQueryExpectedFeatureName(..)) => {
+                        cstr!("PEMQExpectedFeatureName")
+                    },
+                };
+            }
+        };
+    }
+}

--- a/tests/target/issue-2936.rs
+++ b/tests/target/issue-2936.rs
@@ -1,0 +1,19 @@
+struct AStruct {
+    A: u32,
+    B: u32,
+    C: u32,
+}
+
+impl Something for AStruct {
+    fn a_func() {
+        match a_val {
+            ContextualParseError::InvalidMediaRule(ref err) => {
+                let err: &CStr = match err.kind {
+                    ParseErrorKind::Custom(StyleParseErrorKind::MediaQueryExpectedFeatureName(
+                        ..
+                    )) => cstr!("PEMQExpectedFeatureName"),
+                };
+            }
+        };
+    }
+}


### PR DESCRIPTION
This should fix the issue brought up in issue #2936

Previously, the code generated by Rustfmt turned valid code into code that Rust was not able to parse. This PR should fix this.

I opened up this PR to gain feedback because although it fixes a codegen bug, it does not pretty print the resulting code. I am still working on tracing that problem down, but I wanted to get feedback in the while doing so. Thanks!