### PR TITLE
fix a couple of clippy lint warnings

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -752,7 +752,7 @@ where
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#[allow(clippy::too_many_arguments)]
 // Creates an iterator over a list's items with associated comments.
 pub fn itemize_list<'a, T, I, F1, F2, F3>(
     snippet_provider: &'a SnippetProvider,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -429,7 +429,7 @@ pub fn rewrite_macro_def(
             Some(v) => Some(v),
             // if the rewrite returned None because a macro could not be rewritten, then return the
             // original body
-            None if *context.macro_rewrite_failure.borrow() == true => {
+            None if *context.macro_rewrite_failure.borrow() => {
                 Some(context.snippet(branch.body).trim().to_string())
             }
             None => None,
@@ -981,7 +981,7 @@ fn format_macro_args(
 ) -> Option<String> {
     if !context.config.format_macro_matchers() {
         let token_stream: TokenStream = toks.into();
-        let span = span_for_token_stream(token_stream);
+        let span = span_for_token_stream(&token_stream);
         return Some(match span {
             Some(span) => context.snippet(span).to_owned(),
             None => String::new(),
@@ -991,7 +991,7 @@ fn format_macro_args(
     wrap_macro_args(context, &parsed_args, shape)
 }
 
-fn span_for_token_stream(token_stream: TokenStream) -> Option<Span> {
+fn span_for_token_stream(token_stream: &TokenStream) -> Option<Span> {
     token_stream.trees().next().map(|tt| tt.span())
 }
 

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -690,7 +690,7 @@ fn need_block_indent(s: &str, shape: Shape) -> bool {
     })
 }
 
-fn can_be_overflowed<'a>(context: &RewriteContext, items: &[OverflowableItem]) -> bool {
+fn can_be_overflowed(context: &RewriteContext, items: &[OverflowableItem]) -> bool {
     items
         .last()
         .map_or(false, |x| x.can_be_overflowed(context, items.len()))

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -54,7 +54,7 @@ pub(crate) fn rewrite_all_pairs(
     // necessarily need one line per sub-expression, but we don't do anything
     // too funny wrt precedence.
     expr.flatten(true)
-        .and_then(|list| rewrite_pairs_multiline(list, shape, context))
+        .and_then(|list| rewrite_pairs_multiline(&list, shape, context))
 }
 
 // This may return a multi-line result since we allow the last expression to go
@@ -105,7 +105,7 @@ fn rewrite_pairs_one_line<T: Rewrite>(
 }
 
 fn rewrite_pairs_multiline<T: Rewrite>(
-    list: PairList<T>,
+    list: &PairList<T>,
     shape: Shape,
     context: &RewriteContext,
 ) -> Option<String> {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -573,7 +573,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         self.buffer.push_str(s);
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+    #[allow(clippy::needless_pass_by_value)]
     fn push_rewrite_inner(&mut self, span: Span, rewrite: Option<String>) {
         if let Some(ref s) = rewrite {
             self.push_str(s);


### PR DESCRIPTION
simplify a comparison with "true"
fn can_be_overflowed: remove unused lifetime
fn rewrite_pairs_one_line: pass "list" by reference (it is not consumed in the function)
fn span_for_token_stream: pass "token_stream" by reference since it is not consumed
use tool lints for clippy suppressions