### PR TITLE
do not add a newline after a missed span if it is the end of a block comment

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -260,9 +260,8 @@ impl<'a> FmtVisitor<'a> {
         status.line_start = offset + subslice.len();
 
         if let Some('/') = subslice.chars().nth(1) {
-            // check that there are no contained block comments
-            if !subslice.lines().any(|s| s.trim_left().starts_with("/*")) {
-                // Add a newline after line comments
+            // Only add a newline if the last line is a line comment
+            if !subslice.trim_end().ends_with("*/") {
                 self.push_str("\n");
             }
         } else if status.line_start <= snippet.len() {

--- a/tests/target/issue-3124.rs
+++ b/tests/target/issue-3124.rs
@@ -1,0 +1,14 @@
+pub fn fail1() {
+    // Some comment.
+    /**///
+}
+
+pub fn fail2() {
+    // Some comment.
+    /**/
+}
+
+pub fn fail3() {
+    // Some comment.
+    //
+}


### PR DESCRIPTION
close #3124 