### PR TITLE
Get rid of extra commas in Visual struct literal formatting

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -236,7 +236,7 @@ fn main() {
 ```rust
 fn main() {
     let lorem = Lorem { ipsum: dolor,
-                        sit: amet, };
+                        sit: amet };
 }
 ```
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1630,7 +1630,7 @@ fn rewrite_struct_lit<'a>(
             nested_shape,
             tactic,
             context,
-            force_no_trailing_comma || base.is_some(),
+            force_no_trailing_comma || base.is_some() || !context.use_block_indent(),
         );
 
         write_list(&item_vec, &fmt)?

--- a/tests/source/issue-3066.rs
+++ b/tests/source/issue-3066.rs
@@ -1,0 +1,7 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    Struct { field: aaaaaaaaaaa };
+    Struct { field: aaaaaaaaaaaa, };
+    Struct { field: value,
+             field2: value2, };
+}

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -55,11 +55,11 @@ fn main() {
 
 fn floaters() {
     let z = Foo { field1: val1,
-                  field2: val2, };
+                  field2: val2 };
 
     let x = Foo { field1: val1,
-                  field2: val2, }.method_call()
-                                 .method_call();
+                  field2: val2 }.method_call()
+                                .method_call();
 
     let y = if cond { val1 } else { val2 }.method_call();
 
@@ -89,11 +89,11 @@ fn floaters() {
                   .quux();
 
     Foo { y: i_am_multi_line,
-          z: ok, }.baz(|| {
-                           force();
-                           multiline();
-                       })
-                  .quux();
+          z: ok }.baz(|| {
+                          force();
+                          multiline();
+                      })
+                 .quux();
 
     a + match x {
             true => "yay!",

--- a/tests/target/configs/indent_style/visual_struct_lit.rs
+++ b/tests/target/configs/indent_style/visual_struct_lit.rs
@@ -3,5 +3,5 @@
 
 fn main() {
     let lorem = Lorem { ipsum: dolor,
-                        sit: amet, };
+                        sit: amet };
 }

--- a/tests/target/issue-3066.rs
+++ b/tests/target/issue-3066.rs
@@ -1,0 +1,7 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    Struct { field: aaaaaaaaaaa };
+    Struct { field: aaaaaaaaaaaa };
+    Struct { field: value,
+             field2: value2 };
+}

--- a/tests/target/struct_lits_visual.rs
+++ b/tests/target/struct_lits_visual.rs
@@ -20,17 +20,17 @@ fn main() {
     Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { // Comment
                                                                                         a: foo(), /* Comment */
                                                                                         // Comment
-                                                                                        b: bar(), /* Comment */ };
+                                                                                        b: bar() /* Comment */ };
 
     Foo { a: Bar, b: f() };
 
     Quux { x: if cond {
                bar();
            },
-           y: baz(), };
+           y: baz() };
 
     Baz { x: yxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-          z: zzzzz, /* test */ };
+          z: zzzzz /* test */ };
 
     A { // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
@@ -38,12 +38,12 @@ fn main() {
         first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.
-        second: Item, };
+        second: Item };
 
     Diagram { //                 o        This graph demonstrates how
               //                / \       significant whitespace is
               //               o   o      preserved.
               //              /|\   \
               //             o o o   o
-              graph: G, }
+              graph: G }
 }

--- a/tests/target/struct_lits_visual_multiline.rs
+++ b/tests/target/struct_lits_visual_multiline.rs
@@ -17,20 +17,20 @@ fn main() {
           ..something };
 
     Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { a: foo(),
-                                                                               b: bar(), };
+                                                                               b: bar() };
 
     Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { // Comment
                                                                                         a: foo(), /* Comment */
                                                                                         // Comment
-                                                                                        b: bar(), /* Comment */ };
+                                                                                        b: bar() /* Comment */ };
 
     Foo { a: Bar,
-          b: foo(), };
+          b: foo() };
 
     Quux { x: if cond {
                bar();
            },
-           y: baz(), };
+           y: baz() };
 
     A { // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
@@ -38,12 +38,12 @@ fn main() {
         first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.
-        second: Item, };
+        second: Item };
 
     Diagram { //                 o        This graph demonstrates how
               //                / \       significant whitespace is
               //               o   o      preserved.
               //              /|\   \
               //             o o o   o
-              graph: G, }
+              graph: G }
 }


### PR DESCRIPTION
This fixes #3066, however I'm still unsure if maybe this behavior was expected (I haven't got a response).

I think not inserting the final commas is better since in the Visual style, a closing brace immediately follows the expression. There's a similar situation in function arguments where the final commas aren't inserted either.

Besides, the current behavior of the one line case of inserting the final comma if the expression is longer than a certain number of characters (see lines 3 and 4 in the source test case) seems definitely wrong.