### PR TITLE
Accept 2015 and 2018 instead of Edition2015 and Edition2018 for edition option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - env: INTEGRATION=stdsimd
     - env: INTEGRATION=tempdir
   allow_failures:
-    # Needs `edition = "Edition2018"` in rustfmt.toml
+    # Needs `edition = "2018"` in rustfmt.toml
     - env: INTEGRATION=chalk
     # Fails tests, don't know why
     - env: INTEGRATION=crater

--- a/Configurations.md
+++ b/Configurations.md
@@ -2176,8 +2176,8 @@ ignore = [
 
 Specifies which edition is used by the parser.
 
-- **Default value**: `Edition2015`
-- **Possible values**: `Edition2015`, `Edition2018`
+- **Default value**: `2015`
+- **Possible values**: `2015`, `2018`
 - **Stable**: No
 
 ### Example
@@ -2185,7 +2185,7 @@ Specifies which edition is used by the parser.
 If you want to format code that requires edition 2018, add the following to your config file:
 
 ```toml
-edition = "Edition2018"
+edition = "2018"
 ```
 
 ## `emit_mode`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cargo +nightly fmt
 To format code that requires edition 2018, create a `rustfmt.toml` [configuration](#configuring-rustfmt) file containing:
 
 ```toml
-edition = "Edition2018"
+edition = "2018"
 ```
 
 ## Limitations

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 error_on_line_overflow = true
 error_on_unformatted = true
-edition = "Edition2018"
+edition = "2018"

--- a/tests/source/async_block.rs
+++ b/tests/source/async_block.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 
 fn main() {
     let x = async {

--- a/tests/source/async_fn.rs
+++ b/tests/source/async_fn.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 
 async fn bar() -> Result<(), ()> {
     Ok(())

--- a/tests/source/catch.rs
+++ b/tests/source/catch.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 #![feature(try_blocks)]
 
 fn main() {

--- a/tests/source/issue-2927-2.rs
+++ b/tests/source/issue-2927-2.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2015
+// rustfmt-edition: 2015
 #![feature(rust_2018_preview, uniform_paths)]
 use futures::prelude::*;
 use http_03::cli::Cli;

--- a/tests/source/issue-2927.rs
+++ b/tests/source/issue-2927.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 #![feature(rust_2018_preview, uniform_paths)]
 use futures::prelude::*;
 use http_03::cli::Cli;

--- a/tests/target/async_block.rs
+++ b/tests/target/async_block.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 
 fn main() {
     let x = async { Ok(()) };

--- a/tests/target/async_closure.rs
+++ b/tests/target/async_closure.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 
 fn main() {
     let async_closure = async {

--- a/tests/target/async_fn.rs
+++ b/tests/target/async_fn.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 
 async fn bar() -> Result<(), ()> {
     Ok(())

--- a/tests/target/catch.rs
+++ b/tests/target/catch.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 #![feature(try_blocks)]
 
 fn main() {

--- a/tests/target/issue-2927-2.rs
+++ b/tests/target/issue-2927-2.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2015
+// rustfmt-edition: 2015
 #![feature(rust_2018_preview, uniform_paths)]
 use futures::prelude::*;
 use http_03::cli::Cli;

--- a/tests/target/issue-2927.rs
+++ b/tests/target/issue-2927.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: Edition2018
+// rustfmt-edition: 2018
 #![feature(rust_2018_preview, uniform_paths)]
 use ::log::{error, info, log};
 use futures::prelude::*;


### PR DESCRIPTION
It seemed odd to me when playing with Rust2018 that `Cargo.toml` wants `edition = "2018"` but `rustfmt.toml` wants `edition = "Edition2018"`. This PR changes the rustfmt edition parsing to match the parsing in Cargo.toml.

This is my first time trying to work with complex macros so there probably is a better way to make the changes to `configuration_option_enum!`. I'm very open to improvement suggestions there.

I didn't make an issue first so I'm unaware if this is wanted. I felt it would be a small enough change to have fun for a couple hours so I just went and did it. If this is not wanted, I understand.