### PR TITLE
fix the logic for retaining a comment before the arrow in a match

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -379,7 +379,9 @@ fn rewrite_match_body(
     // Look for comments between `=>` and the start of the body.
     let arrow_comment = {
         let arrow_snippet = context.snippet(arrow_span).trim();
-        let arrow_index = arrow_snippet.find("=>").unwrap();
+        // search for the arrow starting from the end of the snippet since there may be a match
+        // expression within the guard
+        let arrow_index = arrow_snippet.rfind("=>").unwrap();
         // 2 = `=>`
         let comment_str = arrow_snippet[arrow_index + 2..].trim();
         if comment_str.is_empty() {

--- a/tests/source/issue-3131.rs
+++ b/tests/source/issue-3131.rs
@@ -1,0 +1,8 @@
+fn main() {
+    match 3 {
+        t if match t {
+            _ => true,
+        } => {},
+        _ => {}
+    }
+}

--- a/tests/target/issue-3131.rs
+++ b/tests/target/issue-3131.rs
@@ -1,0 +1,8 @@
+fn main() {
+    match 3 {
+        t if match t {
+            _ => true,
+        } => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
close #3131 