### PR TITLE
Add println!-like heuristic to the fail attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,20 +35,12 @@ matrix:
     - env: INTEGRATION=stdsimd
     - env: INTEGRATION=tempdir
   allow_failures:
-    # Needs `edition = "2018"` in rustfmt.toml
-    - env: INTEGRATION=chalk
-    # Fails tests, don't know why
-    - env: INTEGRATION=crater
     # Doesn't build
     - env: INTEGRATION=futures-rs
     # Doesn't build - seems to be because of an option
     - env: INTEGRATION=packed_simd
-    # Weird bug I can't reproduce: #2969
-    - env: INTEGRATION=rand
     # Test failure
     - env: INTEGRATION=rust-clippy
-    # Build failure
-    - env: INTEGRATION=rust-semverver
 
 script:
   - |

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -361,13 +361,10 @@ pub fn rewrite_last_closure(
 /// Returns true if the given vector of arguments has more than one `ast::ExprKind::Closure`.
 pub fn args_have_many_closure(args: &[OverflowableItem]) -> bool {
     args.iter()
-        .filter(|arg| {
-            arg.to_expr()
-                .map(|e| match e.node {
-                    ast::ExprKind::Closure(..) => true,
-                    _ => false,
-                })
-                .unwrap_or(false)
+        .filter_map(|arg| arg.to_expr())
+        .filter(|expr| match expr.node {
+            ast::ExprKind::Closure(..) => true,
+            _ => false,
         })
         .count()
         > 1

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -13,9 +13,10 @@ use syntax::parse::classify;
 use syntax::source_map::Span;
 use syntax::{ast, ptr};
 
-use expr::{block_contains_comment, is_simple_block, is_unsafe_block, rewrite_cond, ToExpr};
+use expr::{block_contains_comment, is_simple_block, is_unsafe_block, rewrite_cond};
 use items::{span_hi_for_arg, span_lo_for_arg};
 use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
+use overflow::OverflowableItem;
 use rewrite::{Rewrite, RewriteContext};
 use shape::Shape;
 use source_map::SpanUtils;
@@ -358,10 +359,7 @@ pub fn rewrite_last_closure(
 }
 
 /// Returns true if the given vector of arguments has more than one `ast::ExprKind::Closure`.
-pub fn args_have_many_closure<T>(args: &[&T]) -> bool
-where
-    T: ToExpr,
-{
+pub fn args_have_many_closure(args: &[OverflowableItem]) -> bool {
     args.iter()
         .filter(|arg| {
             arg.to_expr()

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -27,17 +27,17 @@ use lists::{
     definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
     struct_lit_tactic, write_list, ListFormatting, ListItem, Separator,
 };
-use macros::{rewrite_macro, MacroArg, MacroPosition};
+use macros::{rewrite_macro, MacroPosition};
 use matches::rewrite_match;
-use overflow;
+use overflow::{self, IntoOverflowableItem, OverflowableItem};
 use pairs::{rewrite_all_pairs, rewrite_pair, PairParts};
-use patterns::{can_be_overflowed_pat, is_short_pattern, TuplePatField};
+use patterns::is_short_pattern;
 use rewrite::{Rewrite, RewriteContext};
 use shape::{Indent, Shape};
 use source_map::{LineRangeUtils, SpanUtils};
 use spanned::Spanned;
 use string::{rewrite_string, StringFormat};
-use types::{can_be_overflowed_type, rewrite_path, PathContext};
+use types::{rewrite_path, PathContext};
 use utils::{
     colon_spaces, contains_skip, count_newlines, first_line_ends_with, first_line_width,
     inner_attributes, last_line_extendable, last_line_width, mk_sp, outer_attributes,
@@ -391,7 +391,7 @@ pub fn format_expr(
         })
 }
 
-pub fn rewrite_array<'a, T: 'a>(
+pub fn rewrite_array<'a, T: 'a + IntoOverflowableItem<'a>>(
     name: &'a str,
     exprs: impl Iterator<Item = &'a T>,
     span: Span,
@@ -399,10 +399,7 @@ pub fn rewrite_array<'a, T: 'a>(
     shape: Shape,
     force_separator_tactic: Option<SeparatorTactic>,
     delim_token: Option<DelimToken>,
-) -> Option<String>
-where
-    T: Rewrite + Spanned + ToExpr,
-{
+) -> Option<String> {
     overflow::rewrite_with_square_brackets(
         context,
         name,
@@ -1263,7 +1260,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
 }
 
 /// In case special-case style is required, returns an offset from which we start horizontal layout.
-pub fn maybe_get_args_offset<T: ToExpr>(callee_str: &str, args: &[&T]) -> Option<(bool, usize)> {
+pub fn maybe_get_args_offset(callee_str: &str, args: &[OverflowableItem]) -> Option<(bool, usize)> {
     if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
         .iter()
         .find(|&&(s, _)| s == callee_str)
@@ -1358,7 +1355,7 @@ fn is_simple_expr(expr: &ast::Expr) -> bool {
     }
 }
 
-pub fn is_every_expr_simple<T: ToExpr>(lists: &[&T]) -> bool {
+pub fn is_every_expr_simple(lists: &[OverflowableItem]) -> bool {
     lists
         .iter()
         .all(|arg| arg.to_expr().map_or(false, is_simple_expr))
@@ -1723,16 +1720,13 @@ pub fn rewrite_field(
     }
 }
 
-fn rewrite_tuple_in_visual_indent_style<'a, T>(
+fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
     context: &RewriteContext,
     mut items: impl Iterator<Item = &'a T>,
     span: Span,
     shape: Shape,
     is_singleton_tuple: bool,
-) -> Option<String>
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
+) -> Option<String> {
     // In case of length 1, need a trailing comma
     debug!("rewrite_tuple_in_visual_indent_style {:?}", shape);
     if is_singleton_tuple {
@@ -1774,16 +1768,13 @@ where
     Some(format!("({})", list_str))
 }
 
-pub fn rewrite_tuple<'a, T>(
+pub fn rewrite_tuple<'a, T: 'a + IntoOverflowableItem<'a>>(
     context: &'a RewriteContext,
     items: impl Iterator<Item = &'a T>,
     span: Span,
     shape: Shape,
     is_singleton_tuple: bool,
-) -> Option<String>
-where
-    T: Rewrite + Spanned + ToExpr + 'a,
-{
+) -> Option<String> {
     debug!("rewrite_tuple {:?}", shape);
     if context.use_block_indent() {
         // We use the same rule as function calls for rewriting tuples.
@@ -1997,89 +1988,6 @@ fn rewrite_expr_addrof(
         ast::Mutability::Mutable => "&mut ",
     };
     rewrite_unary_prefix(context, operator_str, expr, shape)
-}
-
-pub trait ToExpr {
-    fn to_expr(&self) -> Option<&ast::Expr>;
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool;
-}
-
-impl ToExpr for ast::Expr {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        Some(self)
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        can_be_overflowed_expr(context, self, len)
-    }
-}
-
-impl ToExpr for ast::Ty {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        None
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        can_be_overflowed_type(context, self, len)
-    }
-}
-
-impl<'a> ToExpr for TuplePatField<'a> {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        None
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        can_be_overflowed_pat(context, self, len)
-    }
-}
-
-impl<'a> ToExpr for ast::StructField {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        None
-    }
-
-    fn can_be_overflowed(&self, _: &RewriteContext, _: usize) -> bool {
-        false
-    }
-}
-
-impl<'a> ToExpr for MacroArg {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        match *self {
-            MacroArg::Expr(ref expr) => Some(expr),
-            _ => None,
-        }
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        match *self {
-            MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
-            MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
-            MacroArg::Pat(..) => false,
-            MacroArg::Item(..) => len == 1,
-        }
-    }
-}
-
-impl ToExpr for ast::GenericParam {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        None
-    }
-
-    fn can_be_overflowed(&self, _: &RewriteContext, _: usize) -> bool {
-        false
-    }
-}
-
-impl<T: ToExpr> ToExpr for ptr::P<T> {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        (**self).to_expr()
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        (**self).can_be_overflowed(context, len)
-    }
 }
 
 pub fn is_method_call(expr: &ast::Expr) -> bool {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1337,7 +1337,7 @@ pub fn rewrite_call(
     )
 }
 
