### PR TITLE
Use correct shape in Visual tuple rewriting

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1753,7 +1753,7 @@ where
         Separator::Comma,
         nested_shape.width,
     );
-    let fmt = ListFormatting::new(shape, context.config)
+    let fmt = ListFormatting::new(nested_shape, context.config)
         .tactic(tactic)
         .ends_with_newline(false);
     let list_str = write_list(&item_vec, &fmt)?;

--- a/tests/source/issue-2930.rs
+++ b/tests/source/issue-2930.rs
@@ -1,0 +1,5 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    let (first_variable, second_variable) = (this_is_something_with_an_extraordinarily_long_name,
+    this_variable_name_is_also_pretty_long);
+}

--- a/tests/target/issue-2930.rs
+++ b/tests/target/issue-2930.rs
@@ -1,0 +1,5 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    let (first_variable, second_variable) = (this_is_something_with_an_extraordinarily_long_name,
+                                             this_variable_name_is_also_pretty_long);
+}


### PR DESCRIPTION
Fixes #2930

As an added bonus, fixes the missing offset in calls like this:
```diff
         if let Some((&mut (ref Y_buf, ref U_buf, ref V_buf), pro_que)) =
             get_yuv_buffers_and_pro_que(engine,
                                         (frame.data(0).len(),
-                                        frame.data(1).len(),
-                                        frame.data(2).len()))
+                                         frame.data(1).len(),
+                                         frame.data(2).len()))
         {
             let kernel = pro_que.kernel_builder(func_name)
                                 .global_work_size(image.dims())
```
which was a sub-case of #2930.