### PR TITLE
do not vertically align list items in case the tactic is Horizontal

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -752,9 +752,16 @@ fn trim_custom_comment_prefix(s: &str) -> String {
         .map(|line| {
             let left_trimmed = line.trim_left();
             if left_trimmed.starts_with(RUSTFMT_CUSTOM_COMMENT_PREFIX) {
-                left_trimmed.trim_left_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX)
+                let orig = left_trimmed.trim_left_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX);
+                // due to comment wrapping, a line that was originaly behind `#` is split over
+                // multiple lines, which needs then to be prefixed with a `#`
+                if !orig.trim_left().starts_with("# ") {
+                    format!("# {}", orig)
+                } else {
+                    orig.to_string()
+                }
             } else {
-                line
+                line.to_string()
             }
         })
         .collect::<Vec<_>>()

--- a/tests/source/wrapped_hidden_code_block.rs
+++ b/tests/source/wrapped_hidden_code_block.rs
@@ -1,0 +1,10 @@
+// rustfmt-max_width: 79
+// rustfmt-wrap_comments: true
+
+/// ```rust
+/// # #![cfg_attr(not(dox), feature(cfg_target_feature, target_feature, stdsimd)not(dox), feature(cfg_target_feature, target_feature, stdsimd))]
+///
+/// // Est lectus hendrerit lorem, eget dignissim orci nisl sit amet massa. Etiam volutpat lobortis eros.
+/// let x = 42;
+/// ```
+fn func() {}

--- a/tests/target/issue-2633.rs
+++ b/tests/target/issue-2633.rs
@@ -1,0 +1,13 @@
+// rustfmt-struct_field_align_threshold: 5
+
+#[derive(Fail, Debug, Clone)]
+pub enum BuildError {
+    LineTooLong { length: usize, limit: usize },
+    DisallowedByte { b: u8, pos: usize },
+    ContainsNewLine { pos: usize },
+}
+
+enum Foo {
+    A { a: usize, bbbbb: () },
+    B { a: (), bbbbb: () },
+}

--- a/tests/target/wrapped_hidden_code_block.rs
+++ b/tests/target/wrapped_hidden_code_block.rs
@@ -1,0 +1,13 @@
+// rustfmt-max_width: 79
+// rustfmt-wrap_comments: true
+
+/// ```rust
+/// # #![cfg_attr(not(dox), feature(cfg_target_feature, target_feature,
+/// # stdsimd)not(dox), feature(cfg_target_feature, target_feature,
+/// # stdsimd))]
+///
+/// // Est lectus hendrerit lorem, eget dignissim orci nisl sit amet massa.
+/// // Etiam volutpat lobortis eros.
+/// let x = 42;
+/// ```
+fn func() {}


### PR DESCRIPTION
part of #2633 

This does not close the issue because the use case described in https://github.com/rust-lang-nursery/rustfmt/issues/2633#issuecomment-404679937 is not fixed, but the rest seems fine.