### PR TITLE
Fix indent computation of a macro with braces.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1118,6 +1118,7 @@ fn indent_macro_snippet(
             } else {
                 Some(get_prefix_space_width(context, &line))
             };
+
             let line = if veto_trim || (kind.is_string() && !line.ends_with('\\')) {
                 veto_trim = kind.is_string() && !line.ends_with('\\');
                 trimmed = false;
@@ -1126,7 +1127,12 @@ fn indent_macro_snippet(
                 line.trim().to_owned()
             };
             trimmed_lines.push((trimmed, line, prefix_space_width));
-            prefix_space_width
+
+            // when computing the minimum, do not consider lines within a string
+            match kind {
+                FullCodeCharKind::InString | FullCodeCharKind::EndString => None,
+                _ => prefix_space_width,
+            }
         }).min()?;
 
     Some(
@@ -1139,7 +1145,7 @@ fn indent_macro_snippet(
                         let new_indent_width = indent.width() + original_indent_width
                             .saturating_sub(min_prefix_space_width);
                         let new_indent = Indent::from_width(context.config, new_indent_width);
-                        format!("{}{}", new_indent.to_string(context.config), line.trim())
+                        format!("{}{}", new_indent.to_string(context.config), line)
                     }
                     None => String::new(),
                 },

--- a/tests/source/issue-2973.rs
+++ b/tests/source/issue-2973.rs
@@ -1,0 +1,158 @@
+#[cfg(test)]
+mod test {
+  summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+    "foo: \
+ {{hello}} \
+{{ahah}}",
+        "N:#$>^{N}$<.",
+      }
+
+  summary_test! {
+    tokenize_strings,
+    r#"a = "'a'" + '"b"' + "'c'" + '"d"'#echo hello"#,
+    r#"N="+'+"+'#."#,
+  }
+
+  summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+        "N:#$>^{N}$<.",
+      }
+
+  summary_test! {
+        tokenize_recipe_interpolation_eof,
+    "foo: # more comments
+ {{hello}}
+# another comment
+",
+        "N:#$>^{N}$<#$.",
+      }
+
+  summary_test! {
+    tokenize_recipe_complex_interpolation_expression,
+    "foo: #lol\n {{a + b + \"z\" + blarg}}",
+    "N:#$>^{N+N+\"+N}<.",
+  }
+
+  summary_test! {
+    tokenize_recipe_multiple_interpolations,
+    "foo:,#ok\n {{a}}0{{b}}1{{c}}",
+    "N:,#$>^{N}_{N}_{N}<.",
+  }
+
+  summary_test! {
+        tokenize_junk,
+    "bob
+
+hello blah blah blah : a b c #whatever
+    ",
+        "N$$NNNN:NNN#$.",
+      }
+
+  summary_test! {
+        tokenize_empty_lines,
+    "
+# this does something
+hello:
+  asdf
+  bsdf
+
+  csdf
+
+  dsdf # whatever
+
+# yolo
+  ",
+        "$#$N:$>^_$^_$$^_$$^_$$<#$.",
+      }
+
+  summary_test! {
+        tokenize_comment_before_variable,
+    "
+#
+A='1'
+echo:
+  echo {{A}}
+  ",
+        "$#$N='$N:$>^_{N}$<.",
+      }
+
+  summary_test! {
+    tokenize_interpolation_backticks,
+    "hello:\n echo {{`echo hello` + `echo goodbye`}}",
+    "N:$>^_{`+`}<.",
+  }
+
+  summary_test! {
+    tokenize_assignment_backticks,
+    "a = `echo hello` + `echo goodbye`",
+    "N=`+`.",
+  }
+
+  summary_test! {
+        tokenize_multiple,
+    "
+hello:
+  a
+  b
+
+  c
+
+  d
+
+# hello
+bob:
+  frank
+  ",
+
+        "$N:$>^_$^_$$^_$$^_$$<#$N:$>^_$<.",
+      }
+
+  summary_test! {
+    tokenize_comment,
+    "a:=#",
+    "N:=#."
+  }
+
+  summary_test! {
+    tokenize_comment_with_bang,
+    "a:=#foo!",
+    "N:=#."
+  }
+
+  summary_test! {
+        tokenize_order,
+    r"
+b: a
+  @mv a b
+
+a:
+  @touch F
+  @touch a
+
+d: c
+  @rm c
+
+c: b
+  @mv b c",
+        "$N:N$>^_$$<N:$>^_$^_$$<N:N$>^_$$<N:N$>^_<.",
+      }
+
+  summary_test! {
+    tokenize_parens,
+    r"((())) )abc(+",
+    "((())))N(+.",
+  }
+
+  summary_test! {
+    crlf_newline,
+    "#\r\n#asdf\r\n",
+    "#$#$.",
+  }
+}

