### PR TITLE
Use correct indent in rewrite_bare_fn with Visual style

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -298,6 +298,8 @@ where
     <I as Iterator>::Item: Deref,
     <I::Item as Deref>::Target: Rewrite + Spanned + 'a,
 {
+    debug!("format_function_type {:#?}", shape);
+
     // Code for handling variadics is somewhat duplicated for items, but they
     // are different enough to need some serious refactoring to share code.
     enum ArgumentKind<T>
@@ -706,6 +708,8 @@ fn rewrite_bare_fn(
     context: &RewriteContext,
     shape: Shape,
 ) -> Option<String> {
+    debug!("rewrite_bare_fn {:#?}", shape);
+
     let mut result = String::with_capacity(128);
 
     if let Some(ref lifetime_str) = rewrite_lifetime_param(context, shape, &bare_fn.generic_params)

--- a/src/types.rs
+++ b/src/types.rs
@@ -732,7 +732,11 @@ fn rewrite_bare_fn(
 
     result.push_str("fn");
 
-    let func_ty_shape = shape.offset_left(result.len())?;
+    let func_ty_shape = if context.use_block_indent() {
+        shape.offset_left(result.len())?
+    } else {
+        shape.visual_indent(result.len()).sub_width(result.len())?
+    };
 
     let rewrite = format_function_type(
         bare_fn.decl.inputs.iter(),

--- a/tests/source/issue-2922.rs
+++ b/tests/source/issue-2922.rs
@@ -1,0 +1,9 @@
+// rustfmt-indent_style: Visual
+struct Functions {
+    RunListenServer: unsafe extern "C" fn(*mut c_void,
+     *mut c_char,
+     *mut c_char,
+     *mut c_char,
+     *mut c_void,
+     *mut c_void) -> c_int,
+}

--- a/tests/target/issue-2922.rs
+++ b/tests/target/issue-2922.rs
@@ -1,0 +1,10 @@
+// rustfmt-indent_style: Visual
+struct Functions {
+    RunListenServer: unsafe extern "C" fn(*mut c_void,
+                                          *mut c_char,
+                                          *mut c_char,
+                                          *mut c_char,
+                                          *mut c_void,
+                                          *mut c_void)
+                                          -> c_int,
+}


### PR DESCRIPTION
Fixes #2922.

I'm not sure the fix is "right" since I'm not very familiar with the code base. Looking at the debug log output, the final item in `tests/target/where_clause.rs`:
https://github.com/rust-lang-nursery/rustfmt/blob/430f848c75b100f1fab3fbaa67ba35ab7a8fbfcb/tests/target/where-clause.rs#L101-L103
passes `format_function_type()` a shape that has both `indent.alignment` and `offset` set to the same value. Before the fix in this PR, `rewrite_bare_fn()` would pass `format_function_type()` a shape with correct offset but `indent.alignment` set to zero, which caused the incorrect formatting (since `format_function_type()` ignores `offset` for Visual style).