### PR TITLE
README: remove old requirement for Rust 2018 edition use

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ To run:
 cargo +nightly fmt
 ```
 
-To format code that requires edition 2018, create a `rustfmt.toml` [configuration](#configuring-rustfmt) file containing:
-
-```toml
-edition = "2018"
-```
-
 ## Limitations
 
 Rustfmt tries to work on as much Rust code as possible, sometimes, the code


### PR DESCRIPTION
From now on, the `Cargo.toml` is taken into account when triggering
formatting using `cargo fmt`.

It is considered editor's duty to pass the proper `--edition` argument
for `rustfmt` if it is being called manually.

Refs: #3104.
Refs: #3129.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>