--- a/tests/target/issue-2973.rs
+++ b/tests/target/issue-2973.rs
@@ -1,0 +1,158 @@
+#[cfg(test)]
+mod test {
+    summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+    "foo: \
+    {{hello}} \
+    {{ahah}}",
+        "N:#$>^{N}$<.",
+      }
+
+    summary_test! {
+      tokenize_strings,
+      r#"a = "'a'" + '"b"' + "'c'" + '"d"'#echo hello"#,
+      r#"N="+'+"+'#."#,
+    }
+
+    summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+        "N:#$>^{N}$<.",
+      }
+
+    summary_test! {
+        tokenize_recipe_interpolation_eof,
+    "foo: # more comments
+ {{hello}}
+# another comment
+",
+        "N:#$>^{N}$<#$.",
+      }
+
+    summary_test! {
+      tokenize_recipe_complex_interpolation_expression,
+      "foo: #lol\n {{a + b + \"z\" + blarg}}",
+      "N:#$>^{N+N+\"+N}<.",
+    }
+
+    summary_test! {
+      tokenize_recipe_multiple_interpolations,
+      "foo:,#ok\n {{a}}0{{b}}1{{c}}",
+      "N:,#$>^{N}_{N}_{N}<.",
+    }
+
+    summary_test! {
+        tokenize_junk,
+    "bob
+
+hello blah blah blah : a b c #whatever
+    ",
+        "N$$NNNN:NNN#$.",
+      }
+
+    summary_test! {
+        tokenize_empty_lines,
+    "
+# this does something
+hello:
+  asdf
+  bsdf
+
+  csdf
+
+  dsdf # whatever
+
+# yolo
+  ",
+        "$#$N:$>^_$^_$$^_$$^_$$<#$.",
+      }
+
+    summary_test! {
+        tokenize_comment_before_variable,
+    "
+#
+A='1'
+echo:
+  echo {{A}}
+  ",
+        "$#$N='$N:$>^_{N}$<.",
+      }
+
+    summary_test! {
+      tokenize_interpolation_backticks,
+      "hello:\n echo {{`echo hello` + `echo goodbye`}}",
+      "N:$>^_{`+`}<.",
+    }
+
+    summary_test! {
+      tokenize_assignment_backticks,
+      "a = `echo hello` + `echo goodbye`",
+      "N=`+`.",
+    }
+
+    summary_test! {
+        tokenize_multiple,
+    "
+hello:
+  a
+  b
+
+  c
+
+  d
+
+# hello
+bob:
+  frank
+  ",
+
+        "$N:$>^_$^_$$^_$$^_$$<#$N:$>^_$<.",
+      }
+
+    summary_test! {
+      tokenize_comment,
+      "a:=#",
+      "N:=#."
+    }
+
+    summary_test! {
+      tokenize_comment_with_bang,
+      "a:=#foo!",
+      "N:=#."
+    }
+
+    summary_test! {
+        tokenize_order,
+    r"
+b: a
+  @mv a b
+
+a:
+  @touch F
+  @touch a
+
+d: c
+  @rm c
+
+c: b
+  @mv b c",
+        "$N:N$>^_$$<N:$>^_$^_$$<N:N$>^_$$<N:N$>^_<.",
+      }
+
+    summary_test! {
+      tokenize_parens,
+      r"((())) )abc(+",
+      "((())))N(+.",
+    }
+
+    summary_test! {
+      crlf_newline,
+      "#\r\n#asdf\r\n",
+      "#$#$.",
+    }
+}


### PR DESCRIPTION
The leading whitespace of a multine string was taken into account when
computing the `min_prefix_space_width`, even if that line couldn't be
trimmed. The consequence is it was always shifting the macro's content
to the right.

close #2973 