### PR TITLE
fix a few clippy warnings

### DIFF
--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -167,7 +167,7 @@ fn normalize_ranges(ranges: &mut HashMap<FileName, Vec<Range>>) {
         ranges.sort();
         let mut result = vec![];
         {
-            let mut iter = ranges.into_iter().peekable();
+            let mut iter = ranges.iter_mut().peekable();
             while let Some(next) = iter.next() {
                 let mut next = *next;
                 while let Some(&&mut peek) = iter.peek() {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1584,7 +1584,7 @@ fn rewrite_struct_lit<'a>(
         )?
     } else {
         let field_iter = fields
-            .into_iter()
+            .iter()
             .map(StructLitField::Regular)
             .chain(base.into_iter().map(StructLitField::Base));
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -313,7 +313,7 @@ fn rewrite_tuple_pat(
     context: &RewriteContext,
     shape: Shape,
 ) -> Option<String> {
-    let mut pat_vec: Vec<_> = pats.into_iter().map(|x| TuplePatField::Pat(x)).collect();
+    let mut pat_vec: Vec<_> = pats.iter().map(|x| TuplePatField::Pat(x)).collect();
 
     if let Some(pos) = dotdot_pos {
         let prev = if pos == 0 {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -114,7 +114,7 @@ fn write_message(msg: &str) {
 fn system_tests() {
     // Get all files in the tests/source directory.
     let files = get_test_files(Path::new("tests/source"), true);
-    let (_reports, count, fails) = check_files(files, None);
+    let (_reports, count, fails) = check_files(files, &None);
 
     // Display results.
     println!("Ran {} system tests.", count);
@@ -126,7 +126,7 @@ fn system_tests() {
 #[test]
 fn coverage_tests() {
     let files = get_test_files(Path::new("tests/coverage/source"), true);
-    let (_reports, count, fails) = check_files(files, None);
+    let (_reports, count, fails) = check_files(files, &None);
 
     println!("Ran {} tests in coverage mode.", count);
     assert_eq!(fails, 0, "{} tests failed", fails);
@@ -230,7 +230,7 @@ fn idempotence_tests() {
     }
     // Get all files in the tests/target directory.
     let files = get_test_files(Path::new("tests/target"), true);
-    let (_reports, count, fails) = check_files(files, None);
+    let (_reports, count, fails) = check_files(files, &None);
 
     // Display results.
     println!("Ran {} idempotent tests.", count);
@@ -251,7 +251,7 @@ fn self_tests() {
     }
     files.push(PathBuf::from("src/lib.rs"));
 
-    let (reports, count, fails) = check_files(files, Some(PathBuf::from("rustfmt.toml")));
+    let (reports, count, fails) = check_files(files, &Some(PathBuf::from("rustfmt.toml")));
     let mut warnings = 0;
 
     // Display results.
@@ -340,7 +340,7 @@ fn format_lines_errors_are_reported_with_tabs() {
 
 // For each file, run rustfmt and collect the output.
 // Returns the number of files checked and the number of failures.
-fn check_files(files: Vec<PathBuf>, opt_config: Option<PathBuf>) -> (Vec<FormatReport>, u32, u32) {
+fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<FormatReport>, u32, u32) {
     let mut count = 0;
     let mut fails = 0;
     let mut reports = vec![];

--- a/src/types.rs
+++ b/src/types.rs
@@ -492,7 +492,7 @@ impl Rewrite for ast::GenericBound {
         match *self {
             ast::GenericBound::Trait(ref poly_trait_ref, trait_bound_modifier) => {
                 let snippet = context.snippet(self.span());
-                let has_paren = snippet.starts_with("(") && snippet.ends_with(")");
+                let has_paren = snippet.starts_with('(') && snippet.ends_with(')');
                 let rewrite = match trait_bound_modifier {
                     ast::TraitBoundModifier::None => poly_trait_ref.rewrite(context, shape),
                     ast::TraitBoundModifier::Maybe => poly_trait_ref


### PR DESCRIPTION
types.rs:
fix single_char_pattern (use character patters instead of string for .ends_with() and .starts_with()

patterns.rs
expr.rs
file_lines.rs:
fix into_iter_on_ref_ptr (use iter() or iter_mut() instead of into_iter()

tests/mod.rs:
check_files(): take Option<PathBuf> by reference