### PR TITLE
Improve error message when failing cargo metadata

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -373,9 +373,9 @@ fn run_rustfmt(
 fn get_cargo_metadata(manifest_path: Option<&Path>) -> Result<cargo_metadata::Metadata, io::Error> {
     match cargo_metadata::metadata(manifest_path) {
         Ok(metadata) => Ok(metadata),
-        Err(..) => Err(io::Error::new(
+        Err(error) => Err(io::Error::new(
             io::ErrorKind::Other,
-            "`cargo manifest` failed.",
+            error.to_string(),
         )),
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rustfmt/issues/2933. 

Sample output:

```
error during execution of `cargo metadata`: error: could not find `Cargo.toml` in `/Users/nsutton/Code` or any parent directory
```