### PR TITLE
force a newline after the `if` condition if there is a different indentation level

### DIFF
--- a/tests/source/issue-3038.rs
+++ b/tests/source/issue-3038.rs
@@ -1,0 +1,20 @@
+impl HTMLTableElement {
+    fn func() {
+        if number_of_row_elements == 0 {
+            if let Some(last_tbody) = node.rev_children()
+                    .filter_map(DomRoot::downcast::<Element>)
+                    .find(|n| n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody")) {
+                        last_tbody.upcast::<Node>().AppendChild(new_row.upcast::<Node>())
+                                                   .expect("InsertRow failed to append first row.");
+                    }
+        }
+
+        if number_of_row_elements == 0 {
+            if let Some(last_tbody) = node
+                    .find(|n| n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody")) {
+                        last_tbody.upcast::<Node>().AppendChild(new_row.upcast::<Node>())
+                                                   .expect("InsertRow failed to append first row.");
+                    }
+        }
+    }
+}

--- a/tests/target/issue-2985.rs
+++ b/tests/target/issue-2985.rs
@@ -27,7 +27,8 @@ fn foo() {
                                                           .map(String::as_ref)
                                                           .unwrap_or("")
                                                           .is_empty()
-                                                    }) {
+                                                    })
+            {
                 do_something();
             }
         }

--- a/tests/target/issue-3038.rs
+++ b/tests/target/issue-3038.rs
@@ -1,0 +1,29 @@
+impl HTMLTableElement {
+    fn func() {
+        if number_of_row_elements == 0 {
+            if let Some(last_tbody) = node
+                .rev_children()
+                .filter_map(DomRoot::downcast::<Element>)
+                .find(|n| {
+                    n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody")
+                })
+            {
+                last_tbody
+                    .upcast::<Node>()
+                    .AppendChild(new_row.upcast::<Node>())
+                    .expect("InsertRow failed to append first row.");
+            }
+        }
+
+        if number_of_row_elements == 0 {
+            if let Some(last_tbody) = node.find(|n| {
+                n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody")
+            }) {
+                last_tbody
+                    .upcast::<Node>()
+                    .AppendChild(new_row.upcast::<Node>())
+                    .expect("InsertRow failed to append first row.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #3038 