### PR TITLE
Fix match arm block flattening

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1303,7 +1303,7 @@ fn main() {
     });
 
     match lorem {
-        None => if ipsum {
+        None => |ipsum| {
             println!("Hello World");
         },
         Some(dolor) => foo(),
@@ -1324,7 +1324,7 @@ fn main() {
 
     match lorem {
         None => {
-            if ipsum {
+            |ipsum| {
                 println!("Hello World");
             }
         }

--- a/src/config/lists.rs
+++ b/src/config/lists.rs
@@ -95,11 +95,13 @@ impl SeparatorPlace {
     ) -> SeparatorPlace {
         match tactic {
             DefinitiveListTactic::Vertical => default,
-            _ => if sep == "," {
-                SeparatorPlace::Back
-            } else {
-                default
-            },
+            _ => {
+                if sep == "," {
+                    SeparatorPlace::Back
+                } else {
+                    default
+                }
+            }
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -179,11 +179,13 @@ pub fn format_expr(
                 Some(format!("break{}", id_str))
             }
         }
-        ast::ExprKind::Yield(ref opt_expr) => if let Some(ref expr) = *opt_expr {
-            rewrite_unary_prefix(context, "yield ", &**expr, shape)
-        } else {
-            Some("yield".to_string())
-        },
+        ast::ExprKind::Yield(ref opt_expr) => {
+            if let Some(ref expr) = *opt_expr {
+                rewrite_unary_prefix(context, "yield ", &**expr, shape)
+            } else {
+                Some("yield".to_string())
+            }
+        }
         ast::ExprKind::Closure(capture, asyncness, movability, ref fn_decl, ref body, _) => {
             closures::rewrite_closure(
                 capture, asyncness, movability, fn_decl, body, expr.span, context, shape,

--- a/tests/source/issue-2496.rs
+++ b/tests/source/issue-2496.rs
@@ -1,0 +1,16 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    match option {
+        None => some_function(first_reasonably_long_argument,
+                              second_reasonably_long_argument),
+    }
+}
+
+fn main() {
+    match option {
+        None => {
+            some_function(first_reasonably_long_argument,
+                          second_reasonably_long_argument)
+        }
+    }
+}

--- a/tests/source/match-flattening.rs
+++ b/tests/source/match-flattening.rs
@@ -1,0 +1,21 @@
+fn main() {
+    match option {
+        None => if condition {
+            true
+        } else {
+            false
+        },
+    }
+}
+
+fn main() {
+    match option {
+        None => {
+            if condition {
+                true
+            } else {
+                false
+            }
+        }
+    }
+}

--- a/tests/target/issue-2496.rs
+++ b/tests/target/issue-2496.rs
@@ -1,0 +1,14 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    match option {
+        None => some_function(first_reasonably_long_argument,
+                              second_reasonably_long_argument),
+    }
+}
+
+fn main() {
+    match option {
+        None => some_function(first_reasonably_long_argument,
+                              second_reasonably_long_argument),
+    }
+}

--- a/tests/target/match-flattening.rs
+++ b/tests/target/match-flattening.rs
@@ -1,0 +1,23 @@
+fn main() {
+    match option {
+        None => {
+            if condition {
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+fn main() {
+    match option {
+        None => {
+            if condition {
+                true
+            } else {
+                false
+            }
+        }
+    }
+}


### PR DESCRIPTION
The match arm block flattening was using two different heuristics for when the initial expression was in a block or not. This lead to inconsistent formatting on default settings:
```rust
// Both of these were left untouched!
match option {
    None => if condition {
        true
    } else {
        false
    },
}
match option {
    None => {
        if condition {
            true
        } else {
            false
        }
    }
}
```
and to a much worse cycle on indent_style = "Visual" (#2496).

I factored out the check into a closure so this mistake doesn't happen again and added tests for both the default behavior (match-flattening.rs) and #2496.

I had to change `Configurations.md` as the existing `force_multiline_blocks` was actually invalid according to the preferred heuristic.

Fixes #2496.