### PR TITLE
Remove deprecated cfg_attr from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,7 @@ See [Configurations.md](Configurations.md) for details.
 
 ## Tips
 
-* For things you do not want rustfmt to mangle, use one of
-
-    ```rust
-    #[rustfmt::skip]  // requires nightly Rust and #![feature(tool_attributes)] in crate root
-    #[cfg_attr(rustfmt, rustfmt_skip)]  // works in stable
-    ```
+* For things you do not want rustfmt to mangle, use `#[rustfmt::skip]`
 * When you run rustfmt, place a file named `rustfmt.toml` or `.rustfmt.toml` in
   target file directory or its parents to override the default settings of
   rustfmt. You can generate a file containing the default configuration with


### PR DESCRIPTION
`tool_attributes` are stable since 1.30: [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=c5d53f8225f99e892fbef865935bcd88) The old `cfg_attr(rustfmt, rustfmt_skip)` attributes aren't necessary anymore and everyone should switch to `#[rustfmt::skip]` sooner or later.

There is also a Clippy lint in the making for this: rust-lang-nursery/rust-clippy#3123