### PR TITLE
Trim the indentation on macros which heuristically appear to use block-style indentation

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -332,7 +332,7 @@ fn identify_comment(
     let (first_group, rest) = orig.split_at(first_group_ending);
     let rewritten_first_group =
         if !config.normalize_comments() && has_bare_lines && style.is_block_comment() {
-            trim_left_preserve_layout(first_group, &shape.indent, config)?
+            trim_left_preserve_layout(first_group, shape.indent, config)?
         } else if !config.normalize_comments()
             && !config.wrap_comments()
             && !config.format_doc_comments()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,7 +146,7 @@ fn rewrite_macro_name(
 // Use this on failing to format the macro call.
 fn return_macro_parse_failure_fallback(
     context: &RewriteContext,
-    indent: &Indent,
+    indent: Indent,
     span: Span,
 ) -> Option<String> {
     // Mark this as a failure however we format it
@@ -261,7 +261,7 @@ pub fn rewrite_macro_inner(
             match parse_macro_arg(&mut parser) {
                 Some(arg) => arg_vec.push(arg),
                 None => {
-                    return return_macro_parse_failure_fallback(context, &shape.indent, mac.span);
+                    return return_macro_parse_failure_fallback(context, shape.indent, mac.span);
                 }
             }
 
@@ -285,17 +285,17 @@ pub fn rewrite_macro_inner(
                                 None => {
                                     return return_macro_parse_failure_fallback(
                                         context,
-                                        &shape.indent,
+                                        shape.indent,
                                         mac.span,
                                     );
                                 }
                             }
                         }
                     }
-                    return return_macro_parse_failure_fallback(context, &shape.indent, mac.span);
+                    return return_macro_parse_failure_fallback(context, shape.indent, mac.span);
                 }
                 _ if arg_vec.last().map_or(false, MacroArg::is_item) => continue,
-                _ => return return_macro_parse_failure_fallback(context, &shape.indent, mac.span),
+                _ => return return_macro_parse_failure_fallback(context, shape.indent, mac.span),
             }
 
             parser.bump();
@@ -401,7 +401,7 @@ pub fn rewrite_macro_inner(
         }
         DelimToken::Brace => {
             // Skip macro invocations with braces, for now.
-            trim_left_preserve_layout(context.snippet(mac.span), &shape.indent, &context.config)
+            trim_left_preserve_layout(context.snippet(mac.span), shape.indent, &context.config)
         }
         _ => unreachable!(),
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,11 +144,32 @@ fn rewrite_macro_name(
 }
 
 // Use this on failing to format the macro call.
-fn return_original_snippet_with_failure_marked(
+fn return_macro_parse_failure_fallback(
     context: &RewriteContext,
+    indent: &Indent,
     span: Span,
 ) -> Option<String> {
+    // Mark this as a failure however we format it
     context.macro_rewrite_failure.replace(true);
+
+    // Heuristically determine whether the last line of the macro uses "Block" style
+    // rather than using "Visual" style, or another indentation style.
+    let is_like_block_indent_style = context
+        .snippet(span)
+        .split('\n')
+        .last()
+        .map(|closing_line| {
+            !closing_line.trim().chars().any(|ch| match ch {
+                '}' | ')' | ']' => false,
+                _ => true,
+            })
+        })
+        .unwrap_or(false);
+    if is_like_block_indent_style {
+        return trim_left_preserve_layout(context.snippet(span), indent, &context.config);
+    }
+
+    // Return the snippet unmodified if the macro is not block-like
     Some(context.snippet(span).to_owned())
 }
 
@@ -239,7 +260,9 @@ pub fn rewrite_macro_inner(
         loop {
             match parse_macro_arg(&mut parser) {
                 Some(arg) => arg_vec.push(arg),
-                None => return return_original_snippet_with_failure_marked(context, mac.span),
+                None => {
+                    return return_macro_parse_failure_fallback(context, &shape.indent, mac.span);
+                }
             }
 
             match parser.token {
@@ -260,17 +283,19 @@ pub fn rewrite_macro_inner(
                                     }
                                 }
                                 None => {
-                                    return return_original_snippet_with_failure_marked(
-                                        context, mac.span,
-                                    )
+                                    return return_macro_parse_failure_fallback(
+                                        context,
+                                        &shape.indent,
+                                        mac.span,
+                                    );
                                 }
                             }
                         }
                     }
