### PR TITLE
Trait Implementation - Adds a newline before the last brace on impls without a body if the first brace is also on a newline

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -755,11 +755,10 @@ pub fn format_impl(
             result.push_str(&inner_indent_str);
             result.push_str(visitor.buffer.to_string().trim());
             result.push_str(&outer_indent_str);
-        }
-
-        if result.ends_with('{') && !context.config.empty_item_single_line() {
+        } else if need_newline || !context.config.empty_item_single_line() {
             result.push_str(&sep);
         }
+
         result.push('}');
 
         Some(result)

--- a/tests/target/big-impl-block.rs
+++ b/tests/target/big-impl-block.rs
@@ -78,4 +78,5 @@ where
     S: event::Stream,
     F: for<'t> FnMut(transform::Api<'t, Stream<ContentStream<S>>>) -> transform::Api<'t, X>,
     X: event::Stream,
-{}
+{
+}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -134,11 +134,13 @@ mod m {
 
 impl<BorrowType, K, V, NodeType, HandleType>
     Handle<NodeRef<BorrowType, K, V, NodeType>, HandleType>
-{}
+{
+}
 
 impl<BorrowType, K, V, NodeType, HandleType> PartialEq
     for Handle<NodeRef<BorrowType, K, V, NodeType>, HandleType>
-{}
+{
+}
 
 mod x {
     impl<A, B, C, D> Foo
@@ -147,7 +149,8 @@ mod x {
         B: 'static,
         C: 'static,
         D: 'static,
-    {}
+    {
+    }
 }
 
 impl<ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNodeFoo>
@@ -229,4 +232,5 @@ impl<'seq1, 'seq2, 'body, 'scope, Channel>
     >
 where
     Channel: DmaChannel,
-{}
+{
+}


### PR DESCRIPTION
Hi there, this is my first PR :) Let me know if there's a better way to fix this.

This PRs ends up bypassing the 'empty_item_single_line' configuration when the `{` is on a new line. (related to #2771).

According to the comments from #3046, this is the expected behavior. Fixes #3046