### PR TITLE
The method trim_left_preserve_layout didn't handle tabs properly.

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -332,7 +332,7 @@ fn identify_comment(
     let (first_group, rest) = orig.split_at(first_group_ending);
     let rewritten_first_group =
         if !config.normalize_comments() && has_bare_lines && style.is_block_comment() {
-            trim_left_preserve_layout(first_group, &shape.indent, config)
+            trim_left_preserve_layout(first_group, &shape.indent, config)?
         } else if !config.normalize_comments()
             && !config.wrap_comments()
             && !config.format_doc_comments()

--- a/tests/source/issue-3132.rs
+++ b/tests/source/issue-3132.rs
@@ -1,0 +1,13 @@
+fn test() {
+    /*
+    a
+	*/
+    let x = 42;
+    /*
+    aaa
+    "line 1
+  line 2
+        line 3"
+    */
+    let x = 42;
+}

--- a/tests/target/issue-3132.rs
+++ b/tests/target/issue-3132.rs
@@ -1,0 +1,13 @@
+fn test() {
+    /*
+    a
+    */
+    let x = 42;
+    /*
+      aaa
+      "line 1
+    line 2
+          line 3"
+      */
+    let x = 42;
+}


### PR DESCRIPTION
This is fixed by taking the method `macros::indent_macro_snippet` which
essentially does the same: it indents a paragraph while preserving the
layout.

It has in addition some logic about strings, which anyway is not relevant to the content that was handled by `trim_left_preserve_layout`: it was applied to comments.

Close #3132 