### PR TITLE
Keep formatting fn even if there is an unformattable argument 

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2232,8 +2232,10 @@ fn rewrite_args(
 ) -> Option<String> {
     let mut arg_item_strs = args
         .iter()
-        .map(|arg| arg.rewrite(context, Shape::legacy(multi_line_budget, arg_indent)))
-        .collect::<Option<Vec<_>>>()?;
+        .map(|arg| {
+            arg.rewrite(context, Shape::legacy(multi_line_budget, arg_indent))
+                .unwrap_or_else(|| context.snippet(arg.span()).to_owned())
+        }).collect::<Vec<_>>();
 
     // Account for sugary self.
     // FIXME: the comment for the self argument is dropped. This is blocked

--- a/tests/source/fn-simple.rs
+++ b/tests/source/fn-simple.rs
@@ -67,3 +67,8 @@ crate fn init() {}
 
 // #2630
 fn make_map<T, F: (Fn(&T) -> String)>(records: &Vec<T>, key_fn: F) -> HashMap<String, usize> {}
+
+// #2956
+fn bar(beans: Asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf, spam: bool, eggs: bool) -> bool{
+    unimplemented!();
+}

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -108,3 +108,12 @@ crate fn init() {}
 
 // #2630
 fn make_map<T, F: (Fn(&T) -> String)>(records: &Vec<T>, key_fn: F) -> HashMap<String, usize> {}
+
+// #2956
+fn bar(
+    beans: Asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf,
+    spam: bool,
+    eggs: bool,
+) -> bool {
+    unimplemented!();
+}


### PR DESCRIPTION
We could either retry with larger width or use the original code. I opted for latter.

Closes #2956.