### PR TITLE
utils: rewrite `count_newlines` using `bytecount::count`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytecount"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +598,7 @@ version = "0.99.5"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -842,6 +848,7 @@ dependencies = [
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6809b327f87369e6f3651efd2c5a96c49847a3ed2559477ecba79014751ee1"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rustc-ap-rustc_target = "272.0.0"
 rustc-ap-syntax = "272.0.0"
 rustc-ap-syntax_pos = "272.0.0"
 failure = "0.1.1"
+bytecount = { version = "0.3", features = ["simd-accel"] }
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 #[macro_use]
 extern crate derive_new;
 extern crate atty;
+extern crate bytecount;
 extern crate diff;
 extern crate failure;
 extern crate itertools;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,8 @@
 
 use std::borrow::Cow;
 
+use bytecount;
+
 use rustc_target::spec::abi;
 use syntax::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NestedMetaItemKind, Path,
@@ -305,8 +307,8 @@ pub fn stmt_expr(stmt: &ast::Stmt) -> Option<&ast::Expr> {
 
 #[inline]
 pub fn count_newlines(input: &str) -> usize {
-    // Using `as_bytes` to omit UTF-8 decoding
-    input.as_bytes().iter().filter(|&&c| c == b'\n').count()
+    // Using bytes to omit UTF-8 decoding
+    bytecount::count(input.as_bytes(), b'\n')
 }
 
 // For format_missing and last_pos, need to use the source callsite (if applicable).


### PR DESCRIPTION
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>