### PR TITLE
Impl only use

### DIFF
--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -386,7 +386,7 @@ mod test {
         );
     }
 
-    use super::json::{self, json, json_internal};
+    use super::json::{self, json};
     use super::{FileLines, FileName};
     use std::{collections::HashMap, path::PathBuf};
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -984,6 +984,11 @@ mod test {
     }
 
     #[test]
+    fn test_impl_only_use() {
+        assert_eq!(parse_use_tree("a::b as _").normalize(), parse_use_tree(""));
+    }
+
+    #[test]
     fn test_use_tree_ord() {
         assert!(parse_use_tree("a").normalize() < parse_use_tree("aa").normalize());
         assert!(parse_use_tree("a").normalize() < parse_use_tree("a::a").normalize());

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -348,7 +348,10 @@ impl UseTree {
             UseTreeKind::Simple(ref rename, ..) => {
                 let name = rewrite_ident(context, path_to_imported_ident(&a.prefix)).to_owned();
                 let alias = rename.and_then(|ident| {
-                    if ident == path_to_imported_ident(&a.prefix) {
+                    if ident.name == "_" {
+                        // for impl-only-use
+                        Some("_".to_owned())
+                    } else if ident == path_to_imported_ident(&a.prefix) {
                         None
                     } else {
                         Some(rewrite_ident(context, ident).to_owned())
@@ -976,11 +979,6 @@ mod test {
             parse_use_tree("a::{b as bar, c::self}").normalize(),
             parse_use_tree("a::{b as bar, c}")
         );
-    }
-
-    #[test]
-    fn test_impl_only_use() {
-        assert_eq!(parse_use_tree("a::b as _").normalize(), parse_use_tree(""));
     }
 
     #[test]

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -149,12 +149,10 @@ impl UseSegment {
         if name.is_empty() || name == "{{root}}" {
             return None;
         }
-        Some(if name == "self" {
-            UseSegment::Slf(None)
-        } else if name == "super" {
-            UseSegment::Super(None)
-        } else {
-            UseSegment::Ident((*name).to_owned(), None)
+        Some(match name {
+            "self" => UseSegment::Slf(None),
+            "super" => UseSegment::Super(None),
+            _ => UseSegment::Ident((*name).to_owned(), None),
         })
     }
 }
@@ -356,13 +354,10 @@ impl UseTree {
                         Some(rewrite_ident(context, ident).to_owned())
                     }
                 });
-
-                let segment = if &name == "self" {
-                    UseSegment::Slf(alias)
-                } else if &name == "super" {
-                    UseSegment::Super(alias)
-                } else {
-                    UseSegment::Ident(name, alias)
+                let segment = match name.as_ref() {
+                    "self" => UseSegment::Slf(alias),
+                    "super" => UseSegment::Super(alias),
+                    _ => UseSegment::Ident(name, alias),
                 };
 
                 // `name` is already in result.
@@ -746,7 +741,7 @@ fn rewrite_nested_use_tree(
 
 impl Rewrite for UseSegment {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        Some(match *self {
+        Some(match self {
             UseSegment::Ident(ref ident, Some(ref rename)) => format!("{} as {}", ident, rename),
             UseSegment::Ident(ref ident, None) => ident.clone(),
             UseSegment::Slf(Some(ref rename)) => format!("self as {}", rename),

--- a/tests/source/imports-impl-only-use.rs
+++ b/tests/source/imports-impl-only-use.rs
@@ -1,4 +1,4 @@
 #![feature(underscore_imports)]
 
+use attr;
 use std::iter::Iterator as _;
-

--- a/tests/source/imports-impl-only-use.rs
+++ b/tests/source/imports-impl-only-use.rs
@@ -1,0 +1,4 @@
+#![feature(underscore_imports)]
+
+use std::iter::Iterator as _;
+

--- a/tests/target/imports-impl-only-use.rs
+++ b/tests/target/imports-impl-only-use.rs
@@ -1,4 +1,4 @@
 #![feature(underscore_imports)]
 
+use attr;
 use std::iter::Iterator as _;
-

--- a/tests/target/imports-impl-only-use.rs
+++ b/tests/target/imports-impl-only-use.rs
@@ -1,0 +1,4 @@
+#![feature(underscore_imports)]
+
+use std::iter::Iterator as _;
+


### PR DESCRIPTION
Would close https://github.com/rust-lang-nursery/rustfmt/issues/2887

- [This](https://github.com/rust-lang-nursery/rustfmt/compare/master...max-sixty:impl-only-use?expand=1#diff-5313d4043350f728c500f20b510ee48dR353) is the only meaningful change
- Is this too hacky? I can't find a type of the relevant '`_`' Symbol or anything more than its name to match on. Its span is `Span { lo: BytePos(0), hi: BytePos(0), ctxt: #0 }`
- Would there have been a more focused way to test this rather than the system test? The existing unit tests do no rewriting - they don't access a Context object (which I didn't easily see how to create)
- I cleaned up some other bits when working my way through the code. LMK if you want to retain
