### PR TITLE
Fix inconsistent overflow behavior in Visual style

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -236,7 +236,7 @@ fn main() {
 ```rust
 fn main() {
     let lorem = Lorem { ipsum: dolor,
-                        sit: amet, };
+                        sit: amet };
 }
 ```
 

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -576,7 +576,15 @@ impl<'a> ChainFormatterShared<'a> {
         if all_in_one_line || extendable {
             // First we try to 'overflow' the last child and see if it looks better than using
             // vertical layout.
-            if let Some(one_line_shape) = last_shape.offset_left(almost_total) {
+            let one_line_shape = if context.use_block_indent() {
+                last_shape.offset_left(almost_total)
+            } else {
+                last_shape
+                    .visual_indent(almost_total)
+                    .sub_width(almost_total)
+            };
+
+            if let Some(one_line_shape) = one_line_shape {
                 if let Some(rw) = last.rewrite(context, one_line_shape) {
                     // We allow overflowing here only if both of the following conditions match:
                     // 1. The entire chain fits in a single line except the last child.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1376,8 +1376,7 @@ pub fn can_be_overflowed_expr(context: &RewriteContext, expr: &ast::Expr, args_l
             context.config.combine_control_expr() && context.use_block_indent() && args_len == 1
         }
         ast::ExprKind::Block(..) | ast::ExprKind::Closure(..) => {
-            context.use_block_indent()
-                || context.config.indent_style() == IndentStyle::Visual && args_len > 1
+            context.use_block_indent() || context.config.indent_style() == IndentStyle::Visual
         }
         ast::ExprKind::Array(..)
         | ast::ExprKind::Call(..)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1630,7 +1630,7 @@ fn rewrite_struct_lit<'a>(
             nested_shape,
             tactic,
             context,
-            force_no_trailing_comma || base.is_some(),
+            force_no_trailing_comma || base.is_some() || !context.use_block_indent(),
         );
 
         write_list(&item_vec, &fmt)?

--- a/tests/source/issue-3049.rs
+++ b/tests/source/issue-3049.rs
@@ -1,0 +1,45 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(|| {
+                                 let x = hello();
+                             });
+
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(arg, || {
+                 let x = hello();
+             });
+
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(arg,
+                             || {
+                                 let x = hello();
+                             },
+                             arg);
+
+    AAAAAAAAAAA.function(|| {
+                   let _ = ();
+               });
+
+    AAAAAAAAAAA.chain().function(|| {
+        let _ = ();
+    })
+}

--- a/tests/source/issue-3066.rs
+++ b/tests/source/issue-3066.rs
@@ -1,0 +1,7 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    Struct { field: aaaaaaaaaaa };
+    Struct { field: aaaaaaaaaaaa, };
+    Struct { field: value,
+             field2: value2, };
+}

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -37,8 +37,8 @@ fn main() {
 
     fffffffffffffffffffffffffffffffffff(a, {
         SCRIPT_TASK_ROOT.with(|root| {
-                                  *root.borrow_mut() = Some(&script_task);
-                              });
+                            *root.borrow_mut() = Some(&script_task);
+                        });
     });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum =
@@ -47,9 +47,9 @@ fn main() {
                .fold(0, |acc, x| acc + x);
 
     aaaaaaaaaaaaaaaa.map(|x| {
-                             x += 1;
-                             x
-                         })
+                        x += 1;
+                        x
+                    })
                     .filter(some_mod::some_filter)
 }
 
@@ -83,16 +83,16 @@ fn floaters() {
      .baz();
 
     Foo { x: val }.baz(|| {
-                           force();
-                           multiline();
-                       })
+                      force();
+                      multiline();
+                  })
                   .quux();
 
     Foo { y: i_am_multi_line,
           z: ok }.baz(|| {
-                          force();
-                          multiline();
-                      })
+                     force();
+                     multiline();
+                 })
                  .quux();
 
     a + match x {
@@ -137,9 +137,9 @@ fn issue1434() {
     for _ in 0..100 {
         let prototype_id =
             PrototypeIdData::from_reader::<_, B>(&mut self.file_cursor).chain_err(|| {
-                           format!("could not read prototype ID at offset {:#010x}",
-                                   current_offset)
-                       })?;
+                format!("could not read prototype ID at offset {:#010x}",
+                        current_offset)
+            })?;
     }
 }
 
