### PR TITLE
Avoid control flow expressions conditions to go multi line

### DIFF
--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -404,7 +404,15 @@ impl<'a> Context<'a> {
                             closures::rewrite_last_closure(self.context, expr, shape)
                         }
                     }
-                    ast::ExprKind::Match(..) => {
+                    // When overflowing the expressions which consists of a control flow
+                    // expression, avoid condition to use multi line.
+                    ast::ExprKind::If(..)
+                    | ast::ExprKind::IfLet(..)
+                    | ast::ExprKind::ForLoop(..)
+                    | ast::ExprKind::Loop(..)
+                    | ast::ExprKind::While(..)
+                    | ast::ExprKind::WhileLet(..)
+                    | ast::ExprKind::Match(..) => {
                         let multi_line = rewrite_cond(self.context, expr, shape)
                             .map_or(false, |cond| cond.contains('\n'));
 

--- a/tests/source/issue-3029.rs
+++ b/tests/source/issue-3029.rs
@@ -1,13 +1,86 @@
-fn foo() {
-    EvaluateJSReply::NumberValue(
-        match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
-            Ok(ConversionResult::Success(v)) => v,
-            _ => unreachable!(),
-        },
-    )
+fn keep_if() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    if FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
 }
 
-fn bar() {
+fn keep_if_let() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    if let Some(e) = FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_for() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    for conv in FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_loop() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(loop {
+                    FromJSValConvertible::from_jsval(cx, rval.handle(), ());
+                })
+            }
+        }
+    }
+}
+
+fn keep_while() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    while FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_while_let() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    while let Some(e) = FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_match() {
     {
         {
             EvaluateJSReply::NumberValue(

--- a/tests/target/issue-3029.rs
+++ b/tests/target/issue-3029.rs
@@ -1,13 +1,86 @@
-fn foo() {
-    EvaluateJSReply::NumberValue(
-        match FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
-            Ok(ConversionResult::Success(v)) => v,
-            _ => unreachable!(),
-        },
-    )
+fn keep_if() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    if FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
 }
 
-fn bar() {
+fn keep_if_let() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    if let Some(e) = FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_for() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    for conv in FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_loop() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(loop {
+                    FromJSValConvertible::from_jsval(cx, rval.handle(), ());
+                })
+            }
+        }
+    }
+}
+
+fn keep_while() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    while FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_while_let() {
+    {
+        {
+            {
+                EvaluateJSReply::NumberValue(
+                    while let Some(e) = FromJSValConvertible::from_jsval(cx, rval.handle(), ()) {
+                        unimplemented!();
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn keep_match() {
     {
         {
             EvaluateJSReply::NumberValue(


### PR DESCRIPTION
Extends the multi line condition to over other control flow
expressions, it now covers: `if`, `if let`, `for`, `loop`, `while`,
`while let` and `match`.

Refs: #3029

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>