### PR TITLE
fixed display message for the LineOverflow error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub enum ErrorKind {
     #[fail(
         display = "line formatted, but exceeded maximum width \
                    (maximum: {} (see `max_width` option), found: {})",
-        _0, _1
+        _1, _0
     )]
     LineOverflow(usize, usize),
     /// Line ends in whitespace.


### PR DESCRIPTION
In the `LineOverflow` error message, the `found` and `max` values were switched. In the diff below, the max is 100 and 140 is what got found:

```diff
 fn foo() {
-    let file_name =
-        format!("{}", self.testpaths.file.display())
-        .replace(r"\", "/"); // on windows, translate all '\' path separators to '/'
+    let file_name = format!("{}", self.testpaths.file.display()).replace(r"\", "/"); // on windows, translate all '\' path separators to '/'
 }

internal error: line formatted, but exceeded maximum width (maximum: 140 (see `max_width` option), found: 100)
```