### PR TITLE
Try to fix formatting failures on Windows (issue #2810)

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1347,7 +1347,7 @@ impl MacroBranch {
             .fold(
                 (String::new(), true),
                 |(mut s, need_indent), (i, (kind, ref l))| {
-                    if !l.is_empty()
+                    if !is_empty_line(l)
                         && need_indent
                         && !new_body_snippet.is_line_non_formatted(i + 1)
                     {

--- a/tests/target/issue-2810.rs
+++ b/tests/target/issue-2810.rs
@@ -1,0 +1,14 @@
+// rustfmt-newline_style: Windows
+
+#[macro_export]
+macro_rules! hmmm___ffi_error {
+    ($result:ident) => {
+        pub struct $result {
+            success: bool,
+        }
+
+        impl $result {
+            pub fn foo(self) {}
+        }
+    };
+}


### PR DESCRIPTION
When `newline_style` is set to `Windows`, an empty line inside of a macro results in `\r` being passed to the `fold()` in `MacroBranch::rewrite()`. `\r` is technically _not_ an empty string, so we try to indent it, leaving trailing whitespaces behind, even thought that was not intended (as far as I can see).

There is a handy `is_empty_line()` function in the same file. This PR replaces the `!l.is_empty()` check with calling this function (since trying to indent any whitespace-only string will probably result in trailing whitespaces), but I'm not really sure if this is the best way to fix the root problem. Any feedback is appreciated.