-                    return return_original_snippet_with_failure_marked(context, mac.span);
+                    return return_macro_parse_failure_fallback(context, &shape.indent, mac.span);
                 }
                 _ if arg_vec.last().map_or(false, MacroArg::is_item) => continue,
-                _ => return return_original_snippet_with_failure_marked(context, mac.span),
+                _ => return return_macro_parse_failure_fallback(context, &shape.indent, mac.span),
             }
 
             parser.bump();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -159,9 +159,9 @@ fn return_macro_parse_failure_fallback(
         .lines()
         .last()
         .map(|closing_line| {
-            !closing_line.trim().chars().any(|ch| match ch {
-                '}' | ')' | ']' => false,
-                _ => true,
+            closing_line.trim().chars().all(|ch| match ch {
+                '}' | ')' | ']' => true,
+                _ => false,
             })
         })
         .unwrap_or(false);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -156,7 +156,7 @@ fn return_macro_parse_failure_fallback(
     // rather than using "Visual" style, or another indentation style.
     let is_like_block_indent_style = context
         .snippet(span)
-        .split('\n')
+        .lines()
         .last()
         .map(|closing_line| {
             !closing_line.trim().chars().any(|ch| match ch {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -749,7 +749,7 @@ impl ConfigCodeBlock {
             .code_block
             .as_ref()
             .unwrap()
-            .split('\n')
+            .lines()
             .nth(0)
             .unwrap_or("")
             == "#![rustfmt::skip]";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -511,7 +511,7 @@ pub fn remove_trailing_white_spaces(text: &str) -> String {
 ///     ),
 /// }
 /// ```
-pub fn trim_left_preserve_layout(orig: &str, indent: &Indent, config: &Config) -> Option<String> {
+pub fn trim_left_preserve_layout(orig: &str, indent: Indent, config: &Config) -> Option<String> {
     let mut lines = LineClasses::new(orig);
     let first_line = lines.next().map(|(_, s)| s.trim_right().to_owned())?;
     let mut trimmed_lines = Vec::with_capacity(16);
@@ -598,7 +598,7 @@ mod test {
         let config = Config::default();
         let indent = Indent::new(4, 0);
         assert_eq!(
-            trim_left_preserve_layout(&s, &indent, &config),
+            trim_left_preserve_layout(&s, indent, &config),
             Some("aaa\n    bbb\n    ccc".to_string())
         );
     }

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -184,6 +184,19 @@ fn issue1577() {
     });
 }
 
+// #3174
+fn issue_3174() {
+    let data =
+        if let Some(debug) = error.debug_info() {
+            json!({
+                "errorKind": format!("{:?}", error.err_kind()),
+                "debugMessage": debug.message,
+            })
+        } else {
+            json!({"errorKind": format!("{:?}", error.err_kind())})
+        };
+}
+
 gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     out: gfx::RenderTarget<ColorFormat> = "Target0",

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -225,6 +225,18 @@ fn issue1577() {
     });
 }
 
+// #3174
+fn issue_3174() {
+    let data = if let Some(debug) = error.debug_info() {
+        json!({
+            "errorKind": format!("{:?}", error.err_kind()),
+            "debugMessage": debug.message,
+        })
+    } else {
+        json!({ "errorKind": format!("{:?}", error.err_kind()) })
+    };
+}
+
 gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     out: gfx::RenderTarget<ColorFormat> = "Target0",


### PR DESCRIPTION
1. Fixes https://github.com/rust-lang-nursery/rustfmt/issues/3174.
2. Avoids re-introducting issues similar to https://github.com/rust-lang-nursery/rustfmt/issues/1712.  

-----------------------------------------------

In __Issue 1712__ an example is presented where trimming the leading whitespace on lines of an unparsable macro provides undesirable behavior.

It appears to me that the issues of the sort will most frequently be a result in differences in indentation strategy between the _macro's grammar_ and _rust's grammar_.  I would imagine over time that macro grammar's would diverge more and more from rust given the new [function-like proc macro](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html#procedural-macros) support, for things like `sql!(SELECT * FROM example)`.

#### Implemented Solution
This change uses a heuristic to determine whether the macro uses C-like delimiters and rustfmt-like "Block" indent-style and applies a de-dent if it matches (reusing existing behavior for `brace! {}` macros; which handles all the edge-cases like string literals).

Specifically it checks that the last line of the macro (after being trimmed) contains only a sequence of `)`, `]`, or `}` characters and no other characters or whitespace.
