### PR TITLE
compute the span after a struct-like item based on the ident description

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -464,7 +464,8 @@ impl<'a> FmtVisitor<'a> {
                 BracePos::Auto
             },
             self.block_indent,
-            mk_sp(span.lo(), body_start),
+            // make a span that starts right after `enum Foo`
+            mk_sp(ident.span.hi(), body_start),
             last_line_width(&enum_header),
         )
         .unwrap();
@@ -1186,7 +1187,8 @@ fn format_unit_struct(context: &RewriteContext, p: &StructParts, offset: Indent)
             context.config.brace_style(),
             BracePos::None,
             offset,
-            mk_sp(generics.span.lo(), hi),
+            // make a span that starts right after `struct Foo`
+            mk_sp(p.ident.span.hi(), hi),
             last_line_width(&header_str),
         )?
     } else {
@@ -1208,7 +1210,7 @@ pub fn format_struct_struct(
     let header_str = struct_parts.format_header(context);
     result.push_str(&header_str);
 
-    let header_hi = span.lo() + BytePos(header_str.len() as u32);
+    let header_hi = struct_parts.ident.span.hi();
     let body_lo = context.snippet_provider.span_after(span, "{");
 
     let generics_str = match struct_parts.generics {
@@ -1222,6 +1224,7 @@ pub fn format_struct_struct(
                 BracePos::Auto
             },
             offset,
+            // make a span that starts right after `struct Foo`
             mk_sp(header_hi, body_lo),
             last_line_width(&result),
         )?,

--- a/tests/source/issue-3194.rs
+++ b/tests/source/issue-3194.rs
@@ -1,0 +1,13 @@
+mod m { struct S where A: B; }
+
+mod n { struct Foo where A: B { foo: usize } }
+
+mod o { enum Bar where A: B { Bar } }
+
+mod with_comments {
+  mod m { struct S /* before where */ where A: B; /* after where */ }
+  
+  mod n { struct Foo /* before where */ where A: B /* after where */ { foo: usize } }
+  
+  mod o { enum Bar /* before where */ where A: B /* after where */ { Bar } }
+}

--- a/tests/target/issue-3194.rs
+++ b/tests/target/issue-3194.rs
@@ -1,0 +1,52 @@
+mod m {
+    struct S
+    where
+        A: B;
+}
+
+mod n {
+    struct Foo
+    where
+        A: B,
+    {
+        foo: usize,
+    }
+}
+
+mod o {
+    enum Bar
+    where
+        A: B,
+    {
+        Bar,
+    }
+}
+
+mod with_comments {
+    mod m {
+        struct S
+        /* before where */
+        where
+            A: B; /* after where */
+    }
+
+    mod n {
+        struct Foo
+        /* before where */
+        where
+            A: B, /* after where */
+        {
+            foo: usize,
+        }
+    }
+
+    mod o {
+        enum Bar
+        /* before where */
+        where
+            A: B, /* after where */
+        {
+            Bar,
+        }
+    }
+}


### PR DESCRIPTION
close #3194 

As described in the issue, the `generics.span.lo()` value is equal to `BytePos(0)` which is incorrect in case of a struct with a `where` clause but no parameter. The issue is fixed by taking the `span` of the `ident` instead of the `generics`.
Do you think that problem should be reported upstream ?