### PR TITLE
try to fix comment bad wrapping

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -582,7 +582,7 @@ fn rewrite_comment_inner(
             match rewrite_string(
                 &item_block_buffer.replace("\n", " "),
                 &item_fmt,
-                max_chars - ib.indent,
+                max_chars.saturating_sub(ib.indent),
             ) {
                 Some(s) => result.push_str(&join_block(
                     &s,
@@ -726,7 +726,7 @@ fn rewrite_comment_inner(
         match rewrite_string(
             &item_block_buffer.replace("\n", " "),
             &item_fmt,
-            max_chars - ib.indent,
+            max_chars.saturating_sub(ib.indent),
         ) {
             Some(s) => result.push_str(&join_block(
                 &s,

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -579,7 +579,11 @@ fn rewrite_comment_inner(
             let item_fmt = ib.create_string_format(&fmt);
             result.push_str(&comment_line_separator);
             result.push_str(&ib.opener);
-            match rewrite_string(&item_block_buffer.replace("\n", " "), &item_fmt) {
+            match rewrite_string(
+                &item_block_buffer.replace("\n", " "),
+                &item_fmt,
+                max_chars - ib.indent,
+            ) {
                 Some(s) => result.push_str(&join_block(
                     &s,
                     &format!("{}{}", &comment_line_separator, ib.line_start),
@@ -654,7 +658,7 @@ fn rewrite_comment_inner(
         }
 
         if config.wrap_comments() && line.len() > fmt.shape.width && !has_url(line) {
-            match rewrite_string(line, &fmt) {
+            match rewrite_string(line, &fmt, max_chars) {
                 Some(ref s) => {
                     is_prev_line_multi_line = s.contains('\n');
                     result.push_str(s);
@@ -665,7 +669,7 @@ fn rewrite_comment_inner(
                     result.pop();
                     result.push_str(&comment_line_separator);
                     fmt.shape = Shape::legacy(max_chars, fmt_indent);
-                    match rewrite_string(line, &fmt) {
+                    match rewrite_string(line, &fmt, max_chars) {
                         Some(ref s) => {
                             is_prev_line_multi_line = s.contains('\n');
                             result.push_str(s);
@@ -719,7 +723,11 @@ fn rewrite_comment_inner(
         let item_fmt = ib.create_string_format(&fmt);
         result.push_str(&comment_line_separator);
         result.push_str(&ib.opener);
-        match rewrite_string(&item_block_buffer.replace("\n", " "), &item_fmt) {
+        match rewrite_string(
+            &item_block_buffer.replace("\n", " "),
+            &item_fmt,
+            max_chars - ib.indent,
+        ) {
             Some(s) => result.push_str(&join_block(
                 &s,
                 &format!("{}{}", &comment_line_separator, ib.line_start),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1256,6 +1256,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     rewrite_string(
         str_lit,
         &StringFormat::new(shape.visual_indent(0), context.config),
+        shape.width - 2,
     )
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1256,7 +1256,7 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
     rewrite_string(
         str_lit,
         &StringFormat::new(shape.visual_indent(0), context.config),
-        shape.width - 2,
+        shape.width.saturating_sub(2),
     )
 }
 

--- a/tests/source/issue-3059.rs
+++ b/tests/source/issue-3059.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 80
+
+/// Vestibulum elit nibh, rhoncus non, euismod sit amet, pretium eu, enim. Nunc commodo ultricies dui.
+/// Cras gravida rutrum massa. Donec accumsan mattis turpis. Quisque sem. Quisque elementum sapien
+/// iaculis augue. In dui sem, congue sit amet, feugiat quis, lobortis at, eros.
+fn func4() {}

--- a/tests/target/issue-3059.rs
+++ b/tests/target/issue-3059.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 80
+
+/// Vestibulum elit nibh, rhoncus non, euismod sit amet, pretium eu, enim. Nunc
+/// commodo ultricies dui. Cras gravida rutrum massa. Donec accumsan mattis
+/// turpis. Quisque sem. Quisque elementum sapien iaculis augue. In dui sem,
+/// congue sit amet, feugiat quis, lobortis at, eros.
+fn func4() {}

--- a/tests/target/itemized-blocks/wrap.rs
+++ b/tests/target/itemized-blocks/wrap.rs
@@ -40,8 +40,7 @@
 /// All the parameters ***except for
 /// `from_theater`*** should be inserted as sent
 /// by the remote theater, ie. as passed to
-/// [`Theater::send`] on the remote
-/// actor:
+/// [`Theater::send`] on the remote actor:
 ///  * `from` is the sending (remote) [`ActorId`],
 ///    as reported by the remote theater by
 ///    theater-specific means
@@ -53,15 +52,13 @@
 /// All the parameters ***except for
 /// `from_theater`*** should be inserted as sent
 /// by the remote theater, ie. as passed to
-/// [`Theater::send`] on the remote
-/// actor
+/// [`Theater::send`] on the remote actor
 fn func1() {}
 
 /// All the parameters ***except for
 /// `from_theater`*** should be inserted as sent
 /// by the remote theater, ie. as passed to
-/// [`Theater::send`] on the remote
-/// actor:
+/// [`Theater::send`] on the remote actor:
 ///  * `from` is the sending (remote) [`ActorId`],
 ///    as reported by the remote theater by
 ///    theater-specific means


### PR DESCRIPTION
This an attempt to solve #3059 . I _think_ the problem was that `rewrite_string` was using `shape.max_chars_with_indent` to reset the maximum chars per line, while there could be more possibly. This PR adds a new parameter that is the number of characters per line and use that when `break_string` returns `LineEnd`.

It's my first pr, so I might be completely wrong :)