@@ -147,12 +147,12 @@ fn issue2264() {
     {
         something.function()
                  .map(|| {
-                          if let a_very_very_very_very_very_very_very_very_long_variable =
-                              compute_this_variable()
-                          {
-                              println!("Hello");
-                          }
-                      })
+                     if let a_very_very_very_very_very_very_very_very_long_variable =
+                         compute_this_variable()
+                     {
+                         println!("Hello");
+                     }
+                 })
                  .collect();
     }
 }

--- a/tests/target/chains-visual.rs
+++ b/tests/target/chains-visual.rs
@@ -55,11 +55,11 @@ fn main() {
 
 fn floaters() {
     let z = Foo { field1: val1,
-                  field2: val2, };
+                  field2: val2 };
 
     let x = Foo { field1: val1,
-                  field2: val2, }.method_call()
-                                 .method_call();
+                  field2: val2 }.method_call()
+                                .method_call();
 
     let y = if cond { val1 } else { val2 }.method_call();
 
@@ -89,11 +89,11 @@ fn floaters() {
                   .quux();
 
     Foo { y: i_am_multi_line,
-          z: ok, }.baz(|| {
-                           force();
-                           multiline();
-                       })
-                  .quux();
+          z: ok }.baz(|| {
+                          force();
+                          multiline();
+                      })
+                 .quux();
 
     a + match x {
             true => "yay!",

--- a/tests/target/configs/indent_style/visual_struct_lit.rs
+++ b/tests/target/configs/indent_style/visual_struct_lit.rs
@@ -3,5 +3,5 @@
 
 fn main() {
     let lorem = Lorem { ipsum: dolor,
-                        sit: amet, };
+                        sit: amet };
 }

--- a/tests/target/issue-2985.rs
+++ b/tests/target/issue-2985.rs
@@ -4,30 +4,30 @@ fn foo() {
         {
             let extra_encoder_settings = extra_encoder_settings.iter()
                                                                .filter_map(|&(name, value)| {
-                                                                               value.split()
-                                                                                    .next()
-                                                                                    .something()
-                                                                                    .something2()
-                                                                                    .something3()
-                                                                                    .something4()
-                                                                           });
+                                                                   value.split()
+                                                                        .next()
+                                                                        .something()
+                                                                        .something2()
+                                                                        .something3()
+                                                                        .something4()
+                                                               });
             let extra_encoder_settings = extra_encoder_settings.iter()
                                                                .filter_map(|&(name, value)| {
-                                                                               value.split()
-                                                                                    .next()
-                                                                                    .something()
-                                                                                    .something2()
-                                                                                    .something3()
-                                                                                    .something4()
-                                                                           })
+                                                                   value.split()
+                                                                        .next()
+                                                                        .something()
+                                                                        .something2()
+                                                                        .something3()
+                                                                        .something4()
+                                                               })
                                                                .something();
             if let Some(subpod) = pod.subpods.iter().find(|s| {
-                                                              !s.plaintext
-                                                                .as_ref()
-                                                                .map(String::as_ref)
-                                                                .unwrap_or("")
-                                                                .is_empty()
-                                                          }) {
+                                                        !s.plaintext
+                                                          .as_ref()
+                                                          .map(String::as_ref)
+                                                          .unwrap_or("")
+                                                          .is_empty()
+                                                    }) {
                 do_something();
             }
         }

--- a/tests/target/issue-3049.rs
+++ b/tests/target/issue-3049.rs
@@ -1,0 +1,45 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(|| {
+                 let x = hello();
+             });
+
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(arg, || {
+                 let x = hello();
+             });
+
+    something.aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .aaaaaaaaaaaa()
+             .bench_function(arg,
+                             || {
+                                 let x = hello();
+                             },
+                             arg);
+
+    AAAAAAAAAAA.function(|| {
+                   let _ = ();
+               });
+
+    AAAAAAAAAAA.chain().function(|| {
+                           let _ = ();
+                       })
+}