-fn is_simple_expr(expr: &ast::Expr) -> bool {
+pub fn is_simple_expr(expr: &ast::Expr) -> bool {
     match expr.node {
         ast::ExprKind::Lit(..) => true,
         ast::ExprKind::Path(ref qself, ref path) => qself.is_none() && path.segments.len() <= 1,
@@ -1356,9 +1356,7 @@ fn is_simple_expr(expr: &ast::Expr) -> bool {
 }
 
 pub fn is_every_expr_simple(lists: &[OverflowableItem]) -> bool {
-    lists
-        .iter()
-        .all(|arg| arg.to_expr().map_or(false, is_simple_expr))
+    lists.iter().all(OverflowableItem::is_simple)
 }
 
 pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_len: usize) -> bool {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1259,54 +1259,6 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     )
 }
 
-/// In case special-case style is required, returns an offset from which we start horizontal layout.
-pub fn maybe_get_args_offset(callee_str: &str, args: &[OverflowableItem]) -> Option<(bool, usize)> {
-    if let Some(&(_, num_args_before)) = SPECIAL_MACRO_WHITELIST
-        .iter()
-        .find(|&&(s, _)| s == callee_str)
-    {
-        let all_simple = args.len() > num_args_before && is_every_expr_simple(args);
-
-        Some((all_simple, num_args_before))
-    } else {
-        None
-    }
-}
-
-/// A list of `format!`-like macros, that take a long format string and a list of arguments to
-/// format.
-///
-/// Organized as a list of `(&str, usize)` tuples, giving the name of the macro and the number of
-/// arguments before the format string (none for `format!("format", ...)`, one for `assert!(result,
-/// "format", ...)`, two for `assert_eq!(left, right, "format", ...)`).
-const SPECIAL_MACRO_WHITELIST: &[(&str, usize)] = &[
-    // format! like macros
-    // From the Rust Standard Library.
-    ("eprint!", 0),
-    ("eprintln!", 0),
-    ("format!", 0),
-    ("format_args!", 0),
-    ("print!", 0),
-    ("println!", 0),
-    ("panic!", 0),
-    ("unreachable!", 0),
-    // From the `log` crate.
-    ("debug!", 0),
-    ("error!", 0),
-    ("info!", 0),
-    ("warn!", 0),
-    // write! like macros
-    ("assert!", 1),
-    ("debug_assert!", 1),
-    ("write!", 1),
-    ("writeln!", 1),
-    // assert_eq! like macros
-    ("assert_eq!", 2),
-    ("assert_ne!", 2),
-    ("debug_assert_eq!", 2),
-    ("debug_assert_ne!", 2),
-];
-
 fn choose_separator_tactic(context: &RewriteContext, span: Span) -> Option<SeparatorTactic> {
     if context.inside_macro() {
         if span_ends_with_comma(context, span) {

--- a/src/items.rs
+++ b/src/items.rs
@@ -1391,11 +1391,10 @@ fn format_tuple_struct(
         format_empty_struct_or_tuple(context, inner_span, offset, &mut result, "(", ")");
     } else {
         let shape = Shape::indented(offset, context.config).sub_width(1)?;
-        let fields = &fields.iter().collect::<Vec<_>>();
         result = overflow::rewrite_with_parens(
             context,
             &result,
-            fields,
+            fields.iter(),
             shape,
             span,
             context.config.width_heuristics().fn_call_width,
@@ -2495,7 +2494,7 @@ fn rewrite_generics(
         return Some(ident.to_owned());
     }
 
-    let params = &generics.params.iter().map(|e| &*e).collect::<Vec<_>>();
+    let params = generics.params.iter();
     overflow::rewrite_with_angle_brackets(context, ident, params, shape, generics.span)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,7 @@ pub enum ErrorKind {
     #[fail(
         display = "line formatted, but exceeded maximum width \
                    (maximum: {} (see `max_width` option), found: {})",
-        _0,
-        _1
+        _0, _1
     )]
     LineOverflow(usize, usize),
     /// Line ends in whitespace.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -278,7 +278,7 @@ pub fn rewrite_macro_inner(
             overflow::rewrite_with_parens(
                 context,
                 &macro_name,
-                &arg_vec.iter().map(|e| &*e).collect::<Vec<_>>(),
+                arg_vec.iter(),
                 shape,
                 mac.span,
                 context.config.width_heuristics().fn_call_width,
@@ -334,11 +334,9 @@ pub fn rewrite_macro_inner(
                         force_trailing_comma = Some(SeparatorTactic::Vertical);
                     };
                 }
-                // Convert `MacroArg` into `ast::Expr`, as `rewrite_array` only accepts the latter.
-                let arg_vec = &arg_vec.iter().map(|e| &*e).collect::<Vec<_>>();
                 let rewrite = rewrite_array(
                     macro_name,
-                    arg_vec,
+                    arg_vec.iter(),
                     mac.span,
                     context,
                     shape,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -359,12 +359,11 @@ fn rewrite_tuple_pat(
     // add comma if `(x,)`
     let add_comma = path_str.is_none() && pat_vec.len() == 1 && dotdot_pos.is_none() && !condensed;
     let path_str = path_str.unwrap_or_default();
-    let pat_ref_vec = pat_vec.iter().collect::<Vec<_>>();
 
     overflow::rewrite_with_parens(
         &context,
         &path_str,
-        &pat_ref_vec,
+        pat_vec.iter(),
         shape,
         span,
         context.config.max_width(),

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -264,6 +264,7 @@ impl Rewrite for FieldPat {
     }
 }
 
+#[derive(Debug)]
 pub enum TuplePatField<'a> {
     Pat(&'a ptr::P<ast::Pat>),
     Dotdot(Span),

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -11,6 +11,7 @@
 // A generic trait to abstract the rewriting of an element (of the AST).
 
 use syntax::parse::ParseSess;
+use syntax::ptr;
 use syntax::source_map::{SourceMap, Span};
 
 use config::{Config, IndentStyle};
@@ -23,6 +24,12 @@ use std::cell::RefCell;
 pub trait Rewrite {
     /// Rewrite self into shape.
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String>;
+}
+
+impl<T: Rewrite> Rewrite for ptr::P<T> {
+    fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
+        (**self).rewrite(context, shape)
+    }
 }
 
 #[derive(Clone)]

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syntax::{ast, ptr, source_map::Span};
+use syntax::{
+    ast, ptr,
+    source_map::{self, Span},
+};
 
 use macros::MacroArg;
 use utils::{mk_sp, outer_attributes};
@@ -23,6 +26,12 @@ pub trait Spanned {
 impl<T: Spanned> Spanned for ptr::P<T> {
     fn span(&self) -> Span {
         (**self).span()
+    }
+}
+
+impl<T> Spanned for source_map::Spanned<T> {
+    fn span(&self) -> Span {
+        self.span
     }
 }
 

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syntax::ast;
-use syntax::source_map::Span;
+use syntax::{ast, ptr, source_map::Span};
 
 use macros::MacroArg;
 use utils::{mk_sp, outer_attributes};
@@ -19,6 +18,12 @@ use std::cmp::max;
 /// Spanned returns a span including attributes, if available.
 pub trait Spanned {
     fn span(&self) -> Span;
+}
+
+impl<T: Spanned> Spanned for ptr::P<T> {
+    fn span(&self) -> Span {
+        (**self).span()
+    }
 }
 
 macro_rules! span_with_attrs_lo_hi {

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ use syntax::source_map::{self, BytePos, Span};
 use syntax::symbol::keywords;
 
 use config::{IndentStyle, TypeDensity};
-use expr::{rewrite_assign_rhs, rewrite_tuple, rewrite_unary_prefix, ToExpr};
+use expr::{rewrite_assign_rhs, rewrite_tuple, rewrite_unary_prefix};
 use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
 use macros::{rewrite_macro, MacroPosition};
 use overflow;
@@ -141,7 +141,7 @@ where
 }
 
 #[derive(Debug)]
-enum SegmentParam<'a> {
+pub enum SegmentParam<'a> {
     LifeTime(&'a ast::Lifetime),
     Type(&'a ast::Ty),
     Binding(&'a ast::TypeBinding),
@@ -162,19 +162,6 @@ impl<'a> Spanned for SegmentParam<'a> {
             SegmentParam::LifeTime(lt) => lt.ident.span,
             SegmentParam::Type(ty) => ty.span,
             SegmentParam::Binding(binding) => binding.span,
-        }
-    }
-}
-
-impl<'a> ToExpr for SegmentParam<'a> {
-    fn to_expr(&self) -> Option<&ast::Expr> {
-        None
-    }
-
-    fn can_be_overflowed(&self, context: &RewriteContext, len: usize) -> bool {
-        match *self {
-            SegmentParam::Type(ty) => ty.can_be_overflowed(context, len),
-            _ => false,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -252,7 +252,7 @@ fn rewrite_segment(
                 let generics_str = overflow::rewrite_with_angle_brackets(
                     context,
                     "",
-                    &param_list.iter().map(|e| &*e).collect::<Vec<_>>(),
+                    param_list.iter(),
                     shape,
                     mk_sp(*span_lo, span_hi),
                 )?;
@@ -664,12 +664,9 @@ impl Rewrite for ast::Ty {
                 ty.rewrite(context, Shape::legacy(budget, shape.indent + 1))
                     .map(|ty_str| format!("[{}]", ty_str))
             }
-            ast::TyKind::Tup(ref items) => rewrite_tuple(
-                context,
-                &::utils::ptr_vec_to_ref_vec(items),
-                self.span,
-                shape,
-            ),
+            ast::TyKind::Tup(ref items) => {
+                rewrite_tuple(context, items.iter(), self.span, shape, items.len() == 1)
+            }
             ast::TyKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Type, q_self.as_ref(), path, shape)
             }

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -256,9 +256,7 @@ pub enum QlError {
     // (kind, input, expected)
     #[fail(
         display = "Could not find {}: Found: {}, expected: {:?}",
-        0,
-        1,
-        2
+        0, 1, 2
     )]
     ResolveError(&'static str, String, Option<String>),
 }


### PR DESCRIPTION
This PR adds `println!` like heuristic to the `fail` attribute from the failure crate. See https://github.com/rust-lang-nursery/rustfmt/commit/6e901c8f37235913a6361a97c84689f8768bf8b7 for a concrete example.

The first 4 commits are refactoring in order to achieve this. Essentially those remove `ToExpr` trait (which should have been a temporal fix...) and replacegg it with `OverflowableItem` enum.

cc https://github.com/rust-lang-nursery/rustfmt/issues/2929.