### PR TITLE
Do not trim a block from expression if its condition will go multi-line

### DIFF
--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -507,3 +507,17 @@ fn issue_2377() {
         Tok::TypeOf if prec <= 16 => {}
     }
 }
+
+// #3040
+fn issue_3040() {
+    {
+        match foo {
+            DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => {
+                match documents.find_window(id) {
+                    Some(window) => devtools::handle_wants_live_notifications(window.upcast(), to_send),
+                    None => return warn!("Message sent to closed pipeline {}.", id),
+                }
+            }
+        }
+    }
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -536,3 +536,19 @@ fn issue_2377() {
         Tok::TypeOf if prec <= 16 => {}
     }
 }
+
+// #3040
+fn issue_3040() {
+    {
+        match foo {
+            DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => {
+                match documents.find_window(id) {
+                    Some(window) => {
+                        devtools::handle_wants_live_notifications(window.upcast(), to_send)
+                    }
+                    None => return warn!("Message sent to closed pipeline {}.", id),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3040.

N.B. this PR does not handle adding a block to an arm body. E.g. the following snippet will not get formatted.

```rust
            DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => match documents
                .find_window(id)
            {
                Some(window) => {
                    devtools::handle_wants_live_notifications(window.upcast(), to_send)
                }
                None => return warn!("Message sent to closed pipeline {}.", id),
            },
```

IMHO adding/removing a block around `match` arm's body has been buggish and has confused users, so I think we should review and refactor its logic.