### PR TITLE
Fix wrong shape for last chain items for indent_style = "Visual"

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -614,6 +614,12 @@ impl<'a> ChainFormatterShared<'a> {
             }
         }
 
+        let last_shape = if context.use_block_indent() {
+            last_shape
+        } else {
+            child_shape.sub_width(shape.rhs_overhead(context.config) + last.tries)?
+        };
+
         last_subexpr_str = last_subexpr_str.or_else(|| last.rewrite(context, last_shape));
         self.rewrites.push(last_subexpr_str?);
         Some(())

--- a/tests/source/issue-2985.rs
+++ b/tests/source/issue-2985.rs
@@ -1,0 +1,35 @@
+// rustfmt-indent_style: Visual
+fn foo() {
+    {
+        {
+            let extra_encoder_settings = extra_encoder_settings.iter()
+                                                               .filter_map(|&(name, value)| {
+                                                         value.split()
+                                                              .next()
+                                                              .something()
+                                                              .something2()
+                                                              .something3()
+                                                              .something4()
+                                                     });
+            let extra_encoder_settings = extra_encoder_settings.iter()
+                                                               .filter_map(|&(name, value)| {
+                                                                               value.split()
+                                                                                    .next()
+                                                                                    .something()
+                                                                                    .something2()
+                                                                                    .something3()
+                                                                                    .something4()
+                                                                           })
+                                                               .something();
+            if let Some(subpod) = pod.subpods.iter().find(|s| {
+                                                              !s.plaintext
+                                                                .as_ref()
+                                                                .map(String::as_ref)
+                                                                .unwrap_or("")
+                                                                .is_empty()
+                                                          }) {
+                do_something();
+            }
+        }
+    }
+}

--- a/tests/target/issue-2985.rs
+++ b/tests/target/issue-2985.rs
@@ -1,0 +1,35 @@
+// rustfmt-indent_style: Visual
+fn foo() {
+    {
+        {
+            let extra_encoder_settings = extra_encoder_settings.iter()
+                                                               .filter_map(|&(name, value)| {
+                                                                               value.split()
+                                                                                    .next()
+                                                                                    .something()
+                                                                                    .something2()
+                                                                                    .something3()
+                                                                                    .something4()
+                                                                           });
+            let extra_encoder_settings = extra_encoder_settings.iter()
+                                                               .filter_map(|&(name, value)| {
+                                                                               value.split()
+                                                                                    .next()
+                                                                                    .something()
+                                                                                    .something2()
+                                                                                    .something3()
+                                                                                    .something4()
+                                                                           })
+                                                               .something();
+            if let Some(subpod) = pod.subpods.iter().find(|s| {
+                                                              !s.plaintext
+                                                                .as_ref()
+                                                                .map(String::as_ref)
+                                                                .unwrap_or("")
+                                                                .is_empty()
+                                                          }) {
+                do_something();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2985, apart from the test from that issue I also added an expression from one of my projects that got formatted incorrectly when I was testing out an initial (incorrect) attempt of fixing this (which wasn't caught by anything else in the test suite).