--- a/tests/target/issue-3066.rs
+++ b/tests/target/issue-3066.rs
@@ -1,0 +1,7 @@
+// rustfmt-indent_style: Visual
+fn main() {
+    Struct { field: aaaaaaaaaaa };
+    Struct { field: aaaaaaaaaaaa };
+    Struct { field: value,
+             field2: value2 };
+}

--- a/tests/target/struct_lits_visual.rs
+++ b/tests/target/struct_lits_visual.rs
@@ -20,17 +20,17 @@ fn main() {
     Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { // Comment
                                                                                         a: foo(), /* Comment */
                                                                                         // Comment
-                                                                                        b: bar(), /* Comment */ };
+                                                                                        b: bar() /* Comment */ };
 
     Foo { a: Bar, b: f() };
 
     Quux { x: if cond {
                bar();
            },
-           y: baz(), };
+           y: baz() };
 
     Baz { x: yxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-          z: zzzzz, /* test */ };
+          z: zzzzz /* test */ };
 
     A { // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
@@ -38,12 +38,12 @@ fn main() {
         first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.
-        second: Item, };
+        second: Item };
 
     Diagram { //                 o        This graph demonstrates how
               //                / \       significant whitespace is
               //               o   o      preserved.
               //              /|\   \
               //             o o o   o
-              graph: G, }
+              graph: G }
 }

--- a/tests/target/struct_lits_visual_multiline.rs
+++ b/tests/target/struct_lits_visual_multiline.rs
@@ -17,20 +17,20 @@ fn main() {
           ..something };
 
     Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { a: foo(),
-                                                                               b: bar(), };
+                                                                               b: bar() };
 
     Foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo { // Comment
                                                                                         a: foo(), /* Comment */
                                                                                         // Comment
-                                                                                        b: bar(), /* Comment */ };
+                                                                                        b: bar() /* Comment */ };
 
     Foo { a: Bar,
-          b: foo(), };
+          b: foo() };
 
     Quux { x: if cond {
                bar();
            },
-           y: baz(), };
+           y: baz() };
 
     A { // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
@@ -38,12 +38,12 @@ fn main() {
         first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.
-        second: Item, };
+        second: Item };
 
     Diagram { //                 o        This graph demonstrates how
               //                / \       significant whitespace is
               //               o   o      preserved.
               //              /|\   \
               //             o o o   o
-              graph: G, }
+              graph: G }
 }


### PR DESCRIPTION
Fixes #3049. I based this on #3077 because they change the same test file (first two commits here are from #3077), I can rebase to master instead if necessary.

I picked this approach, as opposed to disabling overflow in the second case, because it looks as well if not better, and gives more of the frequently much needed in Visual style space. Compare:
```rust
impl Something {
    fn something(&self) {
        if (condition) {
            // The approach I picked.
            let variable = something_really_long.some_function_name(|x| {
                                                    if let Some(_) = x {
                                                        println!("A good amount of space here");
                                                    }
                                                });
            // The other approach.
            let variable = something_really_long.some_function_name(|x| {
                                                                        if let Some(_) = x {
                                                                            println!("Help me");
                                                                        }
                                                                    });
        }
    }
}
```
This approach also makes iterator/future chains like these look more consistent due to the same closure indentation:
```rust
    Ok(client.request(request)
             .map_err(RunsError::RequestError)
             .and_then(|response| {
                 // Check the status code.
                 if response.status() != StatusCode::OK {
                     future::err(RunsError::BadStatusCode(response.status()))
                 } else {
                     future::ok(response)
                 }
             })
             .and_then(|response| {
                 // Receive the entire response and concat it together.
                 response.into_body()
                         .concat2()
                         .map_err(RunsError::ResponseError)
             })
             .and_then(|bytes| {
                 // Parse the response JSON into Runs.
                 serde_json::from_slice::<Runs>(&bytes).map_err(RunsError::JsonParseError)
             })
             .map(|runs| runs.data.into_iter()))
```