### PR TITLE
Format brace-delimited macros with a space after the name

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -256,19 +256,7 @@ pub fn rewrite_macro_inner(
             }
             DelimToken::Paren => Some(format!("{}()", macro_name)),
             DelimToken::Bracket => Some(format!("{}[]", macro_name)),
-            DelimToken::Brace => {
-                // Preserve at most one space before the braces.
-                let char_after_bang = context
-                    .snippet(mac.span)
-                    .split('!')
-                    .nth(1)
-                    .and_then(|x| x.chars().next());
-                if let Some(' ') = char_after_bang {
-                    Some(format!("{} {{}}", macro_name))
-                } else {
-                    Some(format!("{}{{}}", macro_name))
-                }
-            }
+            DelimToken::Brace => Some(format!("{} {{}}", macro_name)),
             _ => unreachable!(),
         };
     }
@@ -428,8 +416,15 @@ pub fn rewrite_macro_inner(
             }
         }
         DelimToken::Brace => {
-            // Skip macro invocations with braces, for now.
-            trim_left_preserve_layout(context.snippet(mac.span), shape.indent, &context.config)
+            // For macro invocations with braces, always put a space between
+            // the `macro_name!` and `{ /* macro_body */ }` but skip modifying
+            // anything in between the braces (for now).
+            let snippet = context.snippet(mac.span);
+            let macro_raw = snippet.split_at(snippet.find('!')? + 1).1.trim_start();
+            match trim_left_preserve_layout(macro_raw, &shape.indent, &context.config) {
+                Some(macro_body) => Some(format!("{} {}", macro_name, macro_body)),
+                None => Some(format!("{} {}", macro_name, macro_raw)),
+            }
         }
         _ => unreachable!(),
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -256,7 +256,19 @@ pub fn rewrite_macro_inner(
             }
             DelimToken::Paren => Some(format!("{}()", macro_name)),
             DelimToken::Bracket => Some(format!("{}[]", macro_name)),
-            DelimToken::Brace => Some(format!("{}{{}}", macro_name)),
+            DelimToken::Brace => {
+                // Preserve at most one space before the braces.
+                let char_after_bang = context
+                    .snippet(mac.span)
+                    .split('!')
+                    .nth(1)
+                    .and_then(|x| x.chars().next());
+                if let Some(' ') = char_after_bang {
+                    Some(format!("{} {{}}", macro_name))
+                } else {
+                    Some(format!("{}{{}}", macro_name))
+                }
+            }
             _ => unreachable!(),
         };
     }

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -4,7 +4,7 @@ itemmacro!(this, is.now() .formatted(yay));
 
 itemmacro!(really, long.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb() .is.formatted());
 
-itemmacro!{this, is.bracket().formatted()}
+itemmacro!{this, is.brace().formatted()}
 
 peg_file!   modname  ("mygrammarfile.rustpeg");
 
@@ -106,8 +106,6 @@ fn main() {
 
 impl X {
     empty_invoc!{}
-
-    // Don't format empty either!
     empty_invoc! {}
 }
 

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -106,6 +106,9 @@ fn main() {
 
 impl X {
     empty_invoc!{}
+
+    // Don't format empty either!
+    empty_invoc! {}
 }
 
 fn issue_1279() {

--- a/tests/target/issue-2917/packed_simd.rs
+++ b/tests/target/issue-2917/packed_simd.rs
@@ -31,7 +31,7 @@ macro_rules! impl_from_vector {
         }
         */
 
-        test_if!{
+        test_if! {
             $test_tt:
             interpolate_idents! {
                 mod [$id _from_ $source] {

--- a/tests/target/lazy_static.rs
+++ b/tests/target/lazy_static.rs
@@ -10,7 +10,7 @@ lazy_static! {
 // We need to be able to format `lazy_static!` without known syntax.
 lazy_static!(xxx, yyyy, zzzzz);
 
-lazy_static!{}
+lazy_static! {}
 
 // #2354
 lazy_static! {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -132,6 +132,9 @@ fn main() {
 
 impl X {
     empty_invoc!{}
+
+    // Don't format empty either!
+    empty_invoc! {}
 }
 
 fn issue_1279() {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -9,7 +9,7 @@ itemmacro!(
         .formatted()
 );
 
-itemmacro!{this, is.bracket().formatted()}
+itemmacro! {this, is.brace().formatted()}
 
 peg_file! modname("mygrammarfile.rustpeg");
 
@@ -94,7 +94,7 @@ fn main() {
 
     foo(makro!(1, 3));
 
-    hamkaas!{ () };
+    hamkaas! { () };
 
     macrowithbraces! {dont,    format, me}
 
@@ -104,11 +104,11 @@ fn main() {
 
     some_macro![];
 
-    some_macro!{
+    some_macro! {
         // comment
     };
 
-    some_macro!{
+    some_macro! {
         // comment
     };
 
@@ -131,9 +131,7 @@ fn main() {
 }
 
 impl X {
-    empty_invoc!{}
-
-    // Don't format empty either!
+    empty_invoc! {}
     empty_invoc! {}
 }
 
@@ -952,7 +950,7 @@ macro_rules! m {
     };
 }
 fn foo() {
-    f!{r#"
+    f! {r#"
             test
        "#};
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -204,19 +204,19 @@ fn issue355() {
             vec![3; 4]
         }
         // Funky bracketing styles
-        t => println!{"a", b},
+        t => println! {"a", b},
         u => vec![1, 2],
         v => vec![3; 4],
         w => println!["a", b],
         x => vec![1, 2],
         y => vec![3; 4],
         // Brackets with comments
-        tc => println!{"a", b}, // comment
-        uc => vec![1, 2],       // comment
-        vc => vec![3; 4],       // comment
-        wc => println!["a", b], // comment
-        xc => vec![1, 2],       // comment
-        yc => vec![3; 4],       // comment
+        tc => println! {"a", b}, // comment
+        uc => vec![1, 2],        // comment
+        vc => vec![3; 4],        // comment
+        wc => println!["a", b],  // comment
+        xc => vec![1, 2],        // comment
+        yc => vec![3; 4],        // comment
         yd => looooooooooooooooooooooooooooooooooooooooooooooooooooooooong_func(
             aaaaaaaaaa, bbbbbbbbbb, cccccccccc, dddddddddd,
         ),


### PR DESCRIPTION
This change was motivated by this current behavior:
```rust
// Original
let _: DefaultFields = request! { a: "Boop" };
let _: DefaultFields = request! { };

// Formatted
let _: DefaultFields = request! { a: "Boop" };
let _: DefaultFields = request!{};

// "Fixed"
let _: DefaultFields = request! { a: "Boop" };
let _: DefaultFields = request! {};
```

Currently `rustfmt` skips modifying block like macros, unless they are empty with no comments.
If they are empty, it formats them as `mymacro!{}`.

This changes the behavior to preserve optionally one space between `mymacro!` and `{}` (e.g. `example!     {}` becomes `example! {}`.

This change seems preferable to me from a forward-stability perspective, where I would imagine its likely that any (hypothetical) formatting of brace-delimited macros would behave more like _structs_, _struct literals_, and _blocks_ rather than functions.   
(Where currently an empty struct is formatted as `MyStruct {}` -- with a space)

------------------------------------------------

**Edited - Nov 16**  
Now always adds a space instead of inspecting the source.
