### PR TITLE
Use stable Rust in Travis CI config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ A minimal Travis setup could look like this (requires Rust 1.24.0 or greater):
 
 ```yaml
 language: rust
-rust:
-- nightly
 before_script:
 - rustup component add rustfmt-preview
 script:


### PR DESCRIPTION
In #2725 the Travis CI config snippet in the README was changed to use nightly Rust because the stable rustfmt of the time (rustfmt 0.4.1-stable) did not contain the `--check` flag, which is used in the Travis config snippet. The current stable rustfmt (rustfmt 0.8.2-stable) does contain the `--check` flag, so it is now possible to use the Travis config in the README with stable rustfmt.

This PR makes that change.