### PR TITLE
Don't reorder modules by default

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1496,27 +1496,27 @@ Reorder `mod` declarations alphabetically in group.
 - **Possible values**: `true`, `false`
 - **Stable**: Yes
 
-#### `true` (default)
+#### `false`  (default)
 
 ```rust
-mod a;
 mod b;
+mod a;
 
-mod dolor;
-mod ipsum;
 mod lorem;
+mod ipsum;
+mod dolor;
 mod sit;
 ```
 
-#### `false`
+#### `true`
 
 ```rust
-mod b;
 mod a;
+mod b;
 
-mod lorem;
-mod ipsum;
 mod dolor;
+mod ipsum;
+mod lorem;
 mod sit;
 ```
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -73,7 +73,7 @@ create_config! {
 
     // Ordering
     reorder_imports: bool, true, true, "Reorder import and extern crate statements alphabetically";
-    reorder_modules: bool, true, true, "Reorder module statements alphabetically in group";
+    reorder_modules: bool, false, true, "Reorder module statements alphabetically in group";
     reorder_impl_items: bool, false, false, "Reorder impl items";
 
     // Spaces around punctuation


### PR DESCRIPTION
We can flip this, although this is stable, because disabling
reordering won't change existing order.

Why do we disabling this?

The problem with alphabetical ordering is that is as good as any other
arbitrary ordering. It does not have intrinsic benefits, and it is not
really about enforcing consistency: you only repeat a particular
module once, so any order is consistent.

The default zero-effort ordering of "modules are ordered according to
git history" is better than alphabetical, because it makes git blame
more consistent and gives a hint about what modules are older.

The significantly superior ordering, which probably should be a part
of style guide, is "suggested reading order". We obviously can't
enforce it via rustfmt, so let's just not reorder modules at all.