### PR TITLE
Build with rust nightly. ExprKind::Catch is now ExprKind::TryBlock.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -401,15 +401,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_cratesio_shim"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -426,67 +426,72 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "235.0.0"
+version = "237.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -541,9 +546,9 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -608,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -820,14 +825,14 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum rustc-ap-arena 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f322d66bfa4314b6bbc6e7a0dbce4f33f7a5ed08c5a1bb0588fa8a0d904a99f"
-"checksum rustc-ap-rustc_cratesio_shim 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "082c176b1346fd356c086ffb9695d188bb6a2cffc1db987e1604f36d495797d5"
-"checksum rustc-ap-rustc_data_structures 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df2ce9493ece082cfb8301a718f2945646fc622386d4c68d8fe503b35f36194f"
-"checksum rustc-ap-rustc_errors 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a43a08156fd6b8df7d7e4bae3edd0dc4c67b842518acbfc516cde2ce0638cd82"
-"checksum rustc-ap-rustc_target 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36f7dc5977708040caf9a87f3ad877159c2573a75245280239083315f2f958a7"
-"checksum rustc-ap-serialize 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca9beb1012c0120f95767975bc41f4b599c105da8d7561185ed22dfe2bc52cd6"
-"checksum rustc-ap-syntax 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32fee8563391d36dcef52b180540cf72543a0a4505ee361ac30ed48ce9884a1b"
-"checksum rustc-ap-syntax_pos 235.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35b71f85a97f5c3ed6df05040f0e29227f9c302da4325c27c33a1701ecf9d6a0"
+"checksum rustc-ap-arena 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d24c8b3c1437fad023cb9472381216a1d41d82dbb2d2e6c7858bd6f50317719"
+"checksum rustc-ap-rustc_cratesio_shim 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c5b02c76cd1ee4e9c97c8228701796d6b7431e8f100dea2d8af1d6c2c2bad56"
+"checksum rustc-ap-rustc_data_structures 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4076388154497fb9a007e3badd78e415402a5594111cd6bc7ce1420dd1b1818b"
+"checksum rustc-ap-rustc_errors 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6c11e4789cbc276ceaa87d326c234b1a2d1e0fe6017b88a8a25903200060acb"
+"checksum rustc-ap-rustc_target 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25f711bb152b9d7cdd69410cfe6d99aeb1409c959e0fdf3c8ca4d220e568aa52"
+"checksum rustc-ap-serialize 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57638db658d4942d3f30a12566836f9a67a636ed8002c8cae1c9231214e39929"
+"checksum rustc-ap-syntax 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6dbcf07abf7a9957dce8d34353d55dfb4cd882153181f24349f4690facb58f0"
+"checksum rustc-ap-syntax_pos 237.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0915cb5e166cabe588a129dec2d47357077e96fb1f9b57318fbe217eac4ce508"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6d5a683c6ba4ed37959097e88d71c9e8e26659a3cb5be8b389078e7ad45306"
@@ -840,7 +845,7 @@ dependencies = [
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
-"checksum smallvec 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "211a489e65e94b103926d2054ae515a1cdb5d515ea0ef414fee23b7e043ce748"
+"checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ env_logger = "0.5"
 getopts = "0.2"
 derive-new = "0.5"
 cargo_metadata = "0.6"
-rustc-ap-rustc_target = "235.0.0"
-rustc-ap-syntax = "235.0.0"
-rustc-ap-syntax_pos = "235.0.0"
+rustc-ap-rustc_target = "237.0.0"
+rustc-ap-syntax = "237.0.0"
+rustc-ap-syntax_pos = "237.0.0"
 failure = "0.1.1"
 
 [dev-dependencies]

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -173,7 +173,7 @@ fn rewrite_closure_expr(
         match expr.node {
             ast::ExprKind::Match(..)
             | ast::ExprKind::Block(..)
-            | ast::ExprKind::Catch(..)
+            | ast::ExprKind::TryBlock(..)
             | ast::ExprKind::Loop(..)
             | ast::ExprKind::Struct(..) => true,
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -317,7 +317,7 @@ pub fn format_expr(
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
         ast::ExprKind::InlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
-        ast::ExprKind::Catch(ref block) => {
+        ast::ExprKind::TryBlock(ref block) => {
             if let rw @ Some(_) = rewrite_single_line_block(
                 context,
                 "do catch ",

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -320,7 +320,7 @@ pub fn format_expr(
         ast::ExprKind::TryBlock(ref block) => {
             if let rw @ Some(_) = rewrite_single_line_block(
                 context,
-                "do catch ",
+                "try ",
                 block,
                 Some(&expr.attrs),
                 None,
@@ -328,11 +328,11 @@ pub fn format_expr(
             ) {
                 rw
             } else {
-                // 9 = `do catch `
+                // 9 = `try `
                 let budget = shape.width.saturating_sub(9);
                 Some(format!(
                     "{}{}",
-                    "do catch ",
+                    "try ",
                     rewrite_block(
                         block,
                         Some(&expr.attrs),

--- a/tests/source/catch.rs
+++ b/tests/source/catch.rs
@@ -1,27 +1,27 @@
-#![feature(catch_expr)]
+#![feature(try_blocks)]
 
 fn main() {
-    let x = do catch {
+    let x = try {
         foo()?
     };
 
-    let x = do catch /* Invisible comment */ { foo()? };
+    let x = try /* Invisible comment */ { foo()? };
 
-    let x = do catch {
+    let x = try {
         unsafe { foo()? }
     };
 
-    let y = match (do catch {
+    let y = match (try {
         foo()?
     }) {
         _ => (),
     };
 
-    do catch {
+    try {
         foo()?;
     };
 
-    do catch {
-        // Regular do catch block
+    try {
+        // Regular try block
     };
 }

--- a/tests/target/catch.rs
+++ b/tests/target/catch.rs
@@ -1,21 +1,21 @@
-#![feature(catch_expr)]
+#![feature(try_blocks)]
 
 fn main() {
-    let x = do catch { foo()? };
+    let x = try { foo()? };
 
-    let x = do catch /* Invisible comment */ { foo()? };
+    let x = try /* Invisible comment */ { foo()? };
 
-    let x = do catch { unsafe { foo()? } };
+    let x = try { unsafe { foo()? } };
 
-    let y = match (do catch { foo()? }) {
+    let y = match (try { foo()? }) {
         _ => (),
     };
 
-    do catch {
+    try {
         foo()?;
     };
 
-    do catch {
-        // Regular do catch block
+    try {
+        // Regular try block
     };
 }


### PR DESCRIPTION
Noticed I couldn't build today, so I fixed it.