### PR TITLE
Simplify handling of parens around generic bound trait

### DIFF
--- a/tests/source/type.rs
+++ b/tests/source/type.rs
@@ -92,6 +92,14 @@ macro_rules! foo {
 
 type Target = ( FooAPI ) + 'static;
 
+// #3137
+fn foo<T>(t: T)
+where
+    T: ( FnOnce() -> () ) + Clone,
+    U: ( FnOnce() -> () ) + 'static,
+{
+}
+
 // #3117
 fn issue3117() {
     {

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -91,6 +91,14 @@ macro_rules! foo {
 
 type Target = (FooAPI) + 'static;
 
+// #3137
+fn foo<T>(t: T)
+where
+    T: (FnOnce() -> ()) + Clone,
+    U: (FnOnce() -> ()) + 'static,
+{
+}
+
 // #3117
 fn issue3117() {
     {


### PR DESCRIPTION
I was misunderstanding the syntax of generic bounds and have added some quirky code in #3060. This PR gets rid of them and just look at the original code to see whether the trait bound has parens around it. Ideally AST could tell us the presence of parens, but for now this just seems to work.

Closes #3137.