### PR TITLE
Change `print_diff` to output the correct line number.

### DIFF
--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -161,7 +161,7 @@ where
     let mut writer = OutputWriter::new(color);
 
     for mismatch in diff {
-        let title = get_section_title(mismatch.line_number);
+        let title = get_section_title(mismatch.line_number_orig);
         writer.writeln(&title, None);
 
         for line in mismatch.lines {


### PR DESCRIPTION
The `print_diff` function should output the diff starting from `line_number_orig`, because that is the line number which corresponds to the original file.

**Output before:**
```
Diff in /home/robert/rustfmt/src/rustfmt_diff.rs at line 162:
 
     for mismatch in diff {
         let title = get_section_title(mismatch.line_number);
-        writer.writeln(&title,
-                       None);
+        writer.writeln(&title, None);
 
         for line in mismatch.lines {
             match line {
Diff in /home/robert/rustfmt/src/rustfmt_diff.rs at line 174: // <-- 174 is incorrect
                     Some(term::color::GREEN),
                 ),
                 DiffLine::Resulting(ref str) => writer.writeln(
-                    &format!("-{}{}", str,
-                             line_terminator),
+                    &format!("-{}{}", str, line_terminator),
                     Some(term::color::RED),
                 ),
             }
```
**Output after:**
```
Diff in /home/robert/rustfmt/src/rustfmt_diff.rs at line 162:
 
     for mismatch in diff {
         let title = get_section_title(mismatch.line_number_orig);
-        writer.writeln(&title,
-                       None);
+        writer.writeln(&title, None);
 
         for line in mismatch.lines {
             match line {
Diff in /home/robert/rustfmt/src/rustfmt_diff.rs at line 175: // <-- 175 is correct
                     Some(term::color::GREEN),
                 ),
                 DiffLine::Resulting(ref str) => writer.writeln(
-                    &format!("-{}{}", str,
-                             line_terminator),
+                    &format!("-{}{}", str, line_terminator),
                     Some(term::color::RED),
                 ),
             }


```