### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,17 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "isatty"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itertools"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,13 +592,13 @@ name = "rustfmt-nightly"
 version = "0.99.5"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -876,7 +865,6 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,15 +447,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_cratesio_shim"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -473,8 +473,8 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,33 +484,33 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -518,29 +518,29 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "268.0.0"
+version = "270.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -603,9 +603,9 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -890,14 +890,14 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum rustc-ap-arena 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7d21ba9c286da499364b02af9ec1c835b9c42d92b18c865d0262b99df977374"
-"checksum rustc-ap-rustc_cratesio_shim 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0544e164c111a0bfa1923b8c91737366a300b027d81c9114bb89137808f55c9"
-"checksum rustc-ap-rustc_data_structures 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce60ef21aba8993eb1a91121b4fe9222c5440e0ed0b2dcf6d8e7aa484cee3218"
-"checksum rustc-ap-rustc_errors 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ada01ba44536e77dd7e3f56850d7a26a989e83b68288ace94f0b5a26df72b4e"
-"checksum rustc-ap-rustc_target 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba1aa26f0a3f0c5f19725e6f78b3016b074ff9111dc0b799e0b31e08baa80a27"
-"checksum rustc-ap-serialize 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b38be5ee860d8636f8ad366eb3849fc209720049ba546af687a088ad0da596"
-"checksum rustc-ap-syntax 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d2d7fcb6e38072a6c0d53fe5eecf532f16c3594d4de77169158e42e4654c5f"
-"checksum rustc-ap-syntax_pos 268.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfcf5ec3b80a0fd17f44e880396f7d649a4d8fe5a688e894ad8a70d045c6ce9e"
+"checksum rustc-ap-arena 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7d05a20e1cd007addab4523d31d495c48dd5bc2b6215ea3fe89be567b10b12"
+"checksum rustc-ap-rustc_cratesio_shim 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad1abbb7417f8c8d63ff70a16b7e98e78b88e999d43bda4a5907e4df32e6e362"
+"checksum rustc-ap-rustc_data_structures 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "faf8894496f3abfb4424840d0429d2160918a5a32399e400f932451fccc8541a"
+"checksum rustc-ap-rustc_errors 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31d983d95a7f35615870b88b5c181f7c16602e7c2acaa4602b3f8f42675b5d91"
+"checksum rustc-ap-rustc_target 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c36d40d4b8635563b260b60fb0fab775a873491f72759bf85d2318b3c61c64"
+"checksum rustc-ap-serialize 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a43318eebe504e4b94bfd6a6e977ee0dc2d423a6cd7a1334df51bae3b87ddf91"
+"checksum rustc-ap-syntax 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52eef03e0355016967de52c28d1c909f3d9b8e5323f42a3c678a7709d035b332"
+"checksum rustc-ap-syntax_pos 270.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d627aaff85bbed2e349601c236320a1a2479bc88c74362ceb53411d161361cbf"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6d5a683c6ba4ed37959097e88d71c9e8e26659a3cb5be8b389078e7ad45306"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo-fmt = []
 rustfmt-format-diff = []
 
 [dependencies]
-isatty = "0.1"
+atty = "0.2"
 itertools = "0.7"
 toml = "0.4"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ env_logger = "0.5"
 getopts = "0.2"
 derive-new = "0.5"
 cargo_metadata = "0.6"
-rustc-ap-rustc_target = "268.0.0"
-rustc-ap-syntax = "268.0.0"
-rustc-ap-syntax_pos = "268.0.0"
+rustc-ap-rustc_target = "270.0.0"
+rustc-ap-syntax = "270.0.0"
+rustc-ap-syntax_pos = "270.0.0"
 failure = "0.1.1"
 
 [dev-dependencies]

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -12,7 +12,7 @@ use config::config_type::ConfigType;
 use config::lists::*;
 use config::{Config, FileName};
 
-use isatty::stdout_isatty;
+use atty;
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -297,7 +297,7 @@ impl Color {
         match self {
             Color::Always => true,
             Color::Never => false,
-            Color::Auto => stdout_isatty(),
+            Color::Auto => atty::is(atty::Stream::Stdout),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@
 
 #[macro_use]
 extern crate derive_new;
+extern crate atty;
 extern crate diff;
 extern crate failure;
-extern crate isatty;
 extern crate itertools;
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Two bumps for the crates in use. The main update is `atty` which replaces the `isatty` deprecated one.