### PR TITLE
Prevent right-shifting of block comments with bare lines.

### DIFF
--- a/tests/source/issue-2917/packed_simd.rs
+++ b/tests/source/issue-2917/packed_simd.rs
@@ -1,0 +1,63 @@
+// rustfmt-wrap_comments: true
+//! Implements `From` and `Into` for vector types.
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+                // the blanket impl in `std`, which is not
+                // marked `default`, we cannot override it here with
+                // specialization.
+                /*
+                impl Into<$id> for $source {
+                    #[inline]
+                    fn into(self) -> $id {
+                        unsafe { simd_cast(self) }
+                    }
+                }
+                */
+
+        test_if!{
+            $test_tt:
+            interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_vectors {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $($source:ident),*) => {
+        $(
+            impl_from_vector!([$elem_ty; $elem_count]: $id | $test_tt | $source);
+        )*
+    }
+}

--- a/tests/target/issue-2896.rs
+++ b/tests/target/issue-2896.rs
@@ -91,23 +91,23 @@ fn main() {
 
             let probe = cooccurrences_with_row_sums.probe();
             /*
-      // produce the (item, item) collection
-      let cooccurrences = occurrences
-        .join_map(&occurrences, |_user, &item_a, &item_b| (item_a, item_b));
-      // count the occurrences of each item.
-      let counts = cooccurrences
-        .map(|(item_a,_)| item_a)
-        .count();
-      // produce ((item1, item2), count1, count2, count12) tuples
-      let cooccurrences_with_counts = cooccurrences
-        .join_map(&counts, |&item_a, &item_b, &count_item_a| (item_b, (item_a, count_item_a)))
-        .join_map(&counts, |&item_b, &(item_a, count_item_a), &count_item_b| {
-          ((item_a, item_b), count_item_a, count_item_b)
-        });
-      let probe = cooccurrences_with_counts
-        .inspect(|x| println!("change: {:?}", x))
-        .probe();
-*/
+                  // produce the (item, item) collection
+                  let cooccurrences = occurrences
+                    .join_map(&occurrences, |_user, &item_a, &item_b| (item_a, item_b));
+                  // count the occurrences of each item.
+                  let counts = cooccurrences
+                    .map(|(item_a,_)| item_a)
+                    .count();
+                  // produce ((item1, item2), count1, count2, count12) tuples
+                  let cooccurrences_with_counts = cooccurrences
+                    .join_map(&counts, |&item_a, &item_b, &count_item_a| (item_b, (item_a, count_item_a)))
+                    .join_map(&counts, |&item_b, &(item_a, count_item_a), &count_item_b| {
+                      ((item_a, item_b), count_item_a, count_item_b)
+                    });
+                  let probe = cooccurrences_with_counts
+                    .inspect(|x| println!("change: {:?}", x))
+                    .probe();
+            */
             (input, probe)
         });
 

--- a/tests/target/issue-2917/minimal.rs
+++ b/tests/target/issue-2917/minimal.rs
@@ -1,0 +1,8 @@
+macro_rules! foo {
+    () => {
+        // comment
+        /*
+
+        */
+    };
+}

--- a/tests/target/issue-2917/packed_simd.rs
+++ b/tests/target/issue-2917/packed_simd.rs
@@ -1,0 +1,63 @@
+// rustfmt-wrap_comments: true
+//! Implements `From` and `Into` for vector types.
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+        // the blanket impl in `std`, which is not
+        // marked `default`, we cannot override it here with
+        // specialization.
+        /*
+        impl Into<$id> for $source {
+            #[inline]
+            fn into(self) -> $id {
+                unsafe { simd_cast(self) }
+            }
+        }
+        */
+
+        test_if!{
+            $test_tt:
+            interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_vectors {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $($source:ident),*) => {
+        $(
+            impl_from_vector!([$elem_ty; $elem_count]: $id | $test_tt | $source);
+        )*
+    }
+}


### PR DESCRIPTION
Lines that didn't start with a comment sigil were returned unchanged in
comment::rewrite_comment. Then these unchanged lines were indented in
MacroBranch::rewrite.

Close #2917 