### PR TITLE
Patch 2

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -160,7 +160,7 @@ fn make_opts() -> Options {
 
 fn is_nightly() -> bool {
     option_env!("CFG_RELEASE_CHANNEL")
-        .map(|c| c == "nightly")
+        .map(|c| c == "nightly" || c == "dev")
         .unwrap_or(false)
 }
 

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -73,7 +73,7 @@ impl ConfigType for IgnoreList {
 macro_rules! is_nightly_channel {
     () => {
         option_env!("CFG_RELEASE_CHANNEL")
-            .map(|c| c == "nightly")
+            .map(|c| c == "nightly" || c == "dev")
             .unwrap_or(true)
     };
 }


### PR DESCRIPTION
Closes #2940

These _should_ be the only places where the check is done. At least, `CFG_RELEASE_CHANNEL` doesn't show up elsewhere in the repository.

src/config/config_type.rs defaults to `true` when unset per my previous logic about who might be building with `CFG_RELEASE_CHANNEL` unset, while src/bin/main.rs is defaulting to `false`.

Note that the buildscript dump to commit-info.txt defaults to `nightly` if `CFG_RELEASE_CHANNEL` is unset; perhaps it should be changed to `dev`?

https://github.com/rust-lang-nursery/rustfmt/blob/8242ba93aced1a51bbb7c30162ed6e7055d652bd/build.rs#L45-L51