### PR TITLE
Fix extra new line in fn type aliases with indent_style = "Visual"

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -400,7 +400,7 @@ where
             shape.block().indent.to_string_with_newline(context.config),
         )
     };
-    if last_line_width(&args) + first_line_width(&output) <= shape.width {
+    if output.is_empty() || last_line_width(&args) + first_line_width(&output) <= shape.width {
         Some(format!("{}{}", args, output))
     } else {
         Some(format!(

--- a/tests/source/visual-fn-type.rs
+++ b/tests/source/visual-fn-type.rs
@@ -1,0 +1,10 @@
+// rustfmt-indent_style: Visual
+type CNodeSetAtts = unsafe extern "C" fn(node: *const RsvgNode,
+                                         node_impl: *const RsvgCNodeImpl,
+                                         handle: *const RsvgHandle,
+                                         pbag: *const PropertyBag)
+                                         ;
+type CNodeDraw = unsafe extern "C" fn(node: *const RsvgNode,
+                                      node_impl: *const RsvgCNodeImpl,
+                                      draw_ctx: *const RsvgDrawingCtx,
+                                      dominate: i32);

--- a/tests/target/visual-fn-type.rs
+++ b/tests/target/visual-fn-type.rs
@@ -1,0 +1,9 @@
+// rustfmt-indent_style: Visual
+type CNodeSetAtts = unsafe extern "C" fn(node: *const RsvgNode,
+                                         node_impl: *const RsvgCNodeImpl,
+                                         handle: *const RsvgHandle,
+                                         pbag: *const PropertyBag);
+type CNodeDraw = unsafe extern "C" fn(node: *const RsvgNode,
+                                      node_impl: *const RsvgCNodeImpl,
+                                      draw_ctx: *const RsvgDrawingCtx,
+                                      dominate: i32);


### PR DESCRIPTION
An extra blank line was inserted after the function types sometimes (like in the test source file).