### PR TITLE
Only combine `match` if its condition expression fits in a single line

### DIFF
--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -18,6 +18,7 @@ use syntax::{ast, ptr};
 use closures;
 use expr::{
     can_be_overflowed_expr, is_every_expr_simple, is_method_call, is_nested_call, is_simple_expr,
+    rewrite_cond,
 };
 use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator};
 use macros::MacroArg;
@@ -401,6 +402,16 @@ impl<'a> Context<'a> {
                             None
                         } else {
                             closures::rewrite_last_closure(self.context, expr, shape)
+                        }
+                    }
+                    ast::ExprKind::Match(..) => {
+                        let multi_line = rewrite_cond(self.context, expr, shape)
+                            .map_or(false, |cond| cond.contains('\n'));
+
+                        if multi_line {
+                            None
+                        } else {
+                            expr.rewrite(self.context, shape)
                         }
                     }
                     _ => expr.rewrite(self.context, shape),

--- a/tests/source/issue-3029.rs
+++ b/tests/source/issue-3029.rs
@@ -1,0 +1,21 @@
+fn foo() {
+    EvaluateJSReply::NumberValue(
+        match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+            Ok(ConversionResult::Success(v)) => v,
+            _ => unreachable!(),
+        },
+    )
+}
+
+fn bar() {
+    {
+        {
+            EvaluateJSReply::NumberValue(
+                match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                    Ok(ConversionResult::Success(v)) => v,
+                    _ => unreachable!(),
+                },
+            )
+        }
+    }
+}

--- a/tests/target/issue-3029.rs
+++ b/tests/target/issue-3029.rs
@@ -1,0 +1,21 @@
+fn foo() {
+    EvaluateJSReply::NumberValue(
+        match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+            Ok(ConversionResult::Success(v)) => v,
+            _ => unreachable!(),
+        },
+    )
+}
+
+fn bar() {
+    {
+        {
+            EvaluateJSReply::NumberValue(
+                match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                    Ok(ConversionResult::Success(v)) => v,
+                    _ => unreachable!(),
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
This improves the formatting and reading of code avoiding the
condition expression to be rewrite, if it goes multi line.

Fixes: #3